### PR TITLE
user: fixes slice out of range (#363)

### DIFF
--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -530,6 +530,9 @@ func (this *MOpenSSLProbe) saveMasterSecretBSSL(secretEvent *event.MasterSecretB
 			return
 		}
 		var length = int(secretEvent.HashLen)
+		if length > event.MasterSecretMaxLen {
+			length = event.MasterSecretMaxLen
+		}
 		b = bytes.NewBufferString(fmt.Sprintf("%s %02x %02x\n", hkdf.KeyLogLabelTLS12, secretEvent.ClientRandom, secretEvent.Secret[:length]))
 		this.masterKeys[k] = true
 	case event.Tls13Version:

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -532,6 +532,7 @@ func (this *MOpenSSLProbe) saveMasterSecretBSSL(secretEvent *event.MasterSecretB
 		var length = int(secretEvent.HashLen)
 		if length > event.MasterSecretMaxLen {
 			length = event.MasterSecretMaxLen
+			this.logger.Println("master secret length is too long, truncate to 48 bytes, but it may cause keylog file error")
 		}
 		b = bytes.NewBufferString(fmt.Sprintf("%s %02x %02x\n", hkdf.KeyLogLabelTLS12, secretEvent.ClientRandom, secretEvent.Secret[:length]))
 		this.masterKeys[k] = true


### PR DESCRIPTION
However, we need to identify the root cause. The TLS key length cannot exceed 48 bytes.