### PR TITLE
refactor: removal of deprecated flag support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,5 +156,9 @@ bin/ecapture --help
 ```
 
 
+## Stargazers over time
+
+[![Stargazers over time](https://starchart.cc/gojue/ecapture.svg)](https://starchart.cc/gojue/ecapture)
+
 # Contributing
 See [CONTRIBUTING](./CONTRIBUTING.md) for details on submitting patches and the contribution workflow.

--- a/README_CN.md
+++ b/README_CN.md
@@ -185,5 +185,11 @@ cd ecapture
 make nocore
 bin/ecapture
 ```
+
+## Stargazers over time
+
+[![Stargazers over time](https://starchart.cc/gojue/ecapture.svg)](https://starchart.cc/gojue/ecapture)
+
+
 # 贡献
 参考 [CONTRIBUTING](./CONTRIBUTING.md)的介绍，提交issue、PR等，非常感谢。

--- a/README_JA.md
+++ b/README_JA.md
@@ -157,6 +157,10 @@ make nocore
 bin/ecapture --help
 ```
 
+## Stargazers over time
+
+[![Stargazers over time](https://starchart.cc/gojue/ecapture.svg)](https://starchart.cc/gojue/ecapture)
+
 
 # コントリビュート
 パッチの投稿やコントリビューションのワークフローの詳細は [CONTRIBUTING](./CONTRIBUTING.md) を参照してください。

--- a/cli/cmd/gotls.go
+++ b/cli/cmd/gotls.go
@@ -95,7 +95,7 @@ func goTLSCommandFunc(command *cobra.Command, args []string) {
 	conf.SetUid(gConf.Uid)
 	conf.SetDebug(gConf.Debug)
 	conf.SetHex(gConf.IsHex)
-	conf.SetNoSearch(gConf.NoSearch)
+	//conf.SetNoSearch(gConf.NoSearch)
 
 	err = conf.Check()
 

--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -49,12 +49,12 @@ ecapture tls -w save_android.pcapng -i wlan0 --libssl=/apex/com.android.conscryp
 }
 
 func init() {
-	opensslCmd.PersistentFlags().StringVar(&oc.Curlpath, "curl", "", "curl or wget file path, use to dectet openssl.so path, default:/usr/bin/curl. (Deprecated)")
+	//opensslCmd.PersistentFlags().StringVar(&oc.Curlpath, "curl", "", "curl or wget file path, use to dectet openssl.so path, default:/usr/bin/curl. (Deprecated)")
 	opensslCmd.PersistentFlags().StringVar(&oc.Openssl, "libssl", "", "libssl.so file path, will automatically find it from curl default.")
 	opensslCmd.PersistentFlags().StringVar(&oc.CGroupPath, "cgroup_path", "/sys/fs/cgroup", "cgroup path, default: /sys/fs/cgroup.")
 	opensslCmd.PersistentFlags().StringVar(&gc.Gnutls, "gnutls", "", "libgnutls.so file path, will automatically find it from curl default.")
-	opensslCmd.PersistentFlags().StringVar(&gc.Curlpath, "wget", "", "wget file path, default: /usr/bin/wget. (Deprecated)")
-	opensslCmd.PersistentFlags().StringVar(&nc.Firefoxpath, "firefox", "", "firefox file path, default: /usr/lib/firefox/firefox. (Deprecated)")
+	//opensslCmd.PersistentFlags().StringVar(&gc.Curlpath, "wget", "", "wget file path, default: /usr/bin/wget. (Deprecated)")
+	//opensslCmd.PersistentFlags().StringVar(&nc.Firefoxpath, "firefox", "", "firefox file path, default: /usr/lib/firefox/firefox. (Deprecated)")
 	opensslCmd.PersistentFlags().StringVar(&nc.Nsprpath, "nspr", "", "libnspr44.so file path, will automatically find it from curl default.")
 	opensslCmd.PersistentFlags().StringVarP(&oc.Write, "write", "w", "", "write the  raw packets to file as pcapng format.")
 	opensslCmd.PersistentFlags().StringVarP(&oc.Ifname, "ifname", "i", "", "(TC Classifier) Interface name on which the probe will be attached.")
@@ -130,7 +130,6 @@ func openSSLCommandFunc(command *cobra.Command, args []string) {
 		conf.SetUid(gConf.Uid)
 		conf.SetDebug(gConf.Debug)
 		conf.SetHex(gConf.IsHex)
-		conf.SetNoSearch(gConf.NoSearch)
 
 		err = conf.Check()
 

--- a/user/config/config_gnutls.go
+++ b/user/config/config_gnutls.go
@@ -17,9 +17,9 @@ package config
 // 最终使用openssl参数
 type GnutlsConfig struct {
 	eConfig
-	Curlpath string `json:"curlpath"` //curl的文件路径
-	Gnutls   string `json:"gnutls"`
-	ElfType  uint8  //
+	//Curlpath string `json:"curlpath"` //curl的文件路径
+	Gnutls  string `json:"gnutls"`
+	ElfType uint8  //
 }
 
 func NewGnutlsConfig() *GnutlsConfig {

--- a/user/config/config_gnutls_linux.go
+++ b/user/config/config_gnutls_linux.go
@@ -19,11 +19,10 @@ package config
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
-
-	"errors"
 )
+
+const DefaultGnutlsPath = "/lib/x86_64-linux-gnu/libgnutls.so.30"
 
 func (gc *GnutlsConfig) Check() error {
 
@@ -37,39 +36,36 @@ func (gc *GnutlsConfig) Check() error {
 		return nil
 	}
 
-	if gc.NoSearch {
-		return errors.New("NoSearch requires specifying lib path")
-	}
-
-	//如果配置 Curlpath的地址，判断文件是否存在，不存在则直接返回
-	if gc.Curlpath != "" || len(strings.TrimSpace(gc.Curlpath)) > 0 {
-		_, e := os.Stat(gc.Curlpath)
-		if e != nil {
-			return e
+	/*
+		//如果配置 Curlpath的地址，判断文件是否存在，不存在则直接返回
+		if gc.Curlpath != "" || len(strings.TrimSpace(gc.Curlpath)) > 0 {
+			_, e := os.Stat(gc.Curlpath)
+			if e != nil {
+				return e
+			}
+		} else {
+			//如果没配置，则直接指定。
+			gc.Curlpath = "/usr/bin/wget"
 		}
-	} else {
-		//如果没配置，则直接指定。
-		gc.Curlpath = "/usr/bin/wget"
-	}
 
-	soPath, e := getDynPathByElf(gc.Curlpath, "libgnutls.so")
-	if e != nil {
-		//gc.logger.Printf("get bash:%s dynamic library error:%v.\n", bash, e)
-		_, e = os.Stat(X86BinaryPrefix)
-		prefix := X86BinaryPrefix
+		soPath, e := getDynPathByElf(gc.Curlpath, "libgnutls.so")
 		if e != nil {
-			prefix = OthersBinaryPrefix
+			//gc.logger.Printf("get bash:%s dynamic library error:%v.\n", bash, e)
+			_, e = os.Stat(X86BinaryPrefix)
+			prefix := X86BinaryPrefix
+			if e != nil {
+				prefix = OthersBinaryPrefix
+			}
+			gc.Gnutls = filepath.Join(prefix, "libgnutls.so.30")
+			gc.ElfType = ElfTypeSo
+			_, e = os.Stat(gc.Gnutls)
+			if e != nil {
+				return e
+			}
+			return nil
 		}
-		gc.Gnutls = filepath.Join(prefix, "libgnutls.so.30")
-		gc.ElfType = ElfTypeSo
-		_, e = os.Stat(gc.Gnutls)
-		if e != nil {
-			return e
-		}
-		return nil
-	}
-
-	gc.Gnutls = soPath
+	*/
+	gc.Gnutls = DefaultGnutlsPath
 	gc.ElfType = ElfTypeSo
 
 	return nil

--- a/user/config/config_nspr.go
+++ b/user/config/config_nspr.go
@@ -17,9 +17,9 @@ package config
 // 最终使用openssl参数
 type NsprConfig struct {
 	eConfig
-	Firefoxpath string `json:"firefoxpath"` //curl的文件路径
-	Nsprpath    string `json:"nsprpath"`
-	ElfType     uint8  //
+	//Firefoxpath string `json:"firefoxpath"` //curl的文件路径
+	Nsprpath string `json:"nsprpath"`
+	ElfType  uint8  //
 }
 
 func NewNsprConfig() *NsprConfig {

--- a/user/config/config_nspr_linux.go
+++ b/user/config/config_nspr_linux.go
@@ -19,11 +19,10 @@ package config
 
 import (
 	"os"
-	"path/filepath"
 	"strings"
-
-	"errors"
 )
+
+const DefaultNsprNssPath = "/usr/lib/firefox/libnspr4.so"
 
 func (nc *NsprConfig) Check() error {
 
@@ -36,43 +35,44 @@ func (nc *NsprConfig) Check() error {
 		nc.ElfType = ElfTypeSo
 		return nil
 	}
-
-	if nc.NoSearch {
-		return errors.New("NoSearch requires specifying lib path")
-	}
-
-	//如果配置 Curlpath的地址，判断文件是否存在，不存在则直接返回
-	if nc.Firefoxpath != "" || len(strings.TrimSpace(nc.Firefoxpath)) > 0 {
-		_, e := os.Stat(nc.Firefoxpath)
-		if e != nil {
-			return e
+	/*
+		if nc.NoSearch {
+			return errors.New("NoSearch requires specifying lib path")
 		}
-	} else {
-		//如果没配置，则直接指定。
-		nc.Firefoxpath = "/usr/lib/firefox/firefox"
-	}
 
-	soPath, e := getDynPathByElf(nc.Firefoxpath, "libnspr4.so")
-	if e != nil {
-		//nc.logger.Printf("get bash:%s dynamic library error:%v.\n", bash, e)
-		_, e = os.Stat(X86BinaryPrefix)
-		prefix := X86BinaryPrefix
-		if e != nil {
-			prefix = OthersBinaryPrefix
-		}
-		nc.Nsprpath = filepath.Join(prefix, "libnspr4.so")
-		//nc.Gnutls = "/usr/lib/firefox/libnss3.so"
-		//"/usr/lib/firefox/libnspr4.so"
-		nc.ElfType = ElfTypeSo
-		_, e = os.Stat(nc.Nsprpath)
-		if e != nil {
-			return e
-		}
-		return nil
-	}
 
-	nc.Nsprpath = soPath
+		//如果配置 Curlpath的地址，判断文件是否存在，不存在则直接返回
+		if nc.Firefoxpath != "" || len(strings.TrimSpace(nc.Firefoxpath)) > 0 {
+			_, e := os.Stat(nc.Firefoxpath)
+			if e != nil {
+				return e
+			}
+		} else {
+			//如果没配置，则直接指定。
+			nc.Firefoxpath = "/usr/lib/firefox/firefox"
+		}
+
+		soPath, e := getDynPathByElf(nc.Firefoxpath, "libnspr4.so")
+		if e != nil {
+			//nc.logger.Printf("get bash:%s dynamic library error:%v.\n", bash, e)
+			_, e = os.Stat(X86BinaryPrefix)
+			prefix := X86BinaryPrefix
+			if e != nil {
+				prefix = OthersBinaryPrefix
+			}
+			nc.Nsprpath = filepath.Join(prefix, "libnspr4.so")
+			//nc.Gnutls = "/usr/lib/firefox/libnss3.so"
+			//"/usr/lib/firefox/libnspr4.so"
+			nc.ElfType = ElfTypeSo
+			_, e = os.Stat(nc.Nsprpath)
+			if e != nil {
+				return e
+			}
+			return nil
+		}
+	*/
+
+	nc.Nsprpath = DefaultNsprNssPath
 	nc.ElfType = ElfTypeSo
-
 	return nil
 }

--- a/user/config/config_openssl.go
+++ b/user/config/config_openssl.go
@@ -34,8 +34,8 @@ const cgroupPathCentos = "/mnt/ecapture_cgroupv2" // centos
 // 最终使用openssl参数
 type OpensslConfig struct {
 	eConfig
-	Curlpath string `json:"curlPath"` //curl的文件路径
-	Openssl  string `json:"openssl"`
+	//Curlpath string `json:"curlPath"` //curl的文件路径
+	Openssl string `json:"openssl"`
 	//Pthread    string `json:"pThread"`    // /lib/x86_64-linux-gnu/libpthread.so.0
 	Write      string `json:"write"`      // Write  the  raw  packets  to file rather than parsing and printing them out.
 	Ifname     string `json:"ifName"`     // (TC Classifier) Interface name on which the probe will be attached.

--- a/user/config/config_openssl_linux.go
+++ b/user/config/config_openssl_linux.go
@@ -18,36 +18,30 @@
 package config
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 )
 
 const (
-	DefaultIfname = "eth0"
+	DefaultIfname      = "eth0"
+	DefaultOpensslPath = "/apex/com.android.conscrypt/lib64/libssl.so"
 )
 
 func (oc *OpensslConfig) checkOpenssl() error {
-	soPath, e := getDynPathByElf(oc.Curlpath, "libssl.so")
+	var e error
+	_, e = os.Stat(X86BinaryPrefix)
+	prefix := X86BinaryPrefix
 	if e != nil {
-		//oc.logger.Printf("get bash:%s dynamic library error:%v.\n", bash, e)
-		_, e = os.Stat(X86BinaryPrefix)
-		prefix := X86BinaryPrefix
-		if e != nil {
-			prefix = OthersBinaryPrefix
-		}
+		prefix = OthersBinaryPrefix
+	}
 
-		//	ubuntu 21.04	libssl.so.1.1   default
-		oc.Openssl = filepath.Join(prefix, "libssl.so.1.1")
-		oc.ElfType = ElfTypeSo
-		_, e = os.Stat(oc.Openssl)
-		if e != nil {
-			return e
-		}
-	} else {
-		oc.Openssl = soPath
-		oc.ElfType = ElfTypeSo
+	//	ubuntu 21.04	libssl.so.1.1   default
+	oc.Openssl = filepath.Join(prefix, "libssl.so.1.1")
+	oc.ElfType = ElfTypeSo
+	_, e = os.Stat(oc.Openssl)
+	if e != nil {
+		return e
 	}
 	return nil
 }
@@ -64,30 +58,26 @@ func (oc *OpensslConfig) Check() error {
 		oc.ElfType = ElfTypeSo
 		checkedOpenssl = true
 	}
-
-	//如果配置 Curlpath的地址，判断文件是否存在，不存在则直接返回
-	if oc.Curlpath != "" || len(strings.TrimSpace(oc.Curlpath)) > 0 {
-		_, e := os.Stat(oc.Curlpath)
-		if e != nil {
-			return e
+	/*
+		//如果配置 Curlpath的地址，判断文件是否存在，不存在则直接返回
+		if oc.Curlpath != "" || len(strings.TrimSpace(oc.Curlpath)) > 0 {
+			_, e := os.Stat(oc.Curlpath)
+			if e != nil {
+				return e
+			}
+		} else {
+			//如果没配置，则直接指定。
+			oc.Curlpath = "/usr/bin/curl"
 		}
-	} else {
-		//如果没配置，则直接指定。
-		oc.Curlpath = "/usr/bin/curl"
-	}
 
-	if oc.Ifname == "" || len(strings.TrimSpace(oc.Ifname)) == 0 {
-		oc.Ifname = DefaultIfname
-	}
+		if oc.Ifname == "" || len(strings.TrimSpace(oc.Ifname)) == 0 {
+			oc.Ifname = DefaultIfname
+		}
 
-	if checkedOpenssl {
-		return nil
-	}
-
-	if oc.NoSearch {
-		return errors.New("NoSearch requires specifying lib path")
-	}
-
+		if checkedOpenssl {
+			return nil
+		}
+	*/
 	if !checkedOpenssl {
 		e := oc.checkOpenssl()
 		if e != nil {

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -22,21 +22,18 @@ type IConfig interface {
 	GetUid() uint64
 	GetHex() bool
 	GetDebug() bool
-	GetNoSearch() bool
 	SetPid(uint64)
 	SetUid(uint64)
 	SetHex(bool)
 	SetDebug(bool)
-	SetNoSearch(bool)
 	EnableGlobalVar() bool //
 }
 
 type eConfig struct {
-	Pid      uint64
-	Uid      uint64
-	IsHex    bool
-	Debug    bool
-	NoSearch bool
+	Pid   uint64
+	Uid   uint64
+	IsHex bool
+	Debug bool
 }
 
 func (c *eConfig) GetPid() uint64 {
@@ -55,10 +52,6 @@ func (c *eConfig) GetHex() bool {
 	return c.IsHex
 }
 
-func (c *eConfig) GetNoSearch() bool {
-	return c.NoSearch
-}
-
 func (c *eConfig) SetPid(pid uint64) {
 	c.Pid = pid
 }
@@ -73,10 +66,6 @@ func (c *eConfig) SetDebug(b bool) {
 
 func (c *eConfig) SetHex(isHex bool) {
 	c.IsHex = isHex
-}
-
-func (c *eConfig) SetNoSearch(noSearch bool) {
-	c.NoSearch = noSearch
 }
 
 func (c *eConfig) EnableGlobalVar() bool {

--- a/user/module/probe_gnutls.go
+++ b/user/module/probe_gnutls.go
@@ -118,8 +118,8 @@ func (g *MGnutlsProbe) constantEditor() []manager.ConstantEditor {
 func (g *MGnutlsProbe) setupManagers() error {
 	var binaryPath string
 	switch g.conf.(*config.GnutlsConfig).ElfType {
-	case config.ElfTypeBin:
-		binaryPath = g.conf.(*config.GnutlsConfig).Curlpath
+	//case config.ElfTypeBin:
+	//	binaryPath = g.conf.(*config.GnutlsConfig).Curlpath
 	case config.ElfTypeSo:
 		binaryPath = g.conf.(*config.GnutlsConfig).Gnutls
 	default:

--- a/user/module/probe_nspr.go
+++ b/user/module/probe_nspr.go
@@ -117,8 +117,8 @@ func (n *MNsprProbe) constantEditor() []manager.ConstantEditor {
 func (n *MNsprProbe) setupManagers() error {
 	var binaryPath string
 	switch n.conf.(*config.NsprConfig).ElfType {
-	case config.ElfTypeBin:
-		binaryPath = n.conf.(*config.NsprConfig).Firefoxpath
+	//case config.ElfTypeBin:
+	//	binaryPath = n.conf.(*config.NsprConfig).Firefoxpath
 	case config.ElfTypeSo:
 		binaryPath = n.conf.(*config.NsprConfig).Nsprpath
 	default:

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -277,8 +277,8 @@ func (m *MOpenSSLProbe) setupManagersUprobe() error {
 	sslVersion = m.conf.(*config.OpensslConfig).SslVersion
 	sslVersion = strings.ToLower(sslVersion)
 	switch m.conf.(*config.OpensslConfig).ElfType {
-	case config.ElfTypeBin:
-		binaryPath = m.conf.(*config.OpensslConfig).Curlpath
+	//case config.ElfTypeBin:
+	//	binaryPath = m.conf.(*config.OpensslConfig).Curlpath
 	case config.ElfTypeSo:
 		binaryPath = m.conf.(*config.OpensslConfig).Openssl
 		err := m.getSslBpfFile(binaryPath, sslVersion)

--- a/user/module/probe_openssl_tc.go
+++ b/user/module/probe_openssl_tc.go
@@ -54,8 +54,8 @@ func (m *MOpenSSLProbe) setupManagersTC() error {
 	sslVersion = m.conf.(*config.OpensslConfig).SslVersion
 	sslVersion = strings.ToLower(sslVersion)
 	switch m.conf.(*config.OpensslConfig).ElfType {
-	case config.ElfTypeBin:
-		binaryPath = m.conf.(*config.OpensslConfig).Curlpath
+	//case config.ElfTypeBin:
+	//	binaryPath = m.conf.(*config.OpensslConfig).Curlpath
 	case config.ElfTypeSo:
 		binaryPath = m.conf.(*config.OpensslConfig).Openssl
 		err := m.getSslBpfFile(binaryPath, sslVersion)


### PR DESCRIPTION
remove `Curlpath` flag from gnutls library.
remove `Firefoxpath` flag from nspr library.
remove `Curlpath` flag from openssl library.