### PR TITLE
supports all ports when target_port is 0

### DIFF
--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -59,7 +59,7 @@ func init() {
 	opensslCmd.PersistentFlags().StringVar(&oc.Pthread, "pthread", "", "libpthread.so file path, use to hook connect to capture socket FD.will automatically find it from curl.")
 	opensslCmd.PersistentFlags().StringVarP(&oc.Write, "write", "w", "", "write the  raw packets to file as pcapng format.")
 	opensslCmd.PersistentFlags().StringVarP(&oc.Ifname, "ifname", "i", "", "(TC Classifier) Interface name on which the probe will be attached.")
-	opensslCmd.PersistentFlags().Uint16Var(&oc.Port, "port", 443, "port number to capture, default:443.")
+	opensslCmd.PersistentFlags().Uint16Var(&oc.Port, "port", 443, "port number to capture, default:443; capture all ports:0")
 	opensslCmd.PersistentFlags().StringVar(&oc.SslVersion, "ssl_version", "", "openssl/boringssl version， e.g: --ssl_version=\"openssl 1.1.1g\" or  --ssl_version=\"boringssl 1.1.1\"")
 
 	rootCmd.AddCommand(opensslCmd)

--- a/kern/tc.h
+++ b/kern/tc.h
@@ -163,9 +163,14 @@ static __always_inline int capture_packets(struct __sk_buff *skb, bool is_ingres
     struct tcphdr *tcp = (struct tcphdr *)(data_start + l4_hdr_off);
 
 #ifndef KERNEL_LESS_5_2
-    if (tcp->source != bpf_htons(target_port) &&
-        tcp->dest != bpf_htons(target_port)) {
-        return TC_ACT_OK;
+    if (target_port > 0 ) {
+        // supports only target_port when target_port is not 0
+        if (tcp->source != bpf_htons(target_port) &&
+            tcp->dest != bpf_htons(target_port)) {
+            return TC_ACT_OK;
+        }
+    } else {
+        // supports all ports when target_port is 0
     }
 #endif
 

--- a/pkg/proc/proc.go
+++ b/pkg/proc/proc.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	goVersionPrefix = "Go cmd/compile "
+	goVersionPrefix = "Go cmd/compile"
 )
 
 // ErrVersionNotFound is returned when we can't find Go version info from a binary


### PR DESCRIPTION
当使用**pcapng**模式时，如果`--port`参数为0，则支持所有端口的网络包捕获。否则则只捕获`--port`对应的端口数据。默认是`443` 端口。

`--port`默认没有捕获所有网络包，是因为有很多场景，主机的网络流量很大，eBPF的map写入太快，用户空间消费过慢，导致丢包的问题。虽然用户空间在创建eBPF map时，已经申请了`BufferSizeOfEbpfMap`大的内存，但仍然还存在网络包过多导致数据丢失的可能。 而且，在Android上有内存大小限制，`BufferSizeOfEbpfMap`的值仅为`1024`。

------------------------------------------------------------------------------------------------

When using **pcapng** mode, if the `--port` parameter is set to 0, it supports capturing network packets from all ports. Otherwise, it only captures data from the port corresponding to `--port`. The default port is 443. 

The reason why `--port` does not capture all network packets by default is that in many scenarios, the host's network traffic is high and eBPF map writes too fast while user space consumption is slow, resulting in packet loss issues. Although user space has already allocated memory of size `BufferSizeOfEbpfMap` when creating eBPF map, there still exists a problem of data loss due to excessive network packets. Moreover, on Android, there are memory size limitations and the value of `BufferSizeOfEbpfMap` is only 1024.

```go
	rd, err := perf.NewReader(em, os.Getpagesize()*BufferSizeOfEbpfMap)
```