### PR TITLE
Tls 13 masterkey is taken wrong (fixes #283)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,3 +376,4 @@ format:
 	@clang-format -i -style=$(STYLE) kern/openssl_masterkey_3.0.h
 	@clang-format -i -style=$(STYLE) kern/boringssl_masterkey.h
 	@clang-format -i -style=$(STYLE) kern/openssl_tc.h
+	@clang-format -i -style=$(STYLE) utils/*.c

--- a/kern/boringssl_1_1_1_kern.c
+++ b/kern/boringssl_1_1_1_kern.c
@@ -31,6 +31,9 @@
 // bssl::SSL3_STATE->client_random
 #define BSSL__SSL3_STATE_CLIENT_RANDOM 0x30
 
+// bssl::SSL3_STATE->exporter_secret
+#define BSSL__SSL3_STATE_EXPORTER_SECRET 0x178
+
 // bssl::SSL3_STATE->established_session
 #define BSSL__SSL3_STATE_ESTABLISHED_SESSION 0x1c8
 

--- a/kern/boringssl_1_1_1_kern.c
+++ b/kern/boringssl_1_1_1_kern.c
@@ -13,11 +13,11 @@
 // ssl_st->s3
 #define SSL_ST_S3 0x30
 
-// ssl_session_st->secret
-#define SSL_SESSION_ST_SECRET 0x10
-
 // ssl_session_st->secret_length
 #define SSL_SESSION_ST_SECRET_LENGTH 0xc
+
+// ssl_session_st->secret
+#define SSL_SESSION_ST_SECRET 0x10
 
 // ssl_session_st->cipher
 #define SSL_SESSION_ST_CIPHER 0xd0

--- a/kern/boringssl_1_1_1_kern.c
+++ b/kern/boringssl_1_1_1_kern.c
@@ -30,14 +30,20 @@
 // bssl::SSL3_STATE->client_random
 #define BSSL__SSL3_STATE_CLIENT_RANDOM 0x30
 
+// bssl::SSL3_STATE->established_session
+#define BSSL__SSL3_STATE_ESTABLISHED_SESSION 0x1c8
+
 // bssl::SSL_HANDSHAKE->new_session
 #define BSSL__SSL_HANDSHAKE_NEW_SESSION 0x5d8
 
 // bssl::SSL_HANDSHAKE->early_session
 #define BSSL__SSL_HANDSHAKE_EARLY_SESSION 0x5e0
 
-// bssl::SSL3_STATE->established_session
-#define BSSL__SSL3_STATE_ESTABLISHED_SESSION 0x1c8
+// bssl::SSL_HANDSHAKE->state
+#define BSSL__SSL_HANDSHAKE_STATE 0x14
+
+// bssl::SSL_HANDSHAKE->tls13_state
+#define BSSL__SSL_HANDSHAKE_TLS13_STATE 0x18
 
 // bssl::SSL_HANDSHAKE->max_version
 #define BSSL__SSL_HANDSHAKE_MAX_VERSION 0x1e

--- a/kern/boringssl_1_1_1_kern.c
+++ b/kern/boringssl_1_1_1_kern.c
@@ -1,7 +1,8 @@
 #ifndef ECAPTURE_BORINGSSL_1_1_1_KERN_H
 #define ECAPTURE_BORINGSSL_1_1_1_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1 (compatible; BoringSSL), OPENSSL_VERSION_NUMBER: 269488255 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1 (compatible; BoringSSL) */
+/* OPENSSL_VERSION_NUMBER: 269488255 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x10
@@ -59,4 +60,3 @@
 #include "openssl.h"
 
 #endif
-

--- a/kern/boringssl_1_1_1_kern.c
+++ b/kern/boringssl_1_1_1_kern.c
@@ -39,6 +39,12 @@
 // bssl::SSL_HANDSHAKE->early_session
 #define BSSL__SSL_HANDSHAKE_EARLY_SESSION 0x5e0
 
+// bssl::SSL_HANDSHAKE->hints
+#define BSSL__SSL_HANDSHAKE_HINTS 0x610
+
+// bssl::SSL_HANDSHAKE->client_version
+#define BSSL__SSL_HANDSHAKE_CLIENT_VERSION 0x61c
+
 // bssl::SSL_HANDSHAKE->state
 #define BSSL__SSL_HANDSHAKE_STATE 0x14
 

--- a/kern/boringssl_const.h
+++ b/kern/boringssl_const.h
@@ -41,11 +41,11 @@
 
 //   uint16_t max_version = 0;
 // sizeof(uint16_t) = 2
-#define SSL_HASH_LEN_ roundup(BSSL__SSL_HANDSHAKE_MAX_VERSION+2,8)
+#define SSL_HANDSHAKE_HASH_LEN_ roundup(BSSL__SSL_HANDSHAKE_MAX_VERSION+2,8)
 
 // ssl_st->s3->hs
 // bssl::SSL_HANDSHAKE->secret_
-#define SSL_HANDSHAKE_SECRET_ SSL_HASH_LEN_+8
+#define SSL_HANDSHAKE_SECRET_ SSL_HANDSHAKE_HASH_LEN_+8
 
 // bssl::SSL_HANDSHAKE->early_traffic_secret_
 #define SSL_HANDSHAKE_EARLY_TRAFFIC_SECRET_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*1

--- a/kern/boringssl_const.h
+++ b/kern/boringssl_const.h
@@ -2,34 +2,68 @@
 #define ECAPTURE_BORINGSSL_CONST_H
 
 /////////////////////////////////////////// DON'T REMOVE THIS CODE BLOCK. //////////////////////////////////////////
-
-// memory layout from boringssl repo  ssl/internal.h line 1720
-// struct of struct SSL_HANDSHAKE
-
 // SSL_MAX_MD_SIZE is size of the largest hash function used in TLS, SHA-384.
 #define SSL_MAX_MD_SIZE 48
 
+#define roundup(x, y) (					\
+{							\
+	typeof(y) __y = y;				\
+	(((x) + (__y - 1)) / __y) * __y;		\
+}							\
+)
+
+
+// memory layout from boringssl repo  ssl/internal.h line 1720
+// struct of struct SSL_HANDSHAKE
+/*
+  // via boringssl source code  src/ssl/internal.h : line 1585
+
+  // max_version is the maximum accepted protocol version, taking account both
+  // |SSL_OP_NO_*| and |SSL_CTX_set_max_proto_version| APIs.
+  uint16_t max_version = 0;
+
+ private:
+  size_t hash_len_ = 0;x
+  uint8_t secret_[SSL_MAX_MD_SIZE] = {0};
+  uint8_t early_traffic_secret_[SSL_MAX_MD_SIZE] = {0};
+  uint8_t client_handshake_secret_[SSL_MAX_MD_SIZE] = {0};
+  uint8_t server_handshake_secret_[SSL_MAX_MD_SIZE] = {0};
+  uint8_t client_traffic_secret_0_[SSL_MAX_MD_SIZE] = {0};
+  uint8_t server_traffic_secret_0_[SSL_MAX_MD_SIZE] = {0};
+  uint8_t expected_client_finished_[SSL_MAX_MD_SIZE] = {0};
+  */
+// boringssl中的 TLS 1.3 密钥是 private属性，无法直接offset计算。
+// 所以，计算private前面的属性地址，再手动相加。
+// private 前面的属性是max_version ，offset是30
+// private 第一个属性是size_t hash_len_，内存对齐后，offset就是32
+// secret的offset即 32 + sizeof(size_t) ，即 40 。其他的累加 SSL_MAX_MD_SIZE长度即可。
+
+
+//   uint16_t max_version = 0;
+// sizeof(uint16_t) = 2
+#define SSL_HASH_LEN_ roundup(BSSL__SSL_HANDSHAKE_MAX_VERSION+2,8)
+
 // ssl_st->s3->hs
 // bssl::SSL_HANDSHAKE->secret_
-#define SSL_HANDSHAKE_SECRET_ BSSL__SSL_HANDSHAKE_MAX_VERSION+8+SSL_MAX_MD_SIZE*0
+#define SSL_HANDSHAKE_SECRET_ SSL_HASH_LEN_+8
 
 // bssl::SSL_HANDSHAKE->early_traffic_secret_
-#define SSL_HANDSHAKE_EARLY_TRAFFIC_SECRET_ BSSL__SSL_HANDSHAKE_MAX_VERSION+8+SSL_MAX_MD_SIZE*1
+#define SSL_HANDSHAKE_EARLY_TRAFFIC_SECRET_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*1
 
 // bssl::SSL_HANDSHAKE->client_handshake_secret_
-#define SSL_HANDSHAKE_CLIENT_HANDSHAKE_SECRET_ BSSL__SSL_HANDSHAKE_MAX_VERSION+8+SSL_MAX_MD_SIZE*2
+#define SSL_HANDSHAKE_CLIENT_HANDSHAKE_SECRET_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*2
 
 // bssl::SSL_HANDSHAKE->server_handshake_secret_
-#define SSL_HANDSHAKE_SERVER_HANDSHAKE_SECRET_ BSSL__SSL_HANDSHAKE_MAX_VERSION+8+SSL_MAX_MD_SIZE*3
+#define SSL_HANDSHAKE_SERVER_HANDSHAKE_SECRET_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*3
 
 // bssl::SSL_HANDSHAKE->client_traffic_secret_0_
-#define SSL_HANDSHAKE_CLIENT_TRAFFIC_SECRET_0_ BSSL__SSL_HANDSHAKE_MAX_VERSION+8+SSL_MAX_MD_SIZE*4
+#define SSL_HANDSHAKE_CLIENT_TRAFFIC_SECRET_0_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*4
 
 // bssl::SSL_HANDSHAKE->server_traffic_secret_0_
-#define SSL_HANDSHAKE_SERVER_TRAFFIC_SECRET_0_ BSSL__SSL_HANDSHAKE_MAX_VERSION+8+SSL_MAX_MD_SIZE*5
+#define SSL_HANDSHAKE_SERVER_TRAFFIC_SECRET_0_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*5
 
 // bssl::SSL_HANDSHAKE->expected_client_finished_
-#define SSL_HANDSHAKE_EXPECTED_CLIENT_FINISHED_ BSSL__SSL_HANDSHAKE_MAX_VERSION+8+SSL_MAX_MD_SIZE*6
+#define SSL_HANDSHAKE_EXPECTED_CLIENT_FINISHED_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*6
 
 ///////////////////////////  END   ///////////////////////////
 

--- a/kern/boringssl_masterkey.h
+++ b/kern/boringssl_masterkey.h
@@ -65,13 +65,13 @@ struct ssl3_state_st {
 };
 
 struct ssl3_handshake_st {
-  // state is the internal state for the TLS 1.2 and below handshake. Its
-  // values depend on |do_handshake| but the starting state is always zero.
-  s32 state;
+    // state is the internal state for the TLS 1.2 and below handshake. Its
+    // values depend on |do_handshake| but the starting state is always zero.
+    s32 state;
 
-  // tls13_state is the internal state for the TLS 1.3 handshake. Its values
-  // depend on |do_handshake| but the starting state is always zero.
-  s32 tls13_state;
+    // tls13_state is the internal state for the TLS 1.3 handshake. Its values
+    // depend on |do_handshake| but the starting state is always zero.
+    s32 tls13_state;
 };
 
 #define TLS1_1_VERSION 0x0302
@@ -151,9 +151,9 @@ static __always_inline u64 get_session_addr(void *ssl_st_ptr, u64 s3_address) {
             ssl_st_ptr, ssl_new_session_st_ptr, ret);
         return 0;
     }
