### PR TITLE
修复v0.6.5版本https流量未输出错误

### DIFF
--- a/builder/init_env.sh
+++ b/builder/init_env.sh
@@ -26,6 +26,8 @@ if [ ${release_num} == "20.04" ]; then
   CLANG_NUM=12
   elif [ ${release_num} == "22.10" ]; then
   CLANG_NUM=12
+  elif [ ${release_num} == "23.04" ];then
+  CLANG_NUM=15
   else
     echo "unsupported release version ${release_num}" && exit
 fi

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -174,7 +174,7 @@ func (se *SSLDataEvent) String() string {
 
 func (se *SSLDataEvent) Clone() IEventStruct {
 	event := new(SSLDataEvent)
-	event.eventType = EventTypeModuleData //EventTypeEventProcessor
+	event.eventType = EventTypeEventProcessor //EventTypeModuleData //EventTypeEventProcessor
 	return event
 }
 


### PR DESCRIPTION
我把event_openssl.go的type从新设置回了`EventTypeEventProcessor` ，可以使用http解析器将流量按照明文输出
