### PR TITLE
user: imporve #463, impact on the performance of the tested program

### DIFF
--- a/tests/issue_463/Makefile
+++ b/tests/issue_463/Makefile
@@ -1,0 +1,22 @@
+.PHONY: all
+
+OPENSSL_INCLUDE="/home/cfc4n/project/ecapture/deps/openssl/include"
+OPENSSL_PATH="/home/cfc4n/project/ecapture/deps/openssl"
+
+SDL_LIB = -L$(OPENSSL_PATH) -lcrypto -lssl
+SDL_INCLUDE = -I$(OPENSSL_INCLUDE) -I/usr/local/include
+CXXFLAGS = -Wall -c -std=c++11 $(SDL_INCLUDE)
+LDFLAGS = $(SDL_LIB)
+
+EXE = openssl_client
+
+all: $(EXE)
+
+$(EXE): main.o
+	$(CXX) $< $(LDFLAGS) -o $@
+
+main.o: main.c
+	$(CXX) $(CXXFLAGS) $< -o $@
+
+clean:
+	rm *.o && rm $(EXE)

--- a/tests/issue_463/main.c
+++ b/tests/issue_463/main.c
@@ -1,0 +1,94 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#define SERVER "127.0.0.1"
+#define PORT 443
+#define REQUEST "GET / HTTP/1.1\r\nHost: www.cnxct.com\r\n\r\n"
+#define TEST_CNT 10000000
+//#define TEST_CNT 10
+
+char g_requests[TEST_CNT][strlen(REQUEST) + 1];
+int create_socket(const char *host, int port) {
+    int sockfd;
+    struct sockaddr_in dest_addr;
+
+    sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    if (sockfd == -1) {
+        perror("socket");
+        exit(EXIT_FAILURE);
+    }
+
+    dest_addr.sin_family = AF_INET;
+    dest_addr.sin_port = htons(port);
+    dest_addr.sin_addr.s_addr = inet_addr(host);
+
+    memset(&(dest_addr.sin_zero), '\0', 8);
+
+    if (connect(sockfd, (struct sockaddr *)&dest_addr, sizeof(struct sockaddr)) == -1) {
+        perror("connect");
+        exit(EXIT_FAILURE);
+    }
+
+    return sockfd;
+}
+
+void init_request() {
+    int i;
+    for (i = 0; i < TEST_CNT; i++) {
+        memcpy(g_requests[i], REQUEST, strlen(REQUEST));
+    }
+
+}
+
+int main() {
+    SSL_CTX *ctx;
+    SSL *ssl;
+    int server;
+    char reply[4096];
+
+    SSL_library_init();
+    SSL_load_error_strings();
+    OpenSSL_add_all_algorithms();
+
+    ctx = SSL_CTX_new(TLS_client_method());
+    if (ctx == NULL) {
+        ERR_print_errors_fp(stderr);
+        exit(EXIT_FAILURE);
+    }
+
+    server = create_socket(SERVER, PORT);
+    ssl = SSL_new(ctx);
+    SSL_set_fd(ssl, server);
+    SSL_connect(ssl);
+
+    init_request();
+    int request_len = strlen(REQUEST);
+
+    // Perform SSL_write performance test
+    int i;
+    for (i = 0; i < TEST_CNT; i++) {
+        char *request = g_requests[i];
+        int bytes_written = SSL_write(ssl, request, request_len);  // Perform SSL_write
+        if (bytes_written <= 0) {
+            fprintf(stderr, "SSL_write failed\n");
+            ERR_print_errors_fp(stderr);
+            break;
+        }
+    }
+
+    SSL_read(ssl, reply, sizeof(reply));  // Read server response
+
+    SSL_free(ssl);
+    close(server);
+    SSL_CTX_free(ctx);
+    return 0;
+}