-//    debug_bpf_printk(
-//        "ssl_st:%llx, ssl_st->session is not null, address :%llx\n", ssl_st_ptr,
-//        tmp_address);
+    //    debug_bpf_printk(
+    //        "ssl_st:%llx, ssl_st->session is not null, address :%llx\n",
+    //        ssl_st_ptr, tmp_address);
     return tmp_address;
 }
 
@@ -231,7 +231,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     u64 *ssl_hs_st_ptr = (u64 *)(s3_address + BSSL__SSL3_STATE_HS);
     ret = bpf_probe_read_user(&ssl_hs_st_addr, sizeof(ssl_hs_st_addr),
                               ssl_hs_st_ptr);
-    if (ret || ssl_hs_st_addr==0) {
+    if (ret || ssl_hs_st_addr == 0) {
         debug_bpf_printk("bpf_probe_read ssl_hs_st_ptr failed, ret :%d\n", ret);
         return 0;
     }
@@ -239,42 +239,51 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     //////////////////// get hash len //////////////////
     u16 hash_len;
     u64 *ssl_hs_hashlen_ptr = (u64 *)(ssl_hs_st_addr + SSL_HANDSHAKE_HASH_LEN_);
-    ret = bpf_probe_read_user(&hash_len, sizeof(hash_len),
-                              ssl_hs_hashlen_ptr);
+    ret = bpf_probe_read_user(&hash_len, sizeof(hash_len), ssl_hs_hashlen_ptr);
     if (ret) {
-        debug_bpf_printk("bpf_probe_read ssl_hs_st_ptr failed, ret :%d, hash_len:%d\n", ret, hash_len);
+        debug_bpf_printk(
+            "bpf_probe_read ssl_hs_st_ptr failed, ret :%d, hash_len:%d\n", ret,
+            hash_len);
         return 0;
     }
     mastersecret->hash_len = hash_len;
 
     u16 client_version;
-    u64 *ssl_hs_cv_ptr = (u64 *)(ssl_hs_st_addr + BSSL__SSL_HANDSHAKE_CLIENT_VERSION);
+    u64 *ssl_hs_cv_ptr =
+        (u64 *)(ssl_hs_st_addr + BSSL__SSL_HANDSHAKE_CLIENT_VERSION);
     ret = bpf_probe_read_user(&client_version, sizeof(client_version),
                               ssl_hs_cv_ptr);
-    if (ret || client_version ==0) {
-        debug_bpf_printk("bpf_probe_read ssl_hs_st_ptr failed, ret :%d, client_version:%d\n", ret, hash_len);
+    if (ret || client_version == 0) {
+        debug_bpf_printk(
+            "bpf_probe_read ssl_hs_st_ptr failed, ret :%d, client_version:%d\n",
+            ret, hash_len);
         return 0;
     }
 
     struct ssl3_handshake_st ssl3_hs_state;
     u64 *ssl_hs_state_ptr = (u64 *)(ssl_hs_st_addr + BSSL__SSL_HANDSHAKE_STATE);
-    ret = bpf_probe_read_user(&ssl3_hs_state, sizeof(ssl3_hs_state), (void *)ssl_hs_state_ptr);
+    ret = bpf_probe_read_user(&ssl3_hs_state, sizeof(ssl3_hs_state),
+                              (void *)ssl_hs_state_ptr);
     if (ret) {
         debug_bpf_printk(
             "bpf_probe_read ssl_hs_state_ptr struct failed, ret :%d\n", ret);
         return 0;
     }
-    debug_bpf_printk("state:%d, tls13_state:%d\n", ssl3_hs_state.state, ssl3_hs_state.tls13_state);
+    debug_bpf_printk("state:%d, tls13_state:%d\n", ssl3_hs_state.state,
+                     ssl3_hs_state.tls13_state);
     ///////////// debug info  /////////
-//    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID :%d\n", pid);
-//    debug_bpf_printk("TLS version :%d\n", mastersecret->version);
-//    debug_bpf_printk("Client hello version :%d\n",client_version);
-//    debug_bpf_printk("hs->hash_len :%d\n", mastersecret->hash_len);
-//    debug_bpf_printk("client_random: %x %x %x\n", ssl3_stat.client_random[0],
-//                         ssl3_stat.client_random[1], ssl3_stat.client_random[2]);
+    //    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID :%d\n", pid);
+    //    debug_bpf_printk("TLS version :%d\n", mastersecret->version);
+    //    debug_bpf_printk("Client hello version :%d\n",client_version);
+    //    debug_bpf_printk("hs->hash_len :%d\n", mastersecret->hash_len);
+    //    debug_bpf_printk("client_random: %x %x %x\n",
+    //    ssl3_stat.client_random[0],
+    //                         ssl3_stat.client_random[1],
+    //                         ssl3_stat.client_random[2]);
     ///////////// get TLS handshake->handshake_finalized /////////
     // 判断当前tls链接状态
-    // handshake->handshake_finalized = hs_st_addr + BSSL__SSL_HANDSHAKE_HINTS + 8
+    // handshake->handshake_finalized = hs_st_addr + BSSL__SSL_HANDSHAKE_HINTS +
+    // 8
     s32 all_bool;
     u64 *hs_ptr_ab = (u64 *)(ssl_hs_st_addr + BSSL__SSL_HANDSHAKE_HINTS + 8);
     ret = bpf_probe_read_user(&all_bool, sizeof(all_bool), hs_ptr_ab);
@@ -285,7 +294,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
             ret, ssl_hs_st_addr);
         return 0;
     }
