### PR TITLE
kern: fix wrong uid

### DIFF
--- a/kern/bash_kern.c
+++ b/kern/bash_kern.c
@@ -40,7 +40,7 @@ int uretprobe_bash_readline(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -68,7 +68,7 @@ int uretprobe_bash_retval(struct pt_regs *ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     int retval = (int)PT_REGS_RC(ctx);
 
 #ifndef KERNEL_LESS_5_2

--- a/kern/boringssl_masterkey.h
+++ b/kern/boringssl_masterkey.h
@@ -152,7 +152,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids

--- a/kern/gnutls_kern.c
+++ b/kern/gnutls_kern.c
@@ -122,7 +122,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("gnutls uprobe/gnutls_record_send pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
@@ -146,7 +146,7 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("gnutls uretprobe/gnutls_record_send pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
@@ -178,7 +178,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("gnutls uprobe/gnutls_record_recv pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
@@ -202,7 +202,7 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("gnutls uretprobe/gnutls_record_recv pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2

--- a/kern/nspr_kern.c
+++ b/kern/nspr_kern.c
@@ -119,7 +119,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("nspr uprobe/PR_Write pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
@@ -143,7 +143,7 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("nspr uretprobe/PR_Write pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
@@ -176,7 +176,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("nspr uprobe/PR_Read pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
@@ -200,7 +200,7 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("nspr uretprobe/PR_Read pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2

--- a/kern/openssl.h
+++ b/kern/openssl.h
@@ -176,7 +176,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -218,7 +218,7 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -250,7 +250,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("openssl uprobe/SSL_read pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
@@ -291,7 +291,7 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
     debug_bpf_printk("openssl uretprobe/SSL_read pid :%d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
@@ -324,7 +324,7 @@ int probe_connect(struct pt_regs* ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids

--- a/kern/openssl_masterkey.h
+++ b/kern/openssl_masterkey.h
@@ -91,7 +91,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids

--- a/kern/openssl_masterkey_3.0.h
+++ b/kern/openssl_masterkey_3.0.h
@@ -80,7 +80,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
-    u32 uid = current_uid_gid >> 32;
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids


### PR DESCRIPTION
From the man page:
```
u64 bpf_get_current_uid_gid(void)

       Return A 64-bit integer containing the current GID and UID, and created as such: current_gid << 32 | current_uid.
```