### PR TITLE
Decode kernel time to user time

### DIFF
--- a/user/event/event_gnutls.go
+++ b/user/event/event_gnutls.go
@@ -54,6 +54,12 @@ func (ge *GnutlsDataEvent) Decode(payload []byte) (err error) {
 	if err = binary.Read(buf, binary.LittleEndian, &ge.Comm); err != nil {
 		return
 	}
+
+	decodedKtime, err := DecodeKtime(int64(ge.Timestamp), true)
+	if err == nil {
+		ge.Timestamp = uint64(decodedKtime.Unix())
+	}
+
 	return nil
 }
 

--- a/user/event/event_mysqld.go
+++ b/user/event/event_mysqld.go
@@ -97,6 +97,12 @@ func (me *MysqldEvent) Decode(payload []byte) (err error) {
 	if err = binary.Read(buf, binary.LittleEndian, &me.Retval); err != nil {
 		return
 	}
+
+	decodedKtime, err := DecodeKtime(int64(me.Timestamp), true)
+	if err == nil {
+		me.Timestamp = uint64(decodedKtime.Unix())
+	}
+
 	return nil
 }
 

--- a/user/event/event_nspr.go
+++ b/user/event/event_nspr.go
@@ -55,6 +55,10 @@ func (ne *NsprDataEvent) Decode(payload []byte) (err error) {
 	if err = binary.Read(buf, binary.LittleEndian, &ne.Comm); err != nil {
 		return
 	}
+	decodedKtime, err := DecodeKtime(int64(ne.Timestamp), true)
+	if err == nil {
+		ne.Timestamp = uint64(decodedKtime.Unix())
+	}
 	return nil
 }
 

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -112,6 +112,10 @@ func (se *SSLDataEvent) Decode(payload []byte) (err error) {
 		return
 	}
 
+	decodedKtime, err := DecodeKtime(int64(se.Timestamp), true)
+	if err == nil {
+		se.Timestamp = uint64(decodedKtime.Unix())
+	}
 	return nil
 }
 

--- a/user/event/event_postgres.go
+++ b/user/event/event_postgres.go
@@ -55,6 +55,10 @@ func (pe *PostgresEvent) Decode(payload []byte) (err error) {
 	if err = binary.Read(buf, binary.LittleEndian, &pe.Comm); err != nil {
 		return
 	}
+	decodedKtime, err := DecodeKtime(int64(pe.Timestamp), true)
+	if err == nil {
+		pe.Timestamp = uint64(decodedKtime.Unix())
+	}
 	return nil
 }
 


### PR DESCRIPTION
`DecodeKtime()` snippet is take from tetragon. [Refer](https://github.com/cilium/tetragon/blob/c4ea0e76d6cf5fcc33d8977796d829a98572d531/pkg/ktime/ktime.go#L39)