-    debug_bpf_printk("SSL_HANDSHAKE_ALLBOOL:%d, ssl_hs_st_ptr:%lx\n", all_bool, ssl_hs_st_addr);
+    debug_bpf_printk("SSL_HANDSHAKE_ALLBOOL:%d, ssl_hs_st_ptr:%lx\n", all_bool,
+                     ssl_hs_st_addr);
     // 是否为 state_done
 
     ///////////////////////// get TLS 1.2 master secret ////////////////////

--- a/kern/openssl_1_0_2a_kern.c
+++ b/kern/openssl_1_0_2a_kern.c
@@ -1,7 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_1_0_2_A_KERN_H
 #define ECAPTURE_OPENSSL_1_0_2_A_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 1.0.2u  20 Dec 2019, OPENSSL_VERSION_NUMBER: 268443999 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.0.2u  20 Dec 2019 */
+/* OPENSSL_VERSION_NUMBER: 268443999 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -38,4 +39,3 @@
 #include "openssl_masterkey.h"
 
 #endif
-

--- a/kern/openssl_1_1_0a_kern.c
+++ b/kern/openssl_1_1_0a_kern.c
@@ -1,7 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_1_1_0_A_KERN_H
 #define ECAPTURE_OPENSSL_1_1_0_A_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.0l  10 Sep 2019, OPENSSL_VERSION_NUMBER: 269484239 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.0l  10 Sep 2019 */
