### PR TITLE
add the `model` flag to distinguish the captured modes, support keylog captured.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,85 @@
 <hr>
 
+# v0.7.0 (2023-12-03)
+## 🚀 Breaking Changes
+- Split `nss/gnutls/openssl` into three separate submodules. Corresponding to the `./ecapture nss`, `./ecapture gnutls`, `ecapture tls` commands.
+- Support `keylog` mode, equivalent to the functionality of the `SSLKEYLOGFILE` environment variable. Captures SSL/TLS communication keys directly without the need for changes in the target process.
+- Refactor the mode parameters supported by the `openssl`(aka tls) module using the `-m`parameter, with values `text`, `pcap`,`keylog`.
+  - `pcap` mode: Set with `-m pcap` or `-m pcapng` parameters. When using this mode, it is necessary to specify `--pcapfile` and `-i` parameters. The default value for the `--pcapfile` parameter is `ecapture_openssl.pcapng`.
+  - `keylog` mode: Set with `-m keylog` or `-m key` parameters. When using this mode, it is necessary to specify `--keylogfile`, defaulting to `ecapture_masterkey.log`.
+  - `text` mode: Default mode when `-m` parameter is unspecified. Outputs all plaintext packets in text form. (As of v0.7.0, no longer captures communication keys, please use `keylog` mode instead.)
+- Refactor the mode parameters supported by the `gotls` module, similar to the `openssl` module, without further details.
+- Optimize the memory size of eBPF Map, specify with the `--mapsize` parameter, defaulting to 5120 KB.
+- Remove the `-w` parameter, use `--pcapfile` parameter instead.
+- Change `log-addr` parameter to `logaddr`, with unchanged functionality.
+
+Thanks to the genius idea from @blaisewang.
+
+------
+* 将nss/gnutls/openssl拆分为独立的三个子模块。分别对应`./ecapture nss`、`./ecapture gnutls`、`ecapture tls`三个子命令。
+* 支持`keylog`模式，等同于`SSLKEYLOGFILE`环境变量的功能，无需目标进程改动，直接捕获SSL/TLS通信密钥。
+* 重构`openssl`(aka tls)模块支持的模式参数，使用`-m`参数指定，分别为`text`,`pcap`,`keylog`三个值。
+  * `pcap`模式：`-m pcap`或`-m pcapng`参数来设定。当使用本模式时，必需指定`--pcapfile`、`-i`这两个参数才能使用。 其中`--pcapfile`参数的默认值为`ecapture_openssl.pcapng`。
+  * `keylog`模式：`-m keylog`或`-m key`参数来设定。当使用本模式时，必需指定`--keylogfile`，默认为`ecapture_masterkey.log`。
+  * `text`模式：`-m`参数不指定时，默认为本模式。将以文本形式输出所有的明文数据包。（自v0.7.0起，不再捕获通讯密钥，请使用`keylog`模式代替）
+* 重构`gotls`模块支持的模式参数，与`openssl`模块一样，不再赘述。
+* 优化eBPF Map的内存大小，使用`--mapsize`参数指定，默认为5120 KB。
+* 移除`-w`参数，请使用`--pcapfile`参数代替。
+* 更改`log-addr`参数为`logaddr`，功能含义不变。
+
+感谢 @blaisewang 的天才思路。
+
+### Demo of keylog Mode Usage
+Using eCapture to capture communication keys in real-time and combining it with tshark for real-time decryption enables the real-time plaintext output of encrypted traffic. The steps are as follows:
+
+使用`eCapture`实时捕获通信密钥，并结合`tshark`实时解密，可以做到实时的加密流量明文输出。步骤如下：
+
+#### Terminal 1
+Start the keylog mode of eCapture first.
+
+先启动eCapture的`keylog`模式
+
+```shell
+ecapture tls -m keylog --keylogfile=ecapture_masterkey.log
+```
+
+### 终端2
+Start the tshark tool by specifying tls.keylog_file as the captured key file by eCapture, named ecapture_masterkey.
+
+再启动`tshark`工具，指定`tls.keylog_file`为eCapture捕获的密钥文件`ecapture_masterkey`
+
+**http 1.x**
+```shell
+tshark -o tls.keylog_file:ecapture_masterkey.log -Y http -T fields -e http.file_data -f "port 443" -i eth0
+```
+
+**http 2.0**
+```shell
+tshark -o tls.keylog_file:ecapture_masterkey.log -Y http2 -T fields -e http2.data.data -f "port 443" -i eth0
+```
+Afterward, any software that uses the eCapture HOOK with OpenSSL libraries can achieve real-time decryption and display of all encrypted communication traffic without requiring any modifications to these software applications.
+
+之后，其他使用`eCapture` HOOK的openssl类库的软件，所有加密通讯的流量，都可以实现实时解密并展示了，无需这些软件做任何改动。
+
+See [issue #432](https://github.com/gojue/ecapture/issues/432) for more detail.
+
+## What's Changed
+
+
+**Full Changelog**: https://github.com/gojue/ecapture/compare/v0.6.6...v0.7.0
+
+<hr>
+
 # v0.6.6 (2023-11-19)
 ## What's Changed
+* add ubunutu23.04  aarch64 clang-15 into init_env.sh by @BiteFoo in https://github.com/gojue/ecapture/pull/413
+* Decode kernel time to user time by @h0x0er in https://github.com/gojue/ecapture/pull/418
+* Fix : openssl event output invalid with hex mode  by @cfc4n in https://github.com/gojue/ecapture/pull/421
+* user : Set the connect hook as an optional parameter. by @cfc4n in https://github.com/gojue/ecapture/pull/423
+
+## New Contributors
+* @BiteFoo made their first contribution in https://github.com/gojue/ecapture/pull/413
+* @h0x0er made their first contribution in https://github.com/gojue/ecapture/pull/418
 
 **Full Changelog**: https://github.com/gojue/ecapture/compare/v0.6.5...v0.6.6
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -111,6 +111,7 @@ tshark -o tls.keylog_file:ecapture_masterkey.log -Y http -T fields -e http.file_
 
 ## gotls 模块
 与openssl模块类似。
+
 ### 验证方法：
 
 ```shell

--- a/README_CN.md
+++ b/README_CN.md
@@ -34,9 +34,6 @@ eBPF `Uprobe`/`Traffic Control`实现的各种用户空间/内核空间的数据
 * bash的命令捕获，HIDS的bash命令监控解决方案。
 * mysql query等数据库的数据库审计解决方案。
 
-# eCapture 系统架构
-![](./images/ecapture-architecture.png)
-
 # 演示
 
 ## eCapture 使用方法
@@ -73,14 +70,47 @@ eCapture默认查找`/etc/ld.so.conf`文件，查找SO文件的加载目录，�
 
 如果目标程序使用静态编译方式，则可以直接将`--libssl`参数设定为该程序的路径。
 
-### Pcapng输出格式
+## 模块介绍
+eCapture 有8个模块，分别支持openssl/gnutls/nspr/boringssl/gotls等类库的TLS/SSL加密类库的明文捕获、Bash、Mysql、PostGres软件审计。
+* bash		capture bash command 
+* gnutls	capture gnutls text content without CA cert for gnutls libraries. 
+* gotls		Capturing plaintext communication from Golang programs encrypted with TLS/HTTPS. 
+* mysqld	capture sql queries from mysqld 5.6/5.7/8.0 . 
+* nss		capture nss/nspr encrypted text content without CA cert for nss/nspr libraries. 
+* postgres	capture sql queries from postgres 10+. 
+* tls		use to capture tls/ssl text content without CA cert. (Support openssl 1.0.x/1.1.x/3.0.x or newer).
 
-`./ecapture tls -i eth0 -w pcapng -p 443` 将捕获的明文数据包保存为pcapng文件，可以使用`Wireshark`打开查看。
+你可以通过`ecapture -h`来查看这些自命令列表。
 
-### 文本输出格式
+## openssl  模块
+openssl模块支持3中捕获模式
+* pcap/pcapng模式，将捕获的明文数据以pcap-NG格式存储。
+* keylog/key模式，保存TLS的握手密钥到文件中。
+* text模式，直接捕获明文数据，输出到指定文件中，或者打印到命令行。
+### Pcap 模式
+你可以通过`-m pcap`或`-m pcapng`参数来指定，需要配合`--pcapfile`、`-i`参数使用。其中`--pcapfile`参数的默认值为`ecapture_openssl.pcapng`。
+```shell
+./ecapture tls -m pcap -i eth0 --pcapfile=ecapture.pcapng --port=443
+``` 
+将捕获的明文数据包保存为pcapng文件，可以使用`Wireshark`打开查看。
 
-`./ecapture tls` 将会输出所有的明文数据包，并捕获openssl TLS的密钥`Master Secret`文件到当前目录的`ecapture_masterkey.log`中。你也可以同时开启`tcpdump`抓包，再使用`Wireshark`打开，设置`Master Secret`路径，查看明文数据包。
+### keylog 模式
+你可以通过`-m keylog`或`-m key`参数来指定，需要配合`--keylogfile`参数使用，默认为`ecapture_masterkey.log`。
+捕获的openssl TLS的密钥`Master Secret`信息，将保存到`--keylogfile`中。你也可以同时开启`tcpdump`抓包，再使用`Wireshark`打开，设置`Master Secret`路径，查看明文数据包。
+```shell
+./ecapture tls -m keylog -keylogfile=openssl_keylog.log
+```
 
+也可以直接使用`tshark`软件实时解密展示。
+```shell
+tshark -o tls.keylog_file:ecapture_masterkey.log -Y http -T fields -e http.file_data -f "port 443" -i eth0
+```
+### text 模式
+`./ecapture tls -m text ` 将会输出所有的明文数据包。（v0.7.0起，不再捕获SSLKEYLOG信息。）
+
+
+## gotls 模块
+与openssl模块类似。
 ### 验证方法：
 
 ```shell
@@ -120,6 +150,9 @@ vm@vm-server:~$ /usr/local/bin/openssl s_client -connect www.qq.com:443
 ```shell
 ps -ef | grep foo
 ```
+
+# eCapture 系统架构
+![](./images/ecapture-architecture.png)
 
 # 微信公众号
 ![](./images/wechat_gzhh.png)

--- a/cli/cmd/global.go
+++ b/cli/cmd/global.go
@@ -63,12 +63,12 @@ func getGlobalConf(command *cobra.Command) (conf GlobalFlags, err error) {
 		return
 	}
 
-	conf.mapSizeKB, err = command.Flags().GetInt("map-size")
+	conf.mapSizeKB, err = command.Flags().GetInt("mapsize")
 	if err != nil {
 		return
 	}
 
-	conf.LoggerAddr, err = command.Flags().GetString("log-addr")
+	conf.LoggerAddr, err = command.Flags().GetString("logaddr")
 	if err != nil {
 		return
 	}

--- a/cli/cmd/gotls.go
+++ b/cli/cmd/gotls.go
@@ -38,15 +38,17 @@ var gotlsCmd = &cobra.Command{
 	Long: `Utilize eBPF uprobe/TC to capture both process event and network data, with added support for pcap-NG format.
 ecapture gotls
 ecapture gotls --elfpath=/home/cfc4n/go_https_client --hex --pid=3423
-ecapture gotls --elfpath=/home/cfc4n/go_https_client -l save.log --pid=3423
-ecapture gotls -w save_android.pcapng -i wlan0 --port 443 --elfpath=/home/cfc4n/go_https_client
+ecapture gotls -m keylog -k /tmp/ecap_gotls_key.log --elfpath=/home/cfc4n/go_https_client -l save.log --pid=3423
+ecapture gotls -m pcap -w save_android.pcapng -i wlan0 --port 443 --elfpath=/home/cfc4n/go_https_client
 `,
 	Run: goTLSCommandFunc,
 }
 
 func init() {
 	gotlsCmd.PersistentFlags().StringVarP(&goc.Path, "elfpath", "e", "", "ELF path to binary built with Go toolchain.")
-	gotlsCmd.PersistentFlags().StringVarP(&goc.Write, "write", "w", "", "write the  raw packets to file as pcapng format.")
+	gotlsCmd.PersistentFlags().StringVar(&goc.PcapFile, "pcapfile", "ecapture_gotls.pcapng", "write the  raw packets to file as pcapng format.")
+	gotlsCmd.PersistentFlags().StringVarP(&goc.Model, "model", "m", "text", "capture model, such as : text, pcap/pcapng, key/keylog")
+	gotlsCmd.PersistentFlags().StringVarP(&goc.KeylogFile, "keylogfile", "k", "ecapture_gotls_key.log", "The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.")
 	gotlsCmd.PersistentFlags().StringVarP(&goc.Ifname, "ifname", "i", "", "(TC Classifier) Interface name on which the probe will be attached.")
 	gotlsCmd.PersistentFlags().Uint16Var(&goc.Port, "port", 443, "port number to capture, default:443.")
 	rootCmd.AddCommand(gotlsCmd)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -92,8 +92,8 @@ func init() {
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Debug, "debug", "d", false, "enable debug logging.(coming soon)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.IsHex, "hex", false, "print byte strings as hex encoded strings")
-	rootCmd.PersistentFlags().IntVar(&globalFlags.mapSizeKB, "map-size", 1024*5, "eBPF map size per CPU,for events buffer. default:5120. (KB)")
+	rootCmd.PersistentFlags().IntVar(&globalFlags.mapSizeKB, "mapsize", 1024*5, "eBPF map size per CPU,for events buffer. default:5120. (KB)")
 	rootCmd.PersistentFlags().Uint64VarP(&globalFlags.Pid, "pid", "p", defaultPid, "if pid is 0 then we target all pids")
 	rootCmd.PersistentFlags().Uint64VarP(&globalFlags.Uid, "uid", "u", defaultUid, "if uid is 0 then we target all users")
-	rootCmd.PersistentFlags().StringVarP(&globalFlags.LoggerAddr, "log-addr", "l", "", "-l /tmp/ecapture.log or -l tcp://127.0.0.1:8080")
+	rootCmd.PersistentFlags().StringVarP(&globalFlags.LoggerAddr, "logaddr", "l", "", "-l /tmp/ecapture.log or -l tcp://127.0.0.1:8080")
 }

--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -40,8 +40,8 @@ ecapture tls
 ecapture tls --hex --pid=3423
 ecapture tls -l save.log --pid=3423
 ecapture tls --libssl=/lib/x86_64-linux-gnu/libssl.so.1.1
-ecapture tls -w save_3_0_5.pcapng --ssl_version="openssl 3.0.5" --libssl=/lib/x86_64-linux-gnu/libssl.so.3 
-ecapture tls -w save_android.pcapng -i wlan0 --libssl=/apex/com.android.conscrypt/lib64/libssl.so --ssl_version="boringssl 1.1.1" --port 443
+ecapture tls -m keylog -w save_3_0_5.pcapng --ssl_version="openssl 3.0.5" --libssl=/lib/x86_64-linux-gnu/libssl.so.3 
+ecapture tls -w pcap save_android.pcapng -i wlan0 --libssl=/apex/com.android.conscrypt/lib64/libssl.so --ssl_version="boringssl 1.1.1" --port 443
 `,
 	Run: openSSLCommandFunc,
 }
@@ -51,7 +51,9 @@ func init() {
 	opensslCmd.PersistentFlags().StringVar(&oc.Openssl, "libssl", "", "libssl.so file path, will automatically find it from curl default.")
 	opensslCmd.PersistentFlags().StringVar(&oc.CGroupPath, "cgroup_path", "/sys/fs/cgroup", "cgroup path, default: /sys/fs/cgroup.")
 	opensslCmd.PersistentFlags().StringVar(&oc.Pthread, "pthread", "", "libpthread.so file path, use to hook connect to capture socket FD.will automatically find it from curl.")
-	opensslCmd.PersistentFlags().StringVarP(&oc.Write, "write", "w", "", "write the  raw packets to file as pcapng format.")
+	opensslCmd.PersistentFlags().StringVarP(&oc.Model, "model", "m", "text", "capture model, such as : text, pcap/pcapng, key/keylog")
+	opensslCmd.PersistentFlags().StringVarP(&oc.KeylogFile, "keylogfile", "k", "ecapture_openssl_key.og", "The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.")
+	opensslCmd.PersistentFlags().StringVar(&oc.PcapFile, "pcapfile", "ecapture_openssl.pcapng", "write the raw packets to file as pcapng format.")
 	opensslCmd.PersistentFlags().StringVarP(&oc.Ifname, "ifname", "i", "", "(TC Classifier) Interface name on which the probe will be attached.")
 	opensslCmd.PersistentFlags().Uint16Var(&oc.Port, "port", 443, "port number to capture, default:443; capture all ports:0")
 	opensslCmd.PersistentFlags().StringVar(&oc.SslVersion, "ssl_version", "", "openssl/boringssl version， e.g: --ssl_version=\"openssl 1.1.1g\" or  --ssl_version=\"boringssl 1.1.1\"")

--- a/user/config/config_openssl.go
+++ b/user/config/config_openssl.go
@@ -37,7 +37,9 @@ type OpensslConfig struct {
 	//Curlpath   string `json:"curlPath"` //curl的文件路径
 	Openssl    string `json:"openssl"`
 	Pthread    string `json:"pThread"`    // /lib/x86_64-linux-gnu/libpthread.so.0
-	Write      string `json:"write"`      // Write  the  raw  packets  to file rather than parsing and printing them out.
+	Model      string `json:"model"`      // eCapture Openssl capture model. text:pcap:keylog
+	PcapFile   string `json:"pcapFile"`   // pcapFile  the  raw  packets  to file rather than parsing and printing them out.
+	KeylogFile string `json:"keylog"`     // Keylog  The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.
 	Ifname     string `json:"ifName"`     // (TC Classifier) Interface name on which the probe will be attached.
 	Port       uint16 `json:"port"`       // capture port
 	SslVersion string `json:"sslVersion"` // openssl version like 1.1.1a/1.1.1f/boringssl_1.1.1
@@ -51,6 +53,19 @@ func NewOpensslConfig() *OpensslConfig {
 	config := &OpensslConfig{}
 	config.PerCpuMapSize = DefaultMapSizePerCpu
 	return config
+}
+
+func (oc *OpensslConfig) checkModel() string {
+	var m string
+	switch oc.Model {
+	case TlsCaptureModelKeylog, TlsCaptureModelKey:
+		m = TlsCaptureModelKey
+	case TlsCaptureModelPcap, TlsCaptureModelPcapng:
+		m = TlsCaptureModelPcap
+	default:
+		m = TlsCaptureModelText
+	}
+	return m
 }
 
 func checkCgroupPath(cp string) (string, error) {

--- a/user/config/config_openssl_androidgki.go
+++ b/user/config/config_openssl_androidgki.go
@@ -74,5 +74,7 @@ func (oc *OpensslConfig) Check() error {
 			break
 		}
 	}
+
+	oc.Model = oc.checkModel()
 	return nil
 }

--- a/user/config/config_openssl_linux.go
+++ b/user/config/config_openssl_linux.go
@@ -182,5 +182,7 @@ func (oc *OpensslConfig) Check() error {
 		return e
 	}
 	oc.CGroupPath = s
+
+	oc.Model = oc.checkModel()
 	return nil
 }

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"ecapture/pkg/util/kernel"
+	"os"
 )
 
 type IConfig interface {
@@ -32,6 +33,14 @@ type IConfig interface {
 	SetPerCpuMapSize(int)
 	EnableGlobalVar() bool //
 }
+
+const (
+	TlsCaptureModelText   = "text"
+	TlsCaptureModelPcap   = "pcap"
+	TlsCaptureModelPcapng = "pcapng"
+	TlsCaptureModelKey    = "key"
+	TlsCaptureModelKeylog = "keylog"
+)
 
 type eConfig struct {
 	Pid           uint64
@@ -78,7 +87,7 @@ func (c *eConfig) GetPerCpuMapSize() int {
 }
 
 func (c *eConfig) SetPerCpuMapSize(size int) {
-	c.PerCpuMapSize = size
+	c.PerCpuMapSize = size * os.Getpagesize()
 }
 
 func (c *eConfig) EnableGlobalVar() bool {

--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -189,6 +189,7 @@ func (m *Module) readEvents() error {
 }
 
 func (m *Module) perfEventReader(errChan chan error, em *ebpf.Map) {
+	m.logger.Printf("%s\tperfEventReader created. mapSize:%d MB", m.child.Name(), m.conf.GetPerCpuMapSize()/1024/1024)
 	rd, err := perf.NewReader(em, m.conf.GetPerCpuMapSize())
 	if err != nil {
 		errChan <- fmt.Errorf("creating %s reader dns: %s", em.String(), err)

--- a/user/module/probe_gotls_keylog.go
+++ b/user/module/probe_gotls_keylog.go
@@ -1,0 +1,103 @@
+// Copyright 2022 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package module
+
+import (
+	"ecapture/user/event"
+	"errors"
+	"github.com/cilium/ebpf"
+	manager "github.com/gojue/ebpfmanager"
+	"golang.org/x/sys/unix"
+	"math"
+)
+
+func (g *GoTLSProbe) setupManagersKeylog() error {
+
+	g.logger.Printf("%s\tHOOK type:golang elf, binrayPath:%s\n", g.Name(), g.path)
+	g.logger.Printf("%s\tHook masterKey function:%s\n", g.Name(), goTlsMasterSecretFunc)
+
+	var (
+		sec string
+		fn  string
+	)
+
+	if g.isRegisterABI {
+		sec = "uprobe/gotls_mastersecret_register"
+		fn = "gotls_mastersecret_register"
+	} else {
+		sec = "uprobe/gotls_mastersecret_stack"
+		fn = "gotls_mastersecret_stack"
+	}
+
+	g.bpfManager = &manager.Manager{
+		Probes: []*manager.Probe{
+			// gotls master secrets
+			{
+				Section:          sec,
+				EbpfFuncName:     fn,
+				AttachToFuncName: goTlsMasterSecretFunc,
+				BinaryPath:       g.path,
+				UID:              "uprobe_gotls_master_secret",
+			},
+		},
+
+		Maps: []*manager.Map{
+			{
+				Name: "mastersecret_go_events",
+			},
+		},
+	}
+
+	g.bpfManagerOptions = manager.Options{
+		DefaultKProbeMaxActive: 512,
+
+		VerifierOptions: ebpf.CollectionOptions{
+			Programs: ebpf.ProgramOptions{
+				LogSize: 2097152,
+			},
+		},
+
+		RLimit: &unix.Rlimit{
+			Cur: math.MaxUint64,
+			Max: math.MaxUint64,
+		},
+	}
+
+	if g.conf.EnableGlobalVar() {
+		// 填充 RewriteContants 对应map
+		g.bpfManagerOptions.ConstantEditors = g.constantEditor()
+	}
+	return nil
+}
+
+func (g *GoTLSProbe) initDecodeFunKeylog() error {
+	// master secrets map at ebpf code
+	MasterkeyEventsMap, found, err := g.bpfManager.GetMap("mastersecret_go_events")
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("cant found map:mastersecret_events")
+	}
+	g.eventMaps = append(g.eventMaps, MasterkeyEventsMap)
+
+	var masterkeyEvent event.IEventStruct
+
+	// goTLS Event struct
+	masterkeyEvent = &event.MasterSecretGotlsEvent{}
+
+	g.eventFuncMaps[MasterkeyEventsMap] = masterkeyEvent
+	return nil
+}

--- a/user/module/probe_gotls_pcap.go
+++ b/user/module/probe_gotls_pcap.go
@@ -26,7 +26,7 @@ import (
 	"net"
 )
 
-func (g *GoTLSProbe) setupManagersTC() error {
+func (g *GoTLSProbe) setupManagersPcap() error {
 	var ifname string
 
 	ifname = g.conf.(*config.GoTLSConfig).Ifname
@@ -130,7 +130,7 @@ func (g *GoTLSProbe) setupManagersTC() error {
 	return nil
 }
 
-func (g *GoTLSProbe) initDecodeFunTC() error {
+func (g *GoTLSProbe) initDecodeFunPcap() error {
 	//SkbEventsMap 与解码函数映射
 	SkbEventsMap, found, err := g.bpfManager.GetMap("skb_events")
 	if err != nil {
@@ -161,8 +161,4 @@ func (g *GoTLSProbe) initDecodeFunTC() error {
 
 	g.eventFuncMaps[MasterkeyEventsMap] = masterkeyEvent
 	return nil
-}
-
-func (g *GoTLSProbe) Events() []*ebpf.Map {
-	return g.eventMaps
 }

--- a/user/module/probe_gotls_text.go
+++ b/user/module/probe_gotls_text.go
@@ -1,0 +1,113 @@
+// Copyright 2022 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package module
+
+import (
+	"ecapture/user/config"
+	"ecapture/user/event"
+	"errors"
+	"fmt"
+	"github.com/cilium/ebpf"
+	manager "github.com/gojue/ebpfmanager"
+	"golang.org/x/sys/unix"
+	"math"
+)
+
+func (g *GoTLSProbe) setupManagersText() error {
+	var (
+		sec, readSec string
+		fn, readFn   string
+	)
+
+	if g.isRegisterABI {
+		sec = "uprobe/gotls_write_register"
+		fn = "gotls_write_register"
+		readSec = "uprobe/gotls_read_register"
+		readFn = "gotls_read_register"
+	} else {
+		sec = "uprobe/gotls_write_stack"
+		fn = "gotls_write_stack"
+		readSec = "uprobe/gotls_read_stack"
+		readFn = "gotls_read_stack"
+	}
+	g.logger.Printf("%s\teBPF Function Name:%s, isRegisterABI:%t\n", g.Name(), fn, g.isRegisterABI)
+	g.bpfManager = &manager.Manager{
+		Probes: []*manager.Probe{
+			{
+				Section:          sec,
+				EbpfFuncName:     fn,
+				AttachToFuncName: goTlsWriteFunc,
+				BinaryPath:       g.path,
+			},
+		},
+		Maps: []*manager.Map{
+			{
+				Name: "events",
+			},
+		},
+	}
+
+	readOffsets := g.conf.(*config.GoTLSConfig).ReadTlsAddrs
+	//g.bpfManager.Probes = []*manager.Probe{}
+	for _, v := range readOffsets {
+		var uid = fmt.Sprintf("%s_%d", readFn, v)
+		g.logger.Printf("%s\tadd uretprobe function :%s, offset:0x%X\n", g.Name(), config.GoTlsReadFunc, v)
+		g.bpfManager.Probes = append(g.bpfManager.Probes, &manager.Probe{
+			Section:          readSec,
+			EbpfFuncName:     readFn,
+			AttachToFuncName: config.GoTlsReadFunc,
+			BinaryPath:       g.path,
+			UprobeOffset:     uint64(v),
+			UID:              uid,
+		})
+	}
+	g.bpfManagerOptions = manager.Options{
+		DefaultKProbeMaxActive: 512,
+
+		VerifierOptions: ebpf.CollectionOptions{
+			Programs: ebpf.ProgramOptions{
+				LogSize: 2097152,
+			},
+		},
+
+		RLimit: &unix.Rlimit{
+			Cur: math.MaxUint64,
+			Max: math.MaxUint64,
+		},
+	}
+
+	if g.conf.EnableGlobalVar() {
+		// 填充 RewriteContants 对应map
+		g.bpfManagerOptions.ConstantEditors = g.constantEditor()
+	}
+	return nil
+}
+
+func (g *GoTLSProbe) initDecodeFunText() error {
+
+	m, found, err := g.bpfManager.GetMap("events")
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("cant found map:tls_events")
+	}
+
+	g.eventMaps = append(g.eventMaps, m)
+	gotlsEvent := &event.GoTLSEvent{}
+	//sslEvent.SetModule(g)
+	g.eventFuncMaps[m] = gotlsEvent
+	return nil
+}

--- a/user/module/probe_openssl_keylog.go
+++ b/user/module/probe_openssl_keylog.go
@@ -1,0 +1,116 @@
+// Copyright 2022 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package module
+
+import (
+	"ecapture/user/config"
+	"ecapture/user/event"
+	"errors"
+	"github.com/cilium/ebpf"
+	manager "github.com/gojue/ebpfmanager"
+	"golang.org/x/sys/unix"
+	"math"
+	"strings"
+)
+
+func (m *MOpenSSLProbe) setupManagersKeylog() error {
+	var binaryPath, sslVersion string
+
+	sslVersion = m.conf.(*config.OpensslConfig).SslVersion
+	sslVersion = strings.ToLower(sslVersion)
+	switch m.conf.(*config.OpensslConfig).ElfType {
+	//case config.ElfTypeBin:
+	//	binaryPath = m.conf.(*config.OpensslConfig).Curlpath
+	case config.ElfTypeSo:
+		binaryPath = m.conf.(*config.OpensslConfig).Openssl
+		err := m.getSslBpfFile(binaryPath, sslVersion)
+		if err != nil {
+			return err
+		}
+	default:
+		//如果没找到
+		binaryPath = "/lib/x86_64-linux-gnu/libssl.so.1.1"
+		err := m.getSslBpfFile(binaryPath, sslVersion)
+		if err != nil {
+			return err
+		}
+	}
+
+	m.logger.Printf("%s\tHOOK type:%d, binrayPath:%s\n", m.Name(), m.conf.(*config.OpensslConfig).ElfType, binaryPath)
+	m.logger.Printf("%s\tHook masterKey function:%s\n", m.Name(), m.masterHookFunc)
+
+	m.bpfManager = &manager.Manager{
+		Probes: []*manager.Probe{
+			// openssl masterkey
+			{
+				Section:          "uprobe/SSL_write_key",
+				EbpfFuncName:     "probe_ssl_master_key",
+				AttachToFuncName: m.masterHookFunc, // SSL_do_handshake or SSL_write
+				BinaryPath:       binaryPath,
+				UID:              "uprobe_ssl_master_key",
+			},
+		},
+
+		Maps: []*manager.Map{
+			{
+				Name: "mastersecret_events",
+			},
+		},
+	}
+
+	m.bpfManagerOptions = manager.Options{
+		DefaultKProbeMaxActive: 512,
+
+		VerifierOptions: ebpf.CollectionOptions{
+			Programs: ebpf.ProgramOptions{
+				LogSize: 2097152,
+			},
+		},
+
+		RLimit: &unix.Rlimit{
+			Cur: math.MaxUint64,
+			Max: math.MaxUint64,
+		},
+	}
+
+	if m.conf.EnableGlobalVar() {
+		// 填充 RewriteContants 对应map
+		m.bpfManagerOptions.ConstantEditors = m.constantEditor()
+	}
+	return nil
+}
+
+func (m *MOpenSSLProbe) initDecodeFunKeylog() error {
+	MasterkeyEventsMap, found, err := m.bpfManager.GetMap("mastersecret_events")
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("cant found map:mastersecret_events")
+	}
+	m.eventMaps = append(m.eventMaps, MasterkeyEventsMap)
+
+	var masterkeyEvent event.IEventStruct
+
+	if m.isBoringSSL {
+		masterkeyEvent = &event.MasterSecretBSSLEvent{}
+	} else {
+		masterkeyEvent = &event.MasterSecretEvent{}
+	}
+
+	//masterkeyEvent.SetModule(m)
+	m.eventFuncMaps[MasterkeyEventsMap] = masterkeyEvent
+	return nil
+}

--- a/user/module/probe_openssl_pcap.go
+++ b/user/module/probe_openssl_pcap.go
@@ -33,7 +33,7 @@ type NetEventMetadata struct {
 	ProcessName [16]byte `json:"processName"`
 }
 
-func (m *MOpenSSLProbe) setupManagersTC() error {
+func (m *MOpenSSLProbe) setupManagersPcap() error {
 	var ifname, binaryPath, sslVersion string
 
 	ifname = m.conf.(*config.OpensslConfig).Ifname
@@ -159,7 +159,7 @@ func (m *MOpenSSLProbe) setupManagersTC() error {
 	return nil
 }
 
-func (m *MOpenSSLProbe) initDecodeFunTC() error {
+func (m *MOpenSSLProbe) initDecodeFunPcap() error {
 	//SkbEventsMap 与解码函数映射
 	SkbEventsMap, found, err := m.bpfManager.GetMap("skb_events")
 	if err != nil {

--- a/user/module/probe_openssl_text.go
+++ b/user/module/probe_openssl_text.go
@@ -1,0 +1,218 @@
+package module
+
+import (
+	"ecapture/user/config"
+	"ecapture/user/event"
+	"errors"
+	"github.com/cilium/ebpf"
+	manager "github.com/gojue/ebpfmanager"
+	"golang.org/x/sys/unix"
+	"math"
+	"os"
+	"strings"
+)
+
+func (m *MOpenSSLProbe) setupManagersText() error {
+	var libPthread, binaryPath, sslVersion string
+	sslVersion = m.conf.(*config.OpensslConfig).SslVersion
+	sslVersion = strings.ToLower(sslVersion)
+	switch m.conf.(*config.OpensslConfig).ElfType {
+	//case config.ElfTypeBin:
+	//	binaryPath = m.conf.(*config.OpensslConfig).Curlpath
+	case config.ElfTypeSo:
+		binaryPath = m.conf.(*config.OpensslConfig).Openssl
+		err := m.getSslBpfFile(binaryPath, sslVersion)
+		if err != nil {
+			return err
+		}
+	default:
+		//如果没找到
+		binaryPath = "/lib/x86_64-linux-gnu/libssl.so.1.1"
+		err := m.getSslBpfFile(binaryPath, sslVersion)
+		if err != nil {
+			return err
+		}
+	}
+
+	libPthread = m.conf.(*config.OpensslConfig).Pthread
+	if libPthread == "" {
+		//libPthread = "/lib/x86_64-linux-gnu/libpthread.so.0"
+		m.logger.Printf("%s\tlibPthread path not found, IP info lost.\n", m.Name())
+	}
+
+	_, err := os.Stat(binaryPath)
+	if err != nil {
+		return err
+	}
+
+	m.logger.Printf("%s\tHOOK type:%d, binrayPath:%s\n", m.Name(), m.conf.(*config.OpensslConfig).ElfType, binaryPath)
+	m.logger.Printf("%s\tHook masterKey function:%s\n", m.Name(), m.masterHookFunc)
+
+	m.bpfManager = &manager.Manager{
+		Probes: []*manager.Probe{
+
+			{
+				Section:          "uprobe/SSL_write",
+				EbpfFuncName:     "probe_entry_SSL_write",
+				AttachToFuncName: "SSL_write",
+				BinaryPath:       binaryPath,
+			},
+			{
+				Section:          "uretprobe/SSL_write",
+				EbpfFuncName:     "probe_ret_SSL_write",
+				AttachToFuncName: "SSL_write",
+				BinaryPath:       binaryPath,
+			},
+			{
+				Section:          "uprobe/SSL_read",
+				EbpfFuncName:     "probe_entry_SSL_read",
+				AttachToFuncName: "SSL_read",
+				BinaryPath:       binaryPath,
+			},
+			{
+				Section:          "uretprobe/SSL_read",
+				EbpfFuncName:     "probe_ret_SSL_read",
+				AttachToFuncName: "SSL_read",
+				BinaryPath:       binaryPath,
+			},
+
+			// --------------------------------------------------
+			//{
+			//	Section:          "uprobe/connect",
+			//	EbpfFuncName:     "probe_connect",
+			//	AttachToFuncName: "connect",
+			//	BinaryPath:       libPthread,
+			//},
+
+			// --------------------------------------------------
+
+			// openssl masterkey
+			/*{
+				Section:          "uprobe/SSL_write_key",
+				EbpfFuncName:     "probe_ssl_master_key",
+				AttachToFuncName: m.masterHookFunc,
+				BinaryPath:       binaryPath,
+				UID:              "uprobe_ssl_master_key",
+			},*/
+
+			// ------------------- SSL_set_fd hook-------------------------------------
+			{
+				Section:          "uprobe/SSL_set_fd",
+				EbpfFuncName:     "probe_SSL_set_fd",
+				AttachToFuncName: "SSL_set_fd",
+				BinaryPath:       binaryPath,
+				UID:              "uprobe_ssl_set_fd",
+			},
+			{
+				Section:          "uprobe/SSL_set_rfd",
+				EbpfFuncName:     "probe_SSL_set_fd",
+				AttachToFuncName: "SSL_set_rfd",
+				BinaryPath:       binaryPath,
+				UID:              "uprobe_ssl_set_rfd",
+			},
+			{
+				Section:          "uprobe/SSL_set_wfd",
+				EbpfFuncName:     "probe_SSL_set_fd",
+				AttachToFuncName: "SSL_set_wfd",
+				BinaryPath:       binaryPath,
+				UID:              "uprobe_ssl_set_wfd",
+			},
+		},
+
+		Maps: []*manager.Map{
+			{
+				Name: "tls_events",
+			},
+			{
+				Name: "connect_events",
+			},
+			//{
+			//	Name: "mastersecret_events",
+			//},
+		},
+	}
+
+	if libPthread != "" {
+		// detect libpthread.so path
+		_, err = os.Stat(libPthread)
+		if err == nil {
+			m.logger.Printf("%s\tlibPthread:%s\n", m.Name(), libPthread)
+			m.bpfManager.Probes = append(m.bpfManager.Probes, &manager.Probe{
+				Section:          "uprobe/connect",
+				EbpfFuncName:     "probe_connect",
+				AttachToFuncName: "connect",
+				BinaryPath:       libPthread,
+				UID:              "uprobe_connect",
+			})
+		}
+	}
+
+	m.bpfManagerOptions = manager.Options{
+		DefaultKProbeMaxActive: 512,
+
+		VerifierOptions: ebpf.CollectionOptions{
+			Programs: ebpf.ProgramOptions{
+				LogSize: 2097152,
+			},
+		},
+
+		RLimit: &unix.Rlimit{
+			Cur: math.MaxUint64,
+			Max: math.MaxUint64,
+		},
+	}
+
+	if m.conf.EnableGlobalVar() {
+		// 填充 RewriteContants 对应map
+		m.bpfManagerOptions.ConstantEditors = m.constantEditor()
+	} else {
+		m.logger.Printf("%s\tYour kernel version is less than 5.2, the following parameters will be ignored:[target_pid, target_uid, target_port]\n", m.Name())
+	}
+	return nil
+}
+
+func (m *MOpenSSLProbe) initDecodeFunText() error {
+	//SSLDumpEventsMap 与解码函数映射
+	SSLDumpEventsMap, found, err := m.bpfManager.GetMap("tls_events")
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("cant found map:tls_events")
+	}
+	m.eventMaps = append(m.eventMaps, SSLDumpEventsMap)
+	sslEvent := &event.SSLDataEvent{}
+	m.eventFuncMaps[SSLDumpEventsMap] = sslEvent
+
+	ConnEventsMap, found, err := m.bpfManager.GetMap("connect_events")
+	if err != nil {
+		return err
+	}
+	if !found {
+		return errors.New("cant found map:connect_events")
+	}
+	m.eventMaps = append(m.eventMaps, ConnEventsMap)
+	connEvent := &event.ConnDataEvent{}
+	m.eventFuncMaps[ConnEventsMap] = connEvent
+	/*
+		MasterkeyEventsMap, found, err := m.bpfManager.GetMap("mastersecret_events")
+		if err != nil {
+			return err
+		}
+		if !found {
+			return errors.New("cant found map:mastersecret_events")
+		}
+		m.eventMaps = append(m.eventMaps, MasterkeyEventsMap)
+
+		var masterkeyEvent event.IEventStruct
+
+		if m.isBoringSSL {
+			masterkeyEvent = &event.MasterSecretBSSLEvent{}
+		} else {
+			masterkeyEvent = &event.MasterSecretEvent{}
+		}
+		//masterkeyEvent.SetModule(m)
+		m.eventFuncMaps[MasterkeyEventsMap] = masterkeyEvent
+	*/
+	return nil
+}


### PR DESCRIPTION
add the `model` flag to distinguish the captured modes,

including `text`, `pcapng/pcap`, and `keylog/key`.
Support two modules: **gotls** and **openssl**.

Co-Authored-By: blaisewang <blaisewang@icloud.com>