### PR TITLE
fix: avoid printing confusing message when input contains special character

### DIFF
--- a/user/event/event_bash.go
+++ b/user/event/event_bash.go
@@ -62,12 +62,12 @@ func (be *BashEvent) Decode(payload []byte) (err error) {
 }
 
 func (be *BashEvent) String() string {
-	s := fmt.Sprintf(fmt.Sprintf("PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s", be.Pid, be.Uid, be.Comm, be.Retval, unix.ByteSliceToString((be.Line[:]))))
+	s := fmt.Sprintf("PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s", be.Pid, be.Uid, be.Comm, be.Retval, unix.ByteSliceToString((be.Line[:])))
 	return s
 }
 
 func (be *BashEvent) StringHex() string {
-	s := fmt.Sprintf(fmt.Sprintf("PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s,", be.Pid, be.Uid, be.Comm, be.Retval, dumpByteSlice([]byte(unix.ByteSliceToString((be.Line[:]))), "")))
+	s := fmt.Sprintf("PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s,", be.Pid, be.Uid, be.Comm, be.Retval, dumpByteSlice([]byte(unix.ByteSliceToString((be.Line[:]))), ""))
 	return s
 }
 

--- a/user/event/event_mysqld.go
+++ b/user/event/event_mysqld.go
@@ -107,12 +107,12 @@ func (me *MysqldEvent) Decode(payload []byte) (err error) {
 }
 
 func (me *MysqldEvent) String() string {
-	s := fmt.Sprintf(fmt.Sprintf(" PID:%d, Comm:%s, Time:%d,  length:(%d/%d),  return:%s, Line:%s", me.Pid, me.Comm, me.Timestamp, me.Len, me.Alllen, me.Retval, unix.ByteSliceToString((me.Query[:]))))
+	s := fmt.Sprintf(" PID:%d, Comm:%s, Time:%d,  length:(%d/%d),  return:%s, Line:%s", me.Pid, me.Comm, me.Timestamp, me.Len, me.Alllen, me.Retval, unix.ByteSliceToString((me.Query[:])))
 	return s
 }
 
 func (me *MysqldEvent) StringHex() string {
-	s := fmt.Sprintf(fmt.Sprintf(" PID:%d, Comm:%s, Time:%d,  length:(%d/%d),  return:%s, Line:%s", me.Pid, me.Comm, me.Timestamp, me.Len, me.Alllen, me.Retval, unix.ByteSliceToString((me.Query[:]))))
+	s := fmt.Sprintf(" PID:%d, Comm:%s, Time:%d,  length:(%d/%d),  return:%s, Line:%s", me.Pid, me.Comm, me.Timestamp, me.Len, me.Alllen, me.Retval, unix.ByteSliceToString((me.Query[:])))
 	return s
 }
 

--- a/user/event/event_postgres.go
+++ b/user/event/event_postgres.go
@@ -63,12 +63,12 @@ func (pe *PostgresEvent) Decode(payload []byte) (err error) {
 }
 
 func (pe *PostgresEvent) String() string {
-	s := fmt.Sprintf(fmt.Sprintf(" PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:]))))
+	s := fmt.Sprintf(" PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:])))
 	return s
 }
 
 func (pe *PostgresEvent) StringHex() string {
-	s := fmt.Sprintf(fmt.Sprintf(" PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:]))))
+	s := fmt.Sprintf(" PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:])))
 	return s
 }
 


### PR DESCRIPTION
The following usage would printed out confusing message when user controlled input contains special character like "%s".

Query field is controlled by user and may contains special character.

```go
s := fmt.Sprintf(fmt.Sprintf(" PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:]))))
```

**Reproduce**

run the following command in the terminal:
```bash
sudo ./ecapture bash
```
run the following command in another terminal:
```bash
 echo "SELECT * FROM Customers WHERE CustomerName LIKE 'a%'"
```

output:
```bash
bash_2024/02/29 11:26:21 PID:33569, UID:1000, 	Comm:bash, 	Retvalue:0, 	Line:
echo "SELECT * FROM Customers WHERE CustomerName LIKE 'a%!'(MISSING)"
```
