### PR TITLE
use makefile to build rpm

### DIFF
--- a/builder/rpmBuild.spec
+++ b/builder/rpmBuild.spec
@@ -1,6 +1,6 @@
 Name:       ecapture
-Version:    0.5.0
-Release:    1%{?dist}
+Version:
+Release:
 Summary:    capture SSL/TLS text content without CA cert using eBPF
 License:    AGPL-3.0
 URL:        https://ecapture.cc
@@ -11,7 +11,6 @@ Source0:    %{name}-%{version}.tar.gz
 
 BuildRequires: make
 BuildRequires: clang
-BuildRequires: golang
 
 %description
 SSL/TLS plaintext capture,

--- a/builder/rpm_build.sh
+++ b/builder/rpm_build.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-rpmdev-setuptree
-name=$(grep "Name:" rpmBuild.spec | awk '{print $2}')
-version=$(grep "Version:" rpmBuild.spec | awk '{print $2}')
-source0=$name-$version.tar.gz
-tar zcvf ~/rpmbuild/SOURCES/$source0 ../
-rpmbuild -ba rpmBuild.spec


### PR DESCRIPTION
optimize the way to build rpm, now we can use `make rpm VERSION=0.5.0 RELEASE=2` to generate rpm