### PR TITLE
bugfix: Hook the ssl_set_fd function to get FD.

### DIFF
--- a/kern/openssl.h
+++ b/kern/openssl.h
@@ -15,6 +15,11 @@
 #include "ecapture.h"
 #include "tc.h"
 
+
+/***********************************************************
+ * Internal structs and definitions
+ ***********************************************************/
+
 enum ssl_data_event_type { kSSLRead, kSSLWrite };
 const u32 invalidFD = 0;
 
@@ -58,6 +63,10 @@ struct active_ssl_buf {
     const char* buf;
 };
 
+/***********************************************************
+ * BPF MAPS
+ ***********************************************************/
+
 // Key is thread ID (from bpf_get_current_pid_tgid).
 // Value is a pointer to the data buffer argument to SSL_write/SSL_read.
 struct {
@@ -91,34 +100,6 @@ struct {
     __uint(max_entries, 10240);
 } ssl_st_fd SEC(".maps");
 
-
-/***********************************************************
- * Internal structs and definitions
- ***********************************************************/
-
-// OPENSSL struct to offset , via kern/README.md
-typedef long (*unused_fn)();
-
-struct unused {};
-
-struct BIO {
-    const struct unused* method;
-    unused_fn callback;
-    unused_fn callback_ex;
-    char* cb_arg; /* first argument for the callback */
-    int init;
-    int shutdown;
-    int flags; /* extra storage */
-    int retry_reason;
-    int num;
-};
-
-struct ssl_st {
-    s32 version;
-    struct unused* method;
-    struct BIO* rbio;  // used by SSL_read
-    struct BIO* wbio;  // used by SSL_write
-};
 
 /***********************************************************
  * General helper functions

--- a/kern/openssl.h
+++ b/kern/openssl.h
@@ -35,10 +35,6 @@ struct ssl_data_event_t {
     s32 version;
 };
 
-struct {
-    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-} tls_events SEC(".maps");
-
 struct connect_event_t {
     u64 timestamp_ns;
     u32 pid;
@@ -47,10 +43,6 @@ struct connect_event_t {
     char sa_data[SA_DATA_LEN];
     char comm[TASK_COMM_LEN];
 };
-
-struct {
-    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
-} connect_events SEC(".maps");
 
 struct active_ssl_buf {
     /*
@@ -66,6 +58,23 @@ struct active_ssl_buf {
 /***********************************************************
  * BPF MAPS
  ***********************************************************/
+
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+    __uint(max_entries, 1024);
+} tls_events SEC(".maps");
+
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+    __uint(max_entries, 1024);
+} connect_events SEC(".maps");
+
 
 // Key is thread ID (from bpf_get_current_pid_tgid).
 // Value is a pointer to the data buffer argument to SSL_write/SSL_read.

--- a/kern/openssl_masterkey.h
+++ b/kern/openssl_masterkey.h
@@ -57,6 +57,9 @@ struct ssl3_state_st {
 // bpf map
 struct {
     __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+    __uint(max_entries, 1024);
 } mastersecret_events SEC(".maps");
 
 struct {

--- a/kern/openssl_masterkey_3.0.h
+++ b/kern/openssl_masterkey_3.0.h
@@ -46,6 +46,9 @@ struct mastersecret_t {
 // bpf map
 struct {
     __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
+    __uint(max_entries, 1024);
 } mastersecret_events SEC(".maps");
 
 struct {

--- a/kern/tc.h
+++ b/kern/tc.h
@@ -50,6 +50,8 @@ struct net_ctx_t {
 ////////////////////// ebpf maps //////////////////////
 struct {
     __uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    __uint(key_size, sizeof(u32));
+    __uint(value_size, sizeof(u32));
     __uint(max_entries, 10240);
 } skb_events SEC(".maps");
 

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -355,6 +355,29 @@ func (m *MOpenSSLProbe) setupManagersUprobe() error {
 				BinaryPath:       binaryPath,
 				UID:              "uprobe_ssl_master_key",
 			},
+
+			// ------------------- SSL_set_fd hook-------------------------------------
+			{
+				Section:          "uprobe/SSL_set_fd",
+				EbpfFuncName:     "probe_SSL_set_fd",
+				AttachToFuncName: "SSL_set_fd",
+				BinaryPath:       binaryPath,
+				UID:              "uprobe_ssl_set_fd",
+			},
+			{
+				Section:          "uprobe/SSL_set_rfd",
+				EbpfFuncName:     "probe_SSL_set_fd",
+				AttachToFuncName: "SSL_set_rfd",
+				BinaryPath:       binaryPath,
+				UID:              "uprobe_ssl_set_rfd",
+			},
+			{
+				Section:          "uprobe/SSL_set_wfd",
+				EbpfFuncName:     "probe_SSL_set_fd",
+				AttachToFuncName: "SSL_set_wfd",
+				BinaryPath:       binaryPath,
+				UID:              "uprobe_ssl_set_wfd",
+			},
 		},
 
 		Maps: []*manager.Map{


### PR DESCRIPTION
This block of logic will be used when wbio's FD is empty.