### PR TITLE
add ubunutu23.05 aarch64 clang-15 into init_env.sh

### DIFF
--- a/builder/init_env.sh
+++ b/builder/init_env.sh
@@ -26,6 +26,8 @@ if [ ${release_num} == "20.04" ]; then
   CLANG_NUM=12
   elif [ ${release_num} == "22.10" ]; then
   CLANG_NUM=12
+  elif [ ${release_num} == "23.04" ];then
+  CLANG_NUM=15
   else
     echo "unsupported release version ${release_num}" && exit
 fi


### PR DESCRIPTION
我在ubuntu23.04的机器上使用是增加了clang-15后测试可以，环境如下
```
uname -a
Linux ubuntu 6.5.7-orbstack-00109-gd8500ae6683d #1 SMP Fri Oct 13 01:28:33 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux
```
使用的clang版本
```
 clang --version
Ubuntu clang version 15.0.7
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```
