### PR TITLE
pkg: support android on docker.

### DIFF
--- a/pkg/util/ebpf/bpf.go
+++ b/pkg/util/ebpf/bpf.go
@@ -33,6 +33,12 @@ var (
 		"CONFIG_UPROBES",
 		"CONFIG_ARCH_SUPPORTS_UPROBES",
 	}
+
+	configPaths = []string{
+		"/proc/config.gz",
+		"/boot/config",
+		"/boot/config-%s",
+	}
 )
 
 type UnameInfo struct {

--- a/pkg/util/ebpf/bpf.go
+++ b/pkg/util/ebpf/bpf.go
@@ -18,6 +18,12 @@ import (
 	"fmt"
 	"golang.org/x/sys/unix"
 	"os"
+	"strings"
+)
+
+const (
+	ProcContainerCgroupPath = "/proc/1/cgroup"
+	ProcContainerSchedPath  = "/proc/1/sched"
 )
 
 // CONFIG CHECK ITEMS
@@ -153,4 +159,87 @@ func IsEnableBPF() (bool, error) {
 	}
 
 	return true, nil
+}
+
+// IsContainer returns true if the process is running in a container.
+func IsContainer() (bool, error) {
+	b, e := isContainerCgroup()
+	if e != nil {
+		return false, e
+	}
+
+	// if b is true, it's a container
+	if b {
+		return true, nil
+	}
+
+	// if b is false, continue to check sched
+	b, e = isContainerSched()
+	if e != nil {
+		return false, e
+	}
+
+	return b, nil
+}
+
+// isContainerCgroup returns true if the process is running in a container.
+// https://www.baeldung.com/linux/is-process-running-inside-container
+
+func isContainerCgroup() (bool, error) {
+	var f *os.File
+	var err error
+	var i int
+	f, err = os.Open(ProcContainerCgroupPath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	b := make([]byte, 1024)
+	i, err = f.Read(b)
+	if err != nil {
+		return false, err
+	}
+	switch {
+	case strings.Contains(string(b[:i]), "cpuset:/docker"):
+		// CGROUP V1 docker container
+		return true, nil
+	case strings.Contains(string(b[:i]), "cpuset:/kubepods"):
+		// k8s container
+		return true, nil
+	case strings.Contains(string(b[:i]), "0::/\n"):
+		// CGROUP V2 docker container
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// isContainerSched returns true if the process is running in a container.
+// https://man7.org/linux/man-pages/man7/sched.7.html
+func isContainerSched() (bool, error) {
+	var f *os.File
+	var err error
+	var i int
+	f, err = os.Open(ProcContainerSchedPath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+	b := make([]byte, 1024)
+	i, err = f.Read(b)
+	if err != nil {
+		return false, err
+	}
+	switch {
+	case strings.Contains(string(b[:i]), "bash (1, #threads"):
+		return true, nil
+	case strings.Contains(string(b[:i]), "run-on-arch-com (1, #threads"):
+		return true, nil
+	case strings.Contains(string(b[:i]), "init (1, #threads:"):
+		return false, nil
+	case strings.Contains(string(b[:i]), "systemd (1, #threads"):
+		return false, nil
+	}
+
+	return false, nil
 }

--- a/pkg/util/ebpf/bpf_androidgki.go
+++ b/pkg/util/ebpf/bpf_androidgki.go
@@ -89,8 +89,3 @@ func getAndroidConfig(filename string) (map[string]string, error) {
 	}
 	return KernelConfig, nil
 }
-
-// IsContainedInCgroup returns true if the process is running in a container.
-func IsContainer() (bool, error) {
-	return false, nil
-}

--- a/pkg/util/ebpf/bpf_linux.go
+++ b/pkg/util/ebpf/bpf_linux.go
@@ -43,12 +43,6 @@ var (
 		"/usr/lib/debug/boot/vmlinux-%s.debug",
 		"/usr/lib/debug/lib/modules/%s/vmlinux",
 	}
-
-	configPaths = []string{
-		"/proc/config.gz",
-		"/boot/config",
-		"/boot/config-%s",
-	}
 )
 
 func GetSystemConfig() (map[string]string, error) {

--- a/pkg/util/ebpf/bpf_test.go
+++ b/pkg/util/ebpf/bpf_test.go
@@ -110,7 +110,7 @@ func TestIsContainerCgroup(t *testing.T) {
 }
 
 func TestIsContainerSched(t *testing.T) {
-	isContainer, err := isCOntainerSched()
+	isContainer, err := isContainerSched()
 	if err != nil {
 		t.Fatalf("TestIsContainerSched :: IsContainer error:%s", err.Error())
 	}


### PR DESCRIPTION
fix: #445 

Added detection of Android running on containers


```shell
cda5a878a8c4:/ # ./ecapture tls
2023/12/23 14:37:30 Your environment is like a container. We won't be able to detect the BTF configuration.
tls_2023/12/23 14:37:30 ECAPTURE :: ecapture Version : androidgki_x86_64:--:5.15.0-91-generic
tls_2023/12/23 14:37:30 ECAPTURE :: Pid Info : 1717
tls_2023/12/23 14:37:30 ECAPTURE :: Kernel Info : 5.15.126
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	module initialization
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	master key keylogger:
tls_2023/12/23 14:37:30 ECAPTURE ::	Module.Run()
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	Text MODEL
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	OpenSSL/BoringSSL version not found, used default version :android_default
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	HOOK type:2, binrayPath:/apex/com.android.conscrypt/lib64/libssl.so
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	Hook masterKey function:SSL_in_init
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	libPthread:/apex/com.android.runtime/lib64/bionic/libc.so
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	target all process.
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	target all users.
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	BPF bytecode filename:user/bytecode/boringssl_a_13_kern.o
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	perfEventReader created. mapSize:4 MB
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	perfEventReader created. mapSize:4 MB
tls_2023/12/23 14:37:30 EBPFProbeOPENSSL	module started successfully.
tls_2023/12/23 14:37:30 ECAPTURE :: 	start 1 modules
^Ctls_2023/12/23 14:37:41 EBPFProbeOPENSSL	close.
tls_2023/12/23 14:37:41 EBPFProbeOPENSSL	close
```