+/* OPENSSL_VERSION_NUMBER: 269484239 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -38,4 +39,3 @@
 #include "openssl_masterkey.h"
 
 #endif
-

--- a/kern/openssl_1_1_1a_kern.c
+++ b/kern/openssl_1_1_1a_kern.c
@@ -1,7 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_1_1_1_A_KERN_H
 #define ECAPTURE_OPENSSL_1_1_1_A_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1a  20 Nov 2018, OPENSSL_VERSION_NUMBER: 269488159 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1a  20 Nov 2018 */
+/* OPENSSL_VERSION_NUMBER: 269488159 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -46,4 +47,3 @@
 #include "openssl_masterkey.h"
 
 #endif
-

--- a/kern/openssl_1_1_1b_kern.c
+++ b/kern/openssl_1_1_1b_kern.c
@@ -1,7 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_1_1_1_B_KERN_H
 #define ECAPTURE_OPENSSL_1_1_1_B_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1c  28 May 2019, OPENSSL_VERSION_NUMBER: 269488191 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1c  28 May 2019 */
+/* OPENSSL_VERSION_NUMBER: 269488191 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -46,4 +47,3 @@
 #include "openssl_masterkey.h"
 
 #endif
-

--- a/kern/openssl_1_1_1d_kern.c
+++ b/kern/openssl_1_1_1d_kern.c
@@ -1,7 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_1_1_1_D_KERN_H
 #define ECAPTURE_OPENSSL_1_1_1_D_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1i  8 Dec 2020, OPENSSL_VERSION_NUMBER: 269488287 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1i  8 Dec 2020 */
+/* OPENSSL_VERSION_NUMBER: 269488287 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -46,4 +47,3 @@
 #include "openssl_masterkey.h"
 
 #endif
-

--- a/kern/openssl_1_1_1j_kern.c
+++ b/kern/openssl_1_1_1j_kern.c
@@ -1,7 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_1_1_1_J_KERN_H
 #define ECAPTURE_OPENSSL_1_1_1_J_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1s  1 Nov 2022, OPENSSL_VERSION_NUMBER: 269488447 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1s  1 Nov 2022 */
+/* OPENSSL_VERSION_NUMBER: 269488447 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -46,4 +47,3 @@
 #include "openssl_masterkey.h"
 
 #endif
-

--- a/kern/openssl_3_0_0_kern.c
+++ b/kern/openssl_3_0_0_kern.c
@@ -1,7 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_3_0_0_KERN_H
 #define ECAPTURE_OPENSSL_3_0_0_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 3.0.7 1 Nov 2022, OPENSSL_VERSION_NUMBER: 805306480 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.0.7 1 Nov 2022 */
+/* OPENSSL_VERSION_NUMBER: 805306480 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -46,4 +47,3 @@
 #include "openssl_masterkey_3.0.h"
 
 #endif
-

--- a/user/event/event_masterkey.go
+++ b/user/event/event_masterkey.go
@@ -131,7 +131,7 @@ type MasterSecretBSSLEvent struct {
 	Secret       [MASTER_SECRET_MAX_LEN]byte `json:"secret"`       // secret Key
 
 	// TLS 1.3
-	CipherId              uint32                `json:"cipherId"`              // Cipher ID
+	HashLen               uint32                `json:"hashLen"`              // hashLen
 	EarlyTrafficSecret    [EVP_MAX_MD_SIZE]byte `json:"earlyTrafficSecret"`    // CLIENT_EARLY_TRAFFIC_SECRET
 	ClientHandshakeSecret [EVP_MAX_MD_SIZE]byte `json:"clientHandshakeSecret"` // CLIENT_HANDSHAKE_TRAFFIC_SECRET
 	ServerHandshakeSecret [EVP_MAX_MD_SIZE]byte `json:"serverHandshakeSecret"` // SERVER_HANDSHAKE_TRAFFIC_SECRET
@@ -152,7 +152,7 @@ func (this *MasterSecretBSSLEvent) Decode(payload []byte) (err error) {
 	if err = binary.Read(buf, binary.LittleEndian, &this.Secret); err != nil {
 		return
 	}
-	if err = binary.Read(buf, binary.LittleEndian, &this.CipherId); err != nil {
+	if err = binary.Read(buf, binary.LittleEndian, &this.HashLen); err != nil {
 		return
 	}
 	if err = binary.Read(buf, binary.LittleEndian, &this.EarlyTrafficSecret); err != nil {

--- a/user/module/const.go
+++ b/user/module/const.go
@@ -36,12 +36,12 @@ const (
 )
 
 const (
-	MasterKeyHookFuncOpenSSL   = "SSL_write"
+	MasterKeyHookFuncOpenSSL = "SSL_write"
 
 	/*
 		在boringSSL类库里，SSL_write函数调用了 SSL_do_handshake ，
 		SSL_do_handshake 函数执行时，当前SSL链接握手可能还未完成，且
-	 */
+	*/
 	// 2022-12-16 改为 SSL_in_init
-	MasterKeyHookFuncBoringSSL = "SSL_do_handshake"
+	MasterKeyHookFuncBoringSSL = "SSL_in_init"
 )

