### PR TITLE
makefile: Optimize the feature list for the Android version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,22 +190,25 @@ BPF_NOCORE_TAG = $(subst .,_,$(KERN_RELEASE)).$(subst .,_,$(VERSION))
 #
 # BPF Source file
 #
-
-TARGETS := kern/openssl_1_1_1a
+TARGETS := kern/boringssl_a_13
+TARGETS += kern/boringssl_a_14
+TARGETS += kern/openssl_1_1_1a
 TARGETS += kern/openssl_1_1_1b
 TARGETS += kern/openssl_1_1_1d
 TARGETS += kern/openssl_1_1_1j
 TARGETS += kern/openssl_1_1_0a
 TARGETS += kern/openssl_1_0_2a
 TARGETS += kern/openssl_3_0_0
-TARGETS += kern/boringssl_a_13
-TARGETS += kern/boringssl_a_14
-TARGETS += kern/bash
-TARGETS += kern/gnutls
-TARGETS += kern/nspr
-TARGETS += kern/mysqld
-TARGETS += kern/postgres
 TARGETS += kern/gotls
+
+ifeq ($(ANDROID),0)
+	TARGETS += kern/bash
+	TARGETS += kern/gnutls
+	TARGETS += kern/nspr
+	TARGETS += kern/mysqld
+	TARGETS += kern/postgres
+endif
+
 
 # Generate file name-scheme based on TARGETS
 KERN_SOURCES = ${TARGETS:=_kern.c}

--- a/builder/Makefile.release
+++ b/builder/Makefile.release
@@ -235,7 +235,7 @@ build_deb:
 	# 创建软件包目录结构
 	$(CMD_RM) -rf $(BUILD_DIR)
 	$(CMD_MKDIR) -p $(BUILD_DIR)/DEBIAN
-	$(CMD_MKDIR) -p $(BUILD_DIR)/usr/local/bin  # 这里是例子，请根据实际情况更改
+	$(CMD_MKDIR) -p $(BUILD_DIR)/usr/local/bin
     # 复制程序文件到软件包目录
 	$(CMD_CP) bin/ecapture $(BUILD_DIR)/usr/local/bin/ecapture  # 将二进制文件复制到目标位置
     # 创建控制文件 (DEBIAN/control)


### PR DESCRIPTION
Optimize the feature list for the Android version retaining the three essential modules: openssl, broingssl, and gotls. 

Exclude BPF bytecode for kernels with an architecture smaller than arm64 and versions less than 5.2.