### PR TITLE
support rpm build

### DIFF
--- a/rpmBuild.spec
+++ b/rpmBuild.spec
@@ -1,0 +1,40 @@
+Name:       ecapture
+Version:    0.5.0
+Release:    1%{?dist}
+Summary:    capture SSL/TLS text content without CA cert using eBPF
+License:    AGPL-3.0
+URL:        https://ecapture.cc
+Source0:    %{name}-%{version}.tar.gz
+
+BuildRequires: make,clang
+
+%description
+SSL/TLS plaintext capture,
+support openssl/libressl/boringssl/gnutls/nspr(nss) libraries.
+
+GoTLS plaintext support go tls library, which refers to encrypted
+
+Communication in https/tls programs written in the golang language.
+
+Bash audit, capture bash command for Host Security Audit.
+
+MySQL query SQL audit, support mysqld 5.6/5.7/8.0, and mariadDB.
+
+%prep
+%setup -c
+%build
+make
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}/usr/local/bin/
+install -m 755 bin/ecapture %{buildroot}/usr/local/bin/ecapture
+
+%files
+/usr/local/bin/ecapture
+
+%changelog
+* Sun Apr  2 2023 ecapture - 0.5.0
+- Support for capturing plaintext communication of TLS/HTTPS encrypted programs written in Golang.
+- Refactored the way parameters are obtained from Golang ABI (supports two types of ABI on registers-based and stack-based).
+%autochangelog

--- a/rpm_build.sh
+++ b/rpm_build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+rpmdev-setuptree
+name=$(grep "Name:" rpmBuild.spec | awk '{print $2}')
+version=$(grep "Version:" rpmBuild.spec | awk '{print $2}')
+source0=$name-$version.tar.gz
+tar zcvf ~/rpmbuild/SOURCES/$source0 ./
+rpmbuild -bb rpmBuild.spec


### PR DESCRIPTION
now we can use a simple command to build rpm: `sh rpm_build.sh`, it makes the ecapture installed more convenient.

output of `rpm -qi ecapture` when ecapture is installed is as follows:
![image](https://user-images.githubusercontent.com/22660757/229341892-55f6df92-2fb3-41a1-9f53-288dd91469e8.png)