--- a/tests/issue_463/readme.md
+++ b/tests/issue_463/readme.md
@@ -1,0 +1,64 @@
+## 背景介绍
+在eCapture社区的issue 463：[TLS 模式下，对被检测程序的性能影响](https://github.com/gojue/ecapture/issues/463)提到，eCapture启用后，对程序带来较大性能影响。
+
+
+## 解决思路
+选择低频的、有符号表导出的、可取密钥的函数进行HOOK。
+参见 [PR 471](https://github.com/gojue/ecapture/pull/471)
+
+## 环境搭建
+
+### TLS Server
+1. 在ubuntu 22.04 上执行sudo apt install nginx
+2. 开启SSL 443的服务(这里我以我的博客域名为例)
+3. 在本目录，执行make，编译测试的客户端进程
+
+## 执行测试
+
+### 原生测试
+```shell
+time ./openssl_client
+
+real	0m5.677s
+user	0m3.088s
+sys	0m2.565s
+```
+
+#### 启用eCapture后测试
+**运行eCapture**
+新开一个终端，打开eCapture的`keylog`模式
+```shell
+sudo bin/ecapture tls -m keylog
+[sudo] password for cfc4n:
+tls_2024/01/27 13:42:55 ECAPTURE :: ecapture Version : linux_aarch64:0.7.2-20240104-f368e82:[CORE]
+tls_2024/01/27 13:42:55 ECAPTURE :: Pid Info : 124787
+tls_2024/01/27 13:42:55 ECAPTURE :: Kernel Info : 5.15.131
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	module initialization
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	master key keylogger: ecapture_openssl_key.og
+tls_2024/01/27 13:42:55 ECAPTURE ::	Module.Run()
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	Keylog MODEL
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	OpenSSL/BoringSSL version not found from shared library file, used default version:linux_default_3_0
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	HOOK type:2, binrayPath:/usr/lib/aarch64-linux-gnu/libssl.so.3
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	Hook masterKey function:[SSL_get_wbio SSL_in_before]
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	target all process.
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	target all users.
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	BPF bytecode filename:user/bytecode/openssl_3_0_0_kern.o
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	perfEventReader created. mapSize:4 MB
+tls_2024/01/27 13:42:55 EBPFProbeOPENSSL	module started successfully.
+tls_2024/01/27 13:42:55 ECAPTURE :: 	start 1 modules
+tls_2024/01/27 13:42:59 EBPFProbeOPENSSL	TLS1_2_VERSION: save CLIENT_RANDOM 8516901707503cfcfb0b63d02adc5deba9f7bc3e64418212f4a9c7b0c4007cca to file success, 176 bytes
+^Ctls_2024/01/27 13:43:15 EBPFProbeOPENSSL	close.
+tls_2024/01/27 13:43:15 EBPFProbeOPENSSL	close
+```
+
+**运行测试程序**
+```shell
+time ./openssl_client
+
+real	0m7.133s
+user	0m4.735s
+sys	0m2.394s
+```
+
+### 结果
+可以看到，当使用`keylog`模式后，耗时从30秒下降到7秒。

--- a/user/module/const.go
+++ b/user/module/const.go
@@ -52,17 +52,17 @@ const (
 
 var (
 	/*
-	*	为了读取到TLS握手完成后的client_random等密钥，必需要选择一个合适的HOOK函数。
-	*	SSL_write\SSL_read时，TLS握手是建立完成的，但调用过于频繁，会带来性能问题，参见https://github.com/gojue/ecapture/issues/463
-	*	综合来看，合适的HOOK函数需要满足以下几个条件:
-	*	1. 函数是在TLS握手完成后调用
-	*	2. 函数名在动态链接库的符号表中是导出状态
-	*	3. 函数是低频调用
+	* 为了读取到TLS握手完成后的client_random等密钥，必需要选择一个合适的HOOK函数。
+	* SSL_write\SSL_read时，TLS握手是建立完成的，但调用过于频繁，会带来性能问题，参见https://github.com/gojue/ecapture/issues/463
+	* 综合来看，合适的HOOK函数需要满足以下几个条件:
+	* 1. 函数是在TLS握手完成后调用
+	* 2. 函数名在动态链接库的符号表中是导出状态
+	* 3. 函数是低频调用
 	*
-	*	在 openssl 类库中，以客户端角色调用 `SSL_connect` 或者以服务端角色 `SSL_accept` ，最终都会进入 `ssl/statem/statem.c` 的 `state_machine` 函数进行TLS握手。
-	*	所以，可选范围是在这个函数内以大写`SSL`开头的函数。
-	*	当使用openssl的方式为同步调用时，TLS握手成功会返回1，也就是`ret = 1`，即需要在这个变量赋值后，被调用的函数，才能拿到符合要求的内存数据。
-	*	在这个前提下，`的state_machine`函数内符合要求的就只有`SSL_get_wbio`了。
+	* 在 openssl 类库中，以客户端角色调用 `SSL_connect` 或者以服务端角色 `SSL_accept` ，最终都会进入 `ssl/statem/statem.c` 的 `state_machine` 函数进行TLS握手。
+	* 所以，可选范围是在这个函数内以大写`SSL`开头的函数。
+	* 当使用openssl的方式为`同步`调用时，TLS握手成功会返回1，也就是`ret = 1`，即需要在这个变量赋值后，被调用的函数，才能拿到符合要求的内存数据。 `state_machine`函数内符合要求的就只有`SSL_get_wbio`了。
+	* 当使用openssl的方式为`异步`调用时，还需要增加`SSL_in_before`函数。
 	 */
 	MasterKeyHookFuncs = []string{
 		"SSL_get_wbio", // openssl

--- a/user/module/const.go
+++ b/user/module/const.go
@@ -39,7 +39,8 @@ const (
 )
 
 const (
-	MasterKeyHookFuncOpenSSL = "SSL_write"
+	// 备选 HOOK的函数  SSL_is_init_finished \ SSL_get_wbio \ SSL_write
+	MasterKeyHookFuncOpenSSL = "SSL_is_init_finished"
 
 	/*
 		在boringSSL类库里，SSL_write函数调用了 SSL_do_handshake ，
@@ -47,6 +48,29 @@ const (
 	*/
 	// 2022-12-16 改为 SSL_in_init
 	MasterKeyHookFuncBoringSSL = "SSL_in_init"
+)
+
+var (
+	/*
+	*	为了读取到TLS握手完成后的client_random等密钥，必需要选择一个合适的HOOK函数。
+	*	SSL_write\SSL_read时，TLS握手是建立完成的，但调用过于频繁，会带来性能问题，参见https://github.com/gojue/ecapture/issues/463
+	*	综合来看，合适的HOOK函数需要满足以下几个条件:
+	*	1. 函数是在TLS握手完成后调用
+	*	2. 函数名在动态链接库的符号表中是导出状态
+	*	3. 函数是低频调用
+	*
+	*	在 openssl 类库中，以客户端角色调用 `SSL_connect` 或者以服务端角色 `SSL_accept` ，最终都会进入 `ssl/statem/statem.c` 的 `state_machine` 函数进行TLS握手。
+	*	所以，可选范围是在这个函数内以大写`SSL`开头的函数。
+	*	当使用openssl的方式为同步调用时，TLS握手成功会返回1，也就是`ret = 1`，即需要在这个变量赋值后，被调用的函数，才能拿到符合要求的内存数据。
+	*	在这个前提下，`的state_machine`函数内符合要求的就只有`SSL_get_wbio`了。
+	 */
+	MasterKeyHookFuncs = []string{
+		"SSL_get_wbio", // openssl
+		//"SSL_is_init",  // boringssl
+		// 备用HOOK 函数
+		//"SSL_is_init_finished",
+		"SSL_in_before",
+	}
 )
 
 const (

--- a/user/module/const.go
+++ b/user/module/const.go
@@ -70,6 +70,7 @@ var (
 		// 备用HOOK 函数
 		//"SSL_is_init_finished",
 		"SSL_in_before",
+		"SSL_do_handshake",
 	}
 )
 

--- a/user/module/const.go
+++ b/user/module/const.go
@@ -40,7 +40,7 @@ const (
 
 const (
 	// 备选 HOOK的函数  SSL_is_init_finished \ SSL_get_wbio \ SSL_write
-	MasterKeyHookFuncOpenSSL = "SSL_is_init_finished"
+	MasterKeyHookFuncOpenSSL = "SSL_write"
 
 	/*
 		在boringSSL类库里，SSL_write函数调用了 SSL_do_handshake ，
@@ -64,17 +64,13 @@ var (
 	* 当使用openssl的方式为`同步`调用时，TLS握手成功会返回1，也就是`ret = 1`，即需要在这个变量赋值后，被调用的函数，才能拿到符合要求的内存数据。 `state_machine`函数内符合要求的就只有`SSL_get_wbio`了。
 	* 当使用openssl的方式为`异步`调用时，还需要增加`SSL_in_before`函数。
 	 */
-	MasterKeyHookFuncs = []string{
+	masterKeyHookFuncs = []string{
 		"SSL_get_wbio", // openssl
 		//"SSL_is_init",  // boringssl
 		// 备用HOOK 函数
 		//"SSL_is_init_finished",
 		"SSL_in_before",
 	}
-)
-
-const (
-	MasterSecretKeyLogName = "ecapture_masterkey.log"
 )
 
 var defaultSoPath = "/lib/x86_64-linux-gnu"

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -74,7 +74,7 @@ type MOpenSSLProbe struct {
 	sslVersionBpfMap map[string]string // bpf map key: ssl version, value: bpf map key
 	sslBpfFile       string            // ssl bpf file
 	isBoringSSL      bool              //
-	masterHookFuncs  []string          // SSL_in_init on boringSSL,  SSL_write on openssl
+	masterHookFuncs  []string          // set by masterKeyHookFuncs
 	cgroupPath       string
 }
 
@@ -89,7 +89,7 @@ func (m *MOpenSSLProbe) Init(ctx context.Context, logger *log.Logger, conf confi
 	m.pidLocker = new(sync.Mutex)
 	m.masterKeys = make(map[string]bool)
 	m.sslVersionBpfMap = make(map[string]string)
-	m.masterHookFuncs = MasterKeyHookFuncs
+	m.masterHookFuncs = masterKeyHookFuncs
 
 	//fd := os.Getpid()
 	var err error
@@ -147,9 +147,7 @@ func (m *MOpenSSLProbe) getSslBpfFile(soPath, sslVersion string) error {
 	defer func() {
 		if strings.Contains(m.sslBpfFile, "boringssl") {
 			m.isBoringSSL = true
-			//m.masterHookFuncs = MasterKeyHookFuncBoringSSL
-		} else {
-			//m.masterHookFuncs = MasterKeyHookFuncOpenSSL
+			m.masterHookFuncs = []string{MasterKeyHookFuncBoringSSL}
 		}
 	}()
 

--- a/user/module/probe_openssl_keylog.go
+++ b/user/module/probe_openssl_keylog.go
@@ -18,6 +18,7 @@ import (
 	"ecapture/user/config"
 	"ecapture/user/event"
 	"errors"
+	"fmt"
 	"github.com/cilium/ebpf"
 	manager "github.com/gojue/ebpfmanager"
 	"golang.org/x/sys/unix"
@@ -50,25 +51,24 @@ func (m *MOpenSSLProbe) setupManagersKeylog() error {
 	}
 
 	m.logger.Printf("%s\tHOOK type:%d, binrayPath:%s\n", m.Name(), m.conf.(*config.OpensslConfig).ElfType, binaryPath)
-	m.logger.Printf("%s\tHook masterKey function:%s\n", m.Name(), m.masterHookFunc)
+	m.logger.Printf("%s\tHook masterKey function:%s\n", m.Name(), m.masterHookFuncs)
 
 	m.bpfManager = &manager.Manager{
-		Probes: []*manager.Probe{
-			// openssl masterkey
-			{
-				Section:          "uprobe/SSL_write_key",
-				EbpfFuncName:     "probe_ssl_master_key",
-				AttachToFuncName: m.masterHookFunc, // SSL_do_handshake or SSL_write
-				BinaryPath:       binaryPath,
-				UID:              "uprobe_ssl_master_key",
-			},
-		},
-
 		Maps: []*manager.Map{
 			{
 				Name: "mastersecret_events",
 			},
 		},
+	}
+	m.bpfManager.Probes = make([]*manager.Probe, 0)
+	for _, masterFunc := range m.masterHookFuncs {
+		m.bpfManager.Probes = append(m.bpfManager.Probes, &manager.Probe{
+			Section:          "uprobe/SSL_write_key",
+			EbpfFuncName:     "probe_ssl_master_key",
+			AttachToFuncName: masterFunc,
+			BinaryPath:       binaryPath,
+			UID:              fmt.Sprintf("uprobe_smk_%s", masterFunc),
+		})
 	}
 
 	m.bpfManagerOptions = manager.Options{

--- a/user/module/probe_openssl_text.go
+++ b/user/module/probe_openssl_text.go
@@ -47,7 +47,7 @@ func (m *MOpenSSLProbe) setupManagersText() error {
 	}
 
 	m.logger.Printf("%s\tHOOK type:%d, binrayPath:%s\n", m.Name(), m.conf.(*config.OpensslConfig).ElfType, binaryPath)
-	m.logger.Printf("%s\tHook masterKey function:%s\n", m.Name(), m.masterHookFunc)
+	m.logger.Printf("%s\tHook masterKey function:%s\n", m.Name(), m.masterHookFuncs)
 
 	m.bpfManager = &manager.Manager{
 		Probes: []*manager.Probe{
@@ -91,7 +91,7 @@ func (m *MOpenSSLProbe) setupManagersText() error {
 			/*{
 				Section:          "uprobe/SSL_write_key",
 				EbpfFuncName:     "probe_ssl_master_key",
-				AttachToFuncName: m.masterHookFunc,
+				AttachToFuncName: m.masterHookFuncs,
 				BinaryPath:       binaryPath,
 				UID:              "uprobe_ssl_master_key",
 			},*/


### PR DESCRIPTION
### 设计思路
#### 问题
* 为了读取到TLS握手完成后的client_random等密钥，必需要选择一个合适的HOOK函数。
* SSL_write\SSL_read时，TLS握手是建立完成的，但调用过于频繁，会带来性能问题，参见 #463
* 综合来看，合适的HOOK函数需要满足以下几个条件:
    1. 函数是在TLS握手完成后调用
    2. 函数名在动态链接库的符号表中是导出状态
    3. 函数是低频调用

#### 解决思路
* 在 openssl 类库中，以客户端角色调用 `SSL_connect` 或者以服务端角色 `SSL_accept` ，最终都会进入 `ssl/statem/statem.c` 的 `state_machine` 函数进行TLS握手。
* 所以，可选范围是在这个函数内以大写`SSL`开头的函数。
* 当使用openssl的方式为`同步`调用时，TLS握手成功会返回1，也就是`ret = 1`，即需要在这个变量赋值后，被调用的函数，才能拿到符合要求的内存数据。 `state_machine`函数内符合要求的就只有`SSL_get_wbio`了。
* 当使用openssl的方式为`异步 (BIO)`调用时，还需要增加`SSL_in_before`函数。

------

### Design concept

#### Question 
* In order to read the client_random and other keys after TLS handshake is completed, it is necessary to select a suitable HOOK function.
* When SSL_write\SSL_read, the TLS handshake is already established, but calling it too frequently will cause performance issues, see #463 for reference. 
* Overall, a suitable HOOK function needs to meet the following conditions:     
    1. The function is called after TLS handshake completion
    2. The function name is exported in the symbol table of the dynamic link library     
    3. The function has low-frequency calls

#### Solution
* When calling `SSL_connect` in the OpenSSL library in a client role or `SSL_accept` in a server role, the execution flow ultimately enters the `state_machine` function in `ssl/statem/statem.c` for TLS handshake.
* Therefore, the optional scope is functions within this `state_machine` function that start with an uppercase `SSL`.
* When using OpenSSL synchronously, a successful TLS handshake returns 1, i.e., `ret = 1`. Thus, after this variable is assigned, the called functions can obtain the desired memory data. the only function within the `state_machine` function that meets the requirements is `SSL_get_wbio`.
* When using openssl in an `asynchronous (BIO)`  manner, it is also necessary to add the `SSL_in_before` function.