### PR TITLE
Fix ： openssl event output invalid with hex mode 

### DIFF
--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -751,7 +751,11 @@ func (m *MOpenSSLProbe) dumpSslData(eventStruct *event.SSLDataEvent) {
 		eventStruct.Addr = addr
 	}
 	//m.processor.Write(eventStruct)
-	m.logger.Println(eventStruct)
+	if m.conf.GetHex() {
+		m.logger.Println(eventStruct.StringHex())
+	} else {
+		m.logger.Println(eventStruct.String())
+	}
 }
 
 func init() {


### PR DESCRIPTION
fix #416

修复openssl 事件 hex模式无效的问题.