### PR TITLE
user : increase buffer size of ebpf map. (improve #291 , #314)

### DIFF
--- a/user/module/const.go
+++ b/user/module/const.go
@@ -45,3 +45,7 @@ const (
 	// 2022-12-16 改为 SSL_in_init
 	MasterKeyHookFuncBoringSSL = "SSL_in_init"
 )
+
+// buffer size times of ebpf perf map
+// buffer size = BufferSizeOfEbpfMap * os.pagesize
+const BufferSizeOfEbpfMap = 1024

--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -190,7 +190,7 @@ func (this *Module) readEvents() error {
 }
 
 func (this *Module) perfEventReader(errChan chan error, em *ebpf.Map) {
-	rd, err := perf.NewReader(em, os.Getpagesize()*64)
+	rd, err := perf.NewReader(em, os.Getpagesize()*BufferSizeOfEbpfMap)
 	if err != nil {
 		errChan <- fmt.Errorf("creating %s reader dns: %s", em.String(), err)
 		return


### PR DESCRIPTION
improved event lost.
> perf event ring buffer full

change 64 to 1024. in Linux, will be 4K * 1024 = 4M. 
improve #291 , #314