### PR TITLE
utils: support openssl 3.1.0-3.1.4 and 3.0.9-3.0.12

### DIFF
--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -28,6 +28,7 @@ const (
 	LinuxDefauleFilename_1_1_0 = "linux_default_1_1_0"
 	LinuxDefauleFilename_1_1_1 = "linux_default_1_1_1"
 	LinuxDefauleFilename_3_0   = "linux_default_3_0"
+	LinuxDefauleFilename_3_1   = "linux_default_3_0"
 	AndroidDefauleFilename     = "android_default"
 
 	OpenSslVersionLen = 30 // openssl version string length
@@ -37,7 +38,8 @@ const (
 	MaxSupportedOpenSSL102Version = 'u'
 	MaxSupportedOpenSSL110Version = 'l'
 	MaxSupportedOpenSSL111Version = 'u'
-	MaxSupportedOpenSSL30Version  = '9'
+	MaxSupportedOpenSSL30Version  = 12
+	MaxSupportedOpenSSL31Version  = 4
 )
 
 // initOpensslOffset initial BpfMap
@@ -52,7 +54,7 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 		// openssl 1.1.1*
 		LinuxDefauleFilename_1_1_1: "openssl_1_1_1j_kern.o",
 
-		// openssl 3.0.*
+		// openssl 3.0.* and openssl 3.1.*
 		LinuxDefauleFilename_3_0: "openssl_3_0_0_kern.o",
 
 		// boringssl
@@ -80,9 +82,14 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 		m.sslVersionBpfMap["openssl 1.1.1"+string(ch)] = "openssl_1_1_1j_kern.o"
 	}
 
-	// openssl 3.0.0 - 3.0.7
-	for ch := '0'; ch <= MaxSupportedOpenSSL30Version; ch++ {
-		m.sslVersionBpfMap["openssl 3.0."+string(ch)] = "openssl_3_0_0_kern.o"
+	// openssl 3.0.0 - 3.0.12
+	for ch := 0; ch <= MaxSupportedOpenSSL30Version; ch++ {
+		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.0.%d", ch)] = "openssl_3_0_0_kern.o"
+	}
+
+	// openssl 3.1.0 - 3.1.4
+	for ch := 0; ch <= MaxSupportedOpenSSL31Version; ch++ {
+		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.1.%d", ch)] = "openssl_3_0_0_kern.o"
 	}
 
 	// openssl 1.1.0a - 1.1.0l

--- a/utils/openssl_offset_1.0.2.sh
+++ b/utils/openssl_offset_1.0.2.sh
@@ -11,9 +11,12 @@ if [[ ! -f "go.mod" ]]; then
 fi
 
 # skip cloning if the header file of the max supported version is already generated
+echo "check file exists: ${OPENSSL_DIR}/.git"
 if [[ ! -f "${OPENSSL_DIR}/.git" ]]; then
   # skip cloning if the openssl directory already exists
+  echo "check directory exists: ${OPENSSL_DIR}"
   if [[ ! -d "${OPENSSL_DIR}" ]]; then
+    echo "git clone openssl to ${OPENSSL_DIR}"
     git clone https://github.com/openssl/openssl.git ${OPENSSL_DIR}
   fi
 fi

--- a/utils/openssl_offset_3.1.sh
+++ b/utils/openssl_offset_3.1.sh
@@ -30,19 +30,12 @@ function run() {
   sslVerMap["2"]="0"
   sslVerMap["3"]="0"
   sslVerMap["4"]="0"
-  sslVerMap["5"]="0"
-  sslVerMap["6"]="0"
-  sslVerMap["7"]="0"
-  sslVerMap["8"]="0"
-  sslVerMap["9"]="0"
-  sslVerMap["10"]="0"
-  sslVerMap["11"]="0"
-  sslVerMap["12"]="0"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do
-    tag="openssl-3.0.${ver}"
+    tag="openssl-3.1.${ver}"
     val=${sslVerMap[$ver]}
+    # 3.1.X and 3.0.X OFFSET is the same, use the same for the time being
     header_file="${OUTPUT_DIR}/openssl_3_0_${val}_kern.c"
     header_define="OPENSSL_3_0_$(echo ${val} | tr "[:lower:]" "[:upper:]")_KERN_H"
 


### PR DESCRIPTION
Since 3.0.x has the same offsets as the other properties of the 3.1.x series ssl_st structs, the 3.0.x kern file is used uniformly.