--- a/user/module/const.go
+++ b/user/module/const.go
@@ -37,5 +37,11 @@ const (
 
 const (
 	MasterKeyHookFuncOpenSSL   = "SSL_write"
+
+	/*
+		在boringSSL类库里，SSL_write函数调用了 SSL_do_handshake ，
+		SSL_do_handshake 函数执行时，当前SSL链接握手可能还未完成，且
+	 */
+	// 2022-12-16 改为 SSL_in_init
 	MasterKeyHookFuncBoringSSL = "SSL_do_handshake"
 )

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -83,7 +83,7 @@ type MOpenSSLProbe struct {
 	sslVersionBpfMap map[string]string // bpf map key: ssl version, value: bpf map key
 	sslBpfFile       string            // ssl bpf file
 	isBoringSSL      bool              //
-	masterHookFunc   string            // SSL_do_handshake on boringSSL,  SSL_write on openssl
+	masterHookFunc   string            // SSL_in_init on boringSSL,  SSL_write on openssl
 }
 
 // 对象初始化
@@ -619,8 +619,9 @@ func (this *MOpenSSLProbe) saveMasterSecretBSSL(secretEvent *event.MasterSecretB
 		fallthrough
 	default:
 		var length int
+		//length = int(secretEvent.HashLen)
 		length = 32
-
+		this.logger.Printf("secretEvent.HashLen:%d, CipherId:%d",secretEvent.HashLen, secretEvent.HashLen)
 		b = bytes.NewBufferString(fmt.Sprintf("%s %02x %02x\n", hkdf.KeyLogLabelClientHandshake, secretEvent.ClientRandom, secretEvent.ClientHandshakeSecret[:length]))
 		b.WriteString(fmt.Sprintf("%s %02x %02x\n", hkdf.KeyLogLabelClientEarlyTafficSecret, secretEvent.ClientRandom, secretEvent.EarlyTrafficSecret[:length]))
 		b.WriteString(fmt.Sprintf("%s %02x %02x\n", hkdf.KeyLogLabelClientTraffic, secretEvent.ClientRandom, secretEvent.ClientTrafficSecret0[:length]))

--- a/user/module/probe_openssl_tc.go
+++ b/user/module/probe_openssl_tc.go
@@ -234,6 +234,9 @@ func (this *MOpenSSLProbe) savePcapng() error {
 		}
 	}
 	this.logger.Printf("%s\t save %d packets into pcapng file.\n", this.Name(), i)
+	if i == 0 {
+		this.logger.Printf("nothing captured, please check your network interface, see \"ecapture tls -h\" for more information.")
+	}
 	return this.pcapWriter.Flush()
 }
 

--- a/utils/boringssl-offset.c
+++ b/utils/boringssl-offset.c
@@ -13,40 +13,39 @@
 // limitations under the License.
 
 //  g++ -I include/ -I src/ ./src/offset.c -o off
-#include <stdio.h>
-#include <stddef.h>
-#include <ssl/internal.h>
 #include <openssl/base.h>
 #include <openssl/crypto.h>
+#include <ssl/internal.h>
+#include <stddef.h>
+#include <stdio.h>
 
-
-#define SSL_STRUCT_OFFSETS                      \
-    X(ssl_st, version)                          \
-    X(ssl_st, session)                          \
-    X(ssl_st, s3)                               \
-    X(ssl_session_st, secret)                   \
-    X(ssl_session_st, secret_length)            \
-    X(ssl_session_st, cipher)                   \
-    X(ssl_cipher_st, id)                        \
-    X(bssl::SSL3_STATE, hs)                     \
-    X(bssl::SSL3_STATE, client_random)          \
-    X(bssl::SSL3_STATE, established_session)    \
-    X(bssl::SSL_HANDSHAKE, new_session)         \
-    X(bssl::SSL_HANDSHAKE, early_session)       \
-    X(bssl::SSL_HANDSHAKE, hints)               \
-    X(bssl::SSL_HANDSHAKE, client_version)               \
-    X(bssl::SSL_HANDSHAKE, state)               \
-    X(bssl::SSL_HANDSHAKE, tls13_state)               \
+#define SSL_STRUCT_OFFSETS                   \
+    X(ssl_st, version)                       \
+    X(ssl_st, session)                       \
+    X(ssl_st, s3)                            \
+    X(ssl_session_st, secret)                \
+    X(ssl_session_st, secret_length)         \
+    X(ssl_session_st, cipher)                \
+    X(ssl_cipher_st, id)                     \
+    X(bssl::SSL3_STATE, hs)                  \
+    X(bssl::SSL3_STATE, client_random)       \
+    X(bssl::SSL3_STATE, established_session) \
+    X(bssl::SSL_HANDSHAKE, new_session)      \
+    X(bssl::SSL_HANDSHAKE, early_session)    \
+    X(bssl::SSL_HANDSHAKE, hints)            \
+    X(bssl::SSL_HANDSHAKE, client_version)   \
+    X(bssl::SSL_HANDSHAKE, state)            \
+    X(bssl::SSL_HANDSHAKE, tls13_state)      \
     X(bssl::SSL_HANDSHAKE, max_version)
 
 void toUpper(char *s) {
     int i = 0;
     while (s[i] != '\0') {
-          if (s[i] == '.' || s[i] == ':') {
+        if (s[i] == '.' || s[i] == ':') {
             putchar('_');
-          } else {
+        } else {
             putchar(toupper(s[i]));
-          }
+        }
         i++;
     }
 }
@@ -61,10 +60,10 @@ void format(char *struct_name, char *field_name, size_t offset) {
 }
 
 int main() {
-    printf("/* OPENSSL_VERSION_TEXT: %s, OPENSSL_VERSION_NUMBER: %d */\n\n",
-           OPENSSL_VERSION_TEXT, OPENSSL_VERSION_NUMBER);
+    printf("/* OPENSSL_VERSION_TEXT: %s */\n", OPENSSL_VERSION_TEXT);
+    printf("/* OPENSSL_VERSION_NUMBER: %d */\n\n", OPENSSL_VERSION_NUMBER);
 
-#define X(struct_name, field_name)      \
+#define X(struct_name, field_name) \
     format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
     SSL_STRUCT_OFFSETS
 #undef X

--- a/utils/boringssl-offset.c
+++ b/utils/boringssl-offset.c
@@ -33,8 +33,10 @@
     X(bssl::SSL3_STATE, established_session)    \
     X(bssl::SSL_HANDSHAKE, new_session)         \
     X(bssl::SSL_HANDSHAKE, early_session)       \
+    X(bssl::SSL_HANDSHAKE, hints)               \
+    X(bssl::SSL_HANDSHAKE, client_version)               \
     X(bssl::SSL_HANDSHAKE, state)               \
-    X(bssl::SSL_HANDSHAKE, tls13_state)         \
+    X(bssl::SSL_HANDSHAKE, tls13_state)               \
     X(bssl::SSL_HANDSHAKE, max_version)
 
 void toUpper(char *s) {

--- a/utils/boringssl-offset.c
+++ b/utils/boringssl-offset.c
@@ -23,12 +23,13 @@
     X(ssl_st, version)                       \
     X(ssl_st, session)                       \
     X(ssl_st, s3)                            \
-    X(ssl_session_st, secret)                \
     X(ssl_session_st, secret_length)         \
+    X(ssl_session_st, secret)                \
     X(ssl_session_st, cipher)                \
     X(ssl_cipher_st, id)                     \
     X(bssl::SSL3_STATE, hs)                  \
     X(bssl::SSL3_STATE, client_random)       \
+    X(bssl::SSL3_STATE, exporter_secret)     \
     X(bssl::SSL3_STATE, established_session) \
     X(bssl::SSL_HANDSHAKE, new_session)      \
     X(bssl::SSL_HANDSHAKE, early_session)    \

--- a/utils/boringssl-offset.c
+++ b/utils/boringssl-offset.c
@@ -19,41 +19,22 @@
 #include <openssl/base.h>
 #include <openssl/crypto.h>
 
-/*
-  // via boringssl source code  src/ssl/internal.h : line 1585
 
-  // max_version is the maximum accepted protocol version, taking account both
-  // |SSL_OP_NO_*| and |SSL_CTX_set_max_proto_version| APIs.
-  uint16_t max_version = 0;
-
- private:
-  size_t hash_len_ = 0;
-  uint8_t secret_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t early_traffic_secret_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t client_handshake_secret_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t server_handshake_secret_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t client_traffic_secret_0_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t server_traffic_secret_0_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t expected_client_finished_[SSL_MAX_MD_SIZE] = {0};
-  */
-// boringssl中的 TLS 1.3 密钥是 private属性，无法直接offset计算。
-// 所以，计算private前面的属性地址，再手动相加。
-// private 前面的属性是max_version ，offset是30
-// private 第一个属性是size_t hash_len_，内存对齐后，offset就是32
-// secret的offset即 32 + sizeof(size_t) ，即 40 。其他的累加 SSL_MAX_MD_SIZE长度即可。
 #define SSL_STRUCT_OFFSETS                      \
     X(ssl_st, version)                          \
     X(ssl_st, session)                          \
     X(ssl_st, s3)                               \
     X(ssl_session_st, secret)                   \
     X(ssl_session_st, secret_length)            \
-    X(ssl_session_st, cipher)            \
-    X(ssl_cipher_st, id)            \
+    X(ssl_session_st, cipher)                   \
+    X(ssl_cipher_st, id)                        \
     X(bssl::SSL3_STATE, hs)                     \
     X(bssl::SSL3_STATE, client_random)          \
+    X(bssl::SSL3_STATE, established_session)    \
     X(bssl::SSL_HANDSHAKE, new_session)         \
     X(bssl::SSL_HANDSHAKE, early_session)       \
-    X(bssl::SSL3_STATE, established_session)    \
+    X(bssl::SSL_HANDSHAKE, state)               \
+    X(bssl::SSL_HANDSHAKE, tls13_state)         \
     X(bssl::SSL_HANDSHAKE, max_version)
 
 void toUpper(char *s) {
@@ -78,7 +59,7 @@ void format(char *struct_name, char *field_name, size_t offset) {
 }
 
 int main() {
-    printf("/* OPENSSL_VERSION_TEXT: %s, OPENSSL_VERSION_NUMBER: %ld */\n\n",
+    printf("/* OPENSSL_VERSION_TEXT: %s, OPENSSL_VERSION_NUMBER: %d */\n\n",
            OPENSSL_VERSION_TEXT, OPENSSL_VERSION_NUMBER);
 
 #define X(struct_name, field_name)      \

--- a/utils/boringssl_offset_1.1.1.sh
+++ b/utils/boringssl_offset_1.1.1.sh
@@ -65,7 +65,7 @@ function run() {
     echo -e "#include \"boringssl_const.h\"" >>${header_file}
     echo -e "#include \"boringssl_masterkey.h\"" >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
-    echo -e "\n#endif\n" >>${header_file}
+    echo -e "\n#endif" >>${header_file}
 
   done
 

--- a/utils/boringssl_offset_1.1.1.sh
+++ b/utils/boringssl_offset_1.1.1.sh
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
+
+echo $NON_ANDROID
+
 PROJECT_ROOT_DIR=$(pwd)
 BORINGSSL_REPO=https://android.googlesource.com/platform/external/boringssl
-#BORINGSSL_REPO=https://github.com/google/boringssl.git
 BORINGSSL_DIR="${PROJECT_ROOT_DIR}/deps/boringssl"
+
+NON_ANDROID=0
+if [[ $1 == 1 ]] ; then
+  BORINGSSL_REPO=https://github.com/google/boringssl.git
+  BORINGSSL_DIR="${PROJECT_ROOT_DIR}/deps/boringssl_non_android"
+  NON_ANDROID=1
+fi
+
 OUTPUT_DIR="${PROJECT_ROOT_DIR}/kern"
 
 if [[ ! -f "go.mod" ]]; then
@@ -56,9 +66,6 @@ function run() {
     echo -e "#include \"boringssl_masterkey.h\"" >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "\n#endif\n" >>${header_file}
-
-    # clean up
-    make clean
 
   done
 

--- a/utils/boringssl_offset_1.1.1.sh
+++ b/utils/boringssl_offset_1.1.1.sh
@@ -47,7 +47,7 @@ function run() {
 #    git checkout ${tag}
     echo "Generating ${header_file}"
 
-    g++ -I include/ -I . -I ./src/ offset.c -o offset
+    g++ -Wno-write-strings -Wno-invalid-offsetof -I include/ -I . -I ./src/ offset.c -o offset
 
     echo -e "#ifndef ECAPTURE_${header_define}" >${header_file}
     echo -e "#define ECAPTURE_${header_define}\n" >>${header_file}

--- a/utils/openssl_1_0_2_offset.c
+++ b/utils/openssl_1_0_2_offset.c
@@ -1,18 +1,17 @@
 #include <ctype.h>
-#include <stdio.h>
-#include <stddef.h>
 #include <openssl/crypto.h>
-
 #include <ssl/ssl_locl.h>
+#include <stddef.h>
+#include <stdio.h>
 
-#define SSL_STRUCT_OFFSETS              \
-    X(ssl_st, version)                  \
-    X(ssl_st, session)                  \
-    X(ssl_st, s3)                       \
-    X(ssl_session_st, master_key)       \
-    X(ssl3_state_st, client_random)     \
-    X(ssl_session_st, cipher)           \
-    X(ssl_session_st, cipher_id)        \
+#define SSL_STRUCT_OFFSETS          \
+    X(ssl_st, version)              \
+    X(ssl_st, session)              \
+    X(ssl_st, s3)                   \
+    X(ssl_session_st, master_key)   \
+    X(ssl3_state_st, client_random) \
+    X(ssl_session_st, cipher)       \
+    X(ssl_session_st, cipher_id)    \
     X(ssl_cipher_st, id)
 
 void toUpper(char *s) {
@@ -33,10 +32,9 @@ void format(char *struct_name, char *field_name, size_t offset) {
 }
 
 int main() {
-    printf("/* OPENSSL_VERSION_TEXT: %s, OPENSSL_VERSION_NUMBER: %ld */\n\n",
-           OPENSSL_VERSION_TEXT, OPENSSL_VERSION_NUMBER);
-
-#define X(struct_name, field_name)      \
+    printf("/* OPENSSL_VERSION_TEXT: %s */\n", OPENSSL_VERSION_TEXT);
+    printf("/* OPENSSL_VERSION_NUMBER: %d */\n\n", OPENSSL_VERSION_NUMBER);
+#define X(struct_name, field_name) \
     format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
     SSL_STRUCT_OFFSETS
 #undef X

--- a/utils/openssl_1_1_0_offset.c
+++ b/utils/openssl_1_1_0_offset.c
@@ -1,18 +1,17 @@
 #include <ctype.h>
-#include <stdio.h>
-#include <stddef.h>
 #include <openssl/crypto.h>
-
 #include <ssl/ssl_locl.h>
+#include <stddef.h>
+#include <stdio.h>
 
-#define SSL_STRUCT_OFFSETS              \
-    X(ssl_st, version)                  \
-    X(ssl_st, session)                  \
-    X(ssl_st, s3)                       \
-    X(ssl_session_st, master_key)       \
-    X(ssl3_state_st, client_random)     \
-    X(ssl_session_st, cipher)           \
-    X(ssl_session_st, cipher_id)        \
+#define SSL_STRUCT_OFFSETS          \
+    X(ssl_st, version)              \
+    X(ssl_st, session)              \
+    X(ssl_st, s3)                   \
+    X(ssl_session_st, master_key)   \
+    X(ssl3_state_st, client_random) \
+    X(ssl_session_st, cipher)       \
+    X(ssl_session_st, cipher_id)    \
     X(ssl_cipher_st, id)
 
 void toUpper(char *s) {
@@ -33,10 +32,10 @@ void format(char *struct_name, char *field_name, size_t offset) {
 }
 
 int main() {
-    printf("/* OPENSSL_VERSION_TEXT: %s, OPENSSL_VERSION_NUMBER: %ld */\n\n",
-           OPENSSL_VERSION_TEXT, OPENSSL_VERSION_NUMBER);
+    printf("/* OPENSSL_VERSION_TEXT: %s */\n", OPENSSL_VERSION_TEXT);
+    printf("/* OPENSSL_VERSION_NUMBER: %d */\n\n", OPENSSL_VERSION_NUMBER);
 
-#define X(struct_name, field_name)      \
+#define X(struct_name, field_name) \
     format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
     SSL_STRUCT_OFFSETS
 #undef X

--- a/utils/openssl_1_1_1_offset.c
+++ b/utils/openssl_1_1_1_offset.c
@@ -1,7 +1,7 @@
 #include <ctype.h>
-#include <stdio.h>
-#include <stddef.h>
 #include <openssl/crypto.h>
+#include <stddef.h>
+#include <stdio.h>
 
 #if defined(SSL_LOCL_H)
 #include <ssl/ssl_locl.h>
@@ -9,19 +9,19 @@
 #include <ssl/ssl_local.h>
 #endif
 
-#define SSL_STRUCT_OFFSETS                      \
-    X(ssl_st, version)                          \
-    X(ssl_st, session)                          \
-    X(ssl_st, s3)                               \
-    X(ssl_session_st, master_key)               \
-    X(ssl3_state_st, client_random)             \
-    X(ssl_session_st, cipher)                   \
-    X(ssl_session_st, cipher_id)                \
-    X(ssl_cipher_st, id)                        \
-    X(ssl_st, handshake_secret)                 \
-    X(ssl_st, handshake_traffic_hash)           \
-    X(ssl_st, client_app_traffic_secret)        \
-    X(ssl_st, server_app_traffic_secret)        \
+#define SSL_STRUCT_OFFSETS               \
+    X(ssl_st, version)                   \
+    X(ssl_st, session)                   \
+    X(ssl_st, s3)                        \
+    X(ssl_session_st, master_key)        \
+    X(ssl3_state_st, client_random)      \
+    X(ssl_session_st, cipher)            \
+    X(ssl_session_st, cipher_id)         \
+    X(ssl_cipher_st, id)                 \
+    X(ssl_st, handshake_secret)          \
+    X(ssl_st, handshake_traffic_hash)    \
+    X(ssl_st, client_app_traffic_secret) \
+    X(ssl_st, server_app_traffic_secret) \
     X(ssl_st, exporter_master_secret)
 
 void toUpper(char *s) {
@@ -42,10 +42,10 @@ void format(char *struct_name, char *field_name, size_t offset) {
 }
 
 int main() {
-    printf("/* OPENSSL_VERSION_TEXT: %s, OPENSSL_VERSION_NUMBER: %ld */\n\n",
-           OPENSSL_VERSION_TEXT, OPENSSL_VERSION_NUMBER);
+    printf("/* OPENSSL_VERSION_TEXT: %s */\n", OPENSSL_VERSION_TEXT);
+    printf("/* OPENSSL_VERSION_NUMBER: %d */\n\n", OPENSSL_VERSION_NUMBER);
 
-#define X(struct_name, field_name)      \
+#define X(struct_name, field_name) \
     format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
     SSL_STRUCT_OFFSETS
 #undef X

--- a/utils/openssl_3_0_offset.c
+++ b/utils/openssl_3_0_offset.c
@@ -5,50 +5,49 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#define SSL_STRUCT_OFFSETS                                                     \
-  X(ssl_st, version)                                                           \
-  X(ssl_st, session)                                                           \
-  X(ssl_st, s3)                                                                \
-  X(ssl_session_st, master_key)                                                \
-  X(ssl_st, s3.client_random)                                                  \
-  X(ssl_session_st, cipher)                                                    \
-  X(ssl_session_st, cipher_id)                                                 \
-  X(ssl_cipher_st, id)                                                         \
-  X(ssl_st, handshake_secret)                                                  \
-  X(ssl_st, handshake_traffic_hash)                                            \
-  X(ssl_st, client_app_traffic_secret)                                         \
-  X(ssl_st, server_app_traffic_secret)                                         \
-  X(ssl_st, exporter_master_secret)
+#define SSL_STRUCT_OFFSETS               \
+    X(ssl_st, version)                   \
+    X(ssl_st, session)                   \
+    X(ssl_st, s3)                        \
+    X(ssl_session_st, master_key)        \
+    X(ssl_st, s3.client_random)          \
+    X(ssl_session_st, cipher)            \
+    X(ssl_session_st, cipher_id)         \
+    X(ssl_cipher_st, id)                 \
+    X(ssl_st, handshake_secret)          \
+    X(ssl_st, handshake_traffic_hash)    \
+    X(ssl_st, client_app_traffic_secret) \
+    X(ssl_st, server_app_traffic_secret) \
+    X(ssl_st, exporter_master_secret)
 
 void toUpper(char *s) {
-  int i = 0;
-  while (s[i] != '\0') {
-      if (s[i] == '.') {
-        putchar('_');
-      } else {
-        putchar(toupper(s[i]));
-      }
-    i++;
-  }
+    int i = 0;
+    while (s[i] != '\0') {
+        if (s[i] == '.') {
+            putchar('_');
+        } else {
+            putchar(toupper(s[i]));
+        }
+        i++;
+    }
 }
 
 void format(char *struct_name, char *field_name, size_t offset) {
-  printf("// %s->%s\n", struct_name, field_name);
-  printf("#define ");
-  toUpper(struct_name);
-  printf("_");
-  toUpper(field_name);
-  printf(" 0x%lx\n\n", offset);
+    printf("// %s->%s\n", struct_name, field_name);
+    printf("#define ");
+    toUpper(struct_name);
+    printf("_");
+    toUpper(field_name);
+    printf(" 0x%lx\n\n", offset);
 }
 
 int main() {
-  printf("/* OPENSSL_VERSION_TEXT: %s, OPENSSL_VERSION_NUMBER: %ld */\n\n",
-         OPENSSL_VERSION_TEXT, OPENSSL_VERSION_NUMBER);
-
-#define X(struct_name, field_name)                                             \
-  format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
-  SSL_STRUCT_OFFSETS
+    printf("/* OPENSSL_VERSION_TEXT: %s */\n", OPENSSL_VERSION_TEXT);
+    printf("/* OPENSSL_VERSION_NUMBER: %d */\n\n", OPENSSL_VERSION_NUMBER);
+#define X(struct_name, field_name) \
+    format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
+    SSL_STRUCT_OFFSETS
 #undef X
 
-  return 0;
+    return 0;
 }

--- a/utils/openssl_offset_1.0.2.sh
+++ b/utils/openssl_offset_1.0.2.sh
@@ -80,7 +80,7 @@ function run() {
     echo -e "#define SSL_ST_EXPORTER_MASTER_SECRET 0\n" >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey.h\"" >>${header_file}
-    echo -e "\n#endif\n" >>${header_file}
+    echo -e "\n#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_1.1.0.sh
+++ b/utils/openssl_offset_1.1.0.sh
@@ -42,6 +42,7 @@ function run() {
 
 #  exit 0
 #  for ver in {a..r}; do
+  # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do
     tag="OpenSSL_1_1_0${ver}"
     val=${sslVerMap[$ver]}
@@ -59,7 +60,7 @@ function run() {
     ./config
     make include/openssl/opensslconf.h
 
-    clang -I include/ -I . offset.c -o offset $flag
+    clang -I include/ -I . offset.c -o offset
 
     echo -e "#ifndef ECAPTURE_${header_define}" >${header_file}
     echo -e "#define ECAPTURE_${header_define}\n" >>${header_file}
@@ -72,7 +73,7 @@ function run() {
     echo -e "#define SSL_ST_EXPORTER_MASTER_SECRET 0\n" >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey.h\"" >>${header_file}
-    echo -e "\n#endif\n" >>${header_file}
+    echo -e "\n#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_1.1.1.sh
+++ b/utils/openssl_offset_1.1.1.sh
@@ -73,14 +73,14 @@ function run() {
     else
       unset flags
     fi
-    clang ${flags} -I include/ -I . offset.c -o offset $flag
+    clang ${flags} -I include/ -I . offset.c -o offset
 
     echo -e "#ifndef ECAPTURE_${header_define}" >${header_file}
     echo -e "#define ECAPTURE_${header_define}\n" >>${header_file}
     ./offset >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey.h\"" >>${header_file}
-    echo -e "\n#endif\n" >>${header_file}
+    echo -e "\n#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_3.0.sh
+++ b/utils/openssl_offset_3.0.sh
@@ -51,6 +51,7 @@ function run() {
     ./config
 
 #    make reconfigure reconf
+    make clean
     make include/openssl/opensslconf.h
     make include/openssl/configuration.h
     make build_generated

--- a/utils/openssl_offset_3.0.sh
+++ b/utils/openssl_offset_3.0.sh
@@ -63,7 +63,7 @@ function run() {
     ./offset >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey_3.0.h\"" >>${header_file}
-    echo -e "\n#endif\n" >>${header_file}
+    echo -e "\n#endif" >>${header_file}
 
     # clean up
     make clean


### PR DESCRIPTION
fixes #283 

On an android phone, after triggering network behavior, many null-valued keys were captured. 

Here, the problem of offset address calculation error is fixed, and the detection of TLS handshake state is increased.