### PR TITLE
Fix: init GoTLSProbe.tcPacketsChan #492

### DIFF
--- a/user/module/probe_gotls.go
+++ b/user/module/probe_gotls.go
@@ -24,6 +24,8 @@ import (
 
 func init() {
 	mod := &GoTLSProbe{}
+	mod.name = ModuleNameGotls
+	mod.mType = ProbeTypeUprobe
 	Register(mod)
 }
 
@@ -107,6 +109,7 @@ func (g *GoTLSProbe) Init(ctx context.Context, l *log.Logger, cfg config.IConfig
 	g.bootTime = uint64(bootTime)
 
 	g.tcPackets = make([]*TcPacket, 0, 1024)
+	g.tcPacketsChan = make(chan *TcPacket, 2048)
 	g.tcPacketLocker = &sync.Mutex{}
 	g.masterKeyBuffer = bytes.NewBuffer([]byte{})
 	return nil


### PR DESCRIPTION
* initialize tcPacketsChan in MTCProbe of GoTLSProbe
* filled mod.name and mod.mType in probe_gotls.go::init() used for debugging

The problem mentioned in issure #492 is caused by uninitialized ` tcPacketsChan` in `GoTLSProbe`.

When [code](https://github.com/gojue/ecapture/blob/2127596005116087f13a8d25b382d5bc4b56dd96/user/module/probe_pcap.go#L251) is executed, `eOverflow` is returned which turn out to be the error message mentioned in issue #492 
