### PR TITLE
add -race flags for `go test` and fix data race warning

### DIFF
--- a/.github/workflows/go-c-cpp.yml
+++ b/.github/workflows/go-c-cpp.yml
@@ -48,7 +48,7 @@ jobs:
           make env
           make nocore
       - name: Test
-        run: go test -v ./...
+        run: go test -v -race ./...
 
   build-on-ubuntu2204:
     runs-on: ubuntu-22.04
@@ -91,7 +91,7 @@ jobs:
           make env
           make nocore
       - name: Test
-        run: go test -v ./...
+        run: go test -v -race ./...
 
   build-on-ubuntu2004-arm64:
     runs-on: ubuntu-22.04

--- a/pkg/event_processor/http_request.go
+++ b/pkg/event_processor/http_request.go
@@ -81,11 +81,10 @@ func (hr *HTTPRequest) detect(payload []byte) error {
 	//hr.Init()
 	rd := bytes.NewReader(payload)
 	buf := bufio.NewReader(rd)
-	req, err := http.ReadRequest(buf)
+	_, err := http.ReadRequest(buf)
 	if err != nil {
 		return err
 	}
-	hr.request = req
 	return nil
 }
 

--- a/pkg/event_processor/http_response.go
+++ b/pkg/event_processor/http_response.go
@@ -97,11 +97,10 @@ func (hr *HTTPResponse) Write(b []byte) (int, error) {
 func (hr *HTTPResponse) detect(payload []byte) error {
 	rd := bytes.NewReader(payload)
 	buf := bufio.NewReader(rd)
-	res, err := http.ReadResponse(buf, nil)
+	_, err := http.ReadResponse(buf, nil)
 	if err != nil {
 		return err
 	}
-	hr.response = res
 	return nil
 }
 

--- a/pkg/event_processor/processor.go
+++ b/pkg/event_processor/processor.go
@@ -115,6 +115,8 @@ func (this *EventProcessor) Write(e event.IEventStruct) {
 }
 
 func (this *EventProcessor) Close() error {
+	this.Lock()
+	defer this.Unlock()
 	if len(this.workerQueue) > 0 {
 		return fmt.Errorf("EventProcessor.Close(): workerQueue is not empty:%d", len(this.workerQueue))
 	}


### PR DESCRIPTION
When add -race to `go test` , several data race warnings are raised.

first one(data race for `workerqueue` in `EventProcessor`):

```bash
WARNING: DATA RACE
Read at 0x00c000098c30 by goroutine 7:
  ecapture/pkg/event_processor.(*EventProcessor).Close()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:118 +0xb04
  ecapture/pkg/event_processor.TestEventProcessor_Serve()
      /home/rtzhong/ecapture/pkg/event_processor/processor_test.go:77 +0xb29
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1742 +0x44

Previous write at 0x00c000098c30 by goroutine 9:
  runtime.mapdelete_faststr()
      /usr/local/go/src/runtime/map_faststr.go:301 +0x0
  ecapture/pkg/event_processor.(*EventProcessor).delWorkerByUUID()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:105 +0xed
  ecapture/pkg/event_processor.(*eventWorker).Close()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:152 +0x99
  ecapture/pkg/event_processor.(*eventWorker).Run()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:134 +0x1e4
  ecapture/pkg/event_processor.NewEventWorker.func1()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:58 +0x2e

Goroutine 7 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:47 +0x2bd

Goroutine 9 (finished) created at:
  ecapture/pkg/event_processor.NewEventWorker()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:57 +0x11c
  ecapture/pkg/event_processor.(*EventProcessor).dispatch()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:68 +0x86
  ecapture/pkg/event_processor.(*EventProcessor).Serve()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:57 +0x65
  ecapture/pkg/event_processor.TestEventProcessor_Serve.func1()
      /home/rtzhong/ecapture/pkg/event_processor/processor_test.go:46 +0x25
```

the second one (data race HttpRequest and HttpResponse but they are benign data race):
```bash
WARNING: DATA RACE
Write at 0x00c000078100 by goroutine 13:
  ecapture/pkg/event_processor.(*HTTPRequest).detect()
      /home/rtzhong/ecapture/pkg/event_processor/http_request.go:88 +0x1f2
  ecapture/pkg/event_processor.NewParser()
      /home/rtzhong/ecapture/pkg/event_processor/iparser.go:89 +0x22d
  ecapture/pkg/event_processor.(*eventWorker).parserEvents()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:117 +0xf1
  ecapture/pkg/event_processor.(*eventWorker).Display()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:86 +0x3e
  ecapture/pkg/event_processor.(*eventWorker).Close()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:150 +0x67
  ecapture/pkg/event_processor.(*eventWorker).Run()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:134 +0x1e4
  ecapture/pkg/event_processor.NewEventWorker.func1()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:58 +0x2e

Previous write at 0x00c000078100 by goroutine 9:
  ecapture/pkg/event_processor.(*HTTPRequest).detect()
      /home/rtzhong/ecapture/pkg/event_processor/http_request.go:88 +0x1f2
  ecapture/pkg/event_processor.NewParser()
      /home/rtzhong/ecapture/pkg/event_processor/iparser.go:89 +0x22d
  ecapture/pkg/event_processor.(*eventWorker).parserEvents()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:117 +0xf1
  ecapture/pkg/event_processor.(*eventWorker).Display()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:86 +0x3e
  ecapture/pkg/event_processor.(*eventWorker).Close()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:150 +0x67
  ecapture/pkg/event_processor.(*eventWorker).Run()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:134 +0x1e4
  ecapture/pkg/event_processor.NewEventWorker.func1()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:58 +0x2e

Goroutine 13 (running) created at:
  ecapture/pkg/event_processor.NewEventWorker()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:57 +0x11c
  ecapture/pkg/event_processor.(*EventProcessor).dispatch()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:68 +0x86
  ecapture/pkg/event_processor.(*EventProcessor).Serve()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:57 +0x65
  ecapture/pkg/event_processor.TestEventProcessor_Serve.func1()
      /home/rtzhong/ecapture/pkg/event_processor/processor_test.go:46 +0x25

Goroutine 9 (running) created at:
  ecapture/pkg/event_processor.NewEventWorker()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:57 +0x11c
  ecapture/pkg/event_processor.(*EventProcessor).dispatch()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:68 +0x86
  ecapture/pkg/event_processor.(*EventProcessor).Serve()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:57 +0x65
  ecapture/pkg/event_processor.TestEventProcessor_Serve.func1()
      /home/rtzhong/ecapture/pkg/event_processor/processor_test.go:46 +0x25
==================
==================
WARNING: DATA RACE
Write at 0x00c0000162c0 by goroutine 10:
  ecapture/pkg/event_processor.(*HTTPResponse).detect()
      /home/rtzhong/ecapture/pkg/event_processor/http_response.go:104 +0x1f8
  ecapture/pkg/event_processor.NewParser()
      /home/rtzhong/ecapture/pkg/event_processor/iparser.go:89 +0x22d
  ecapture/pkg/event_processor.(*eventWorker).parserEvents()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:117 +0xf1
  ecapture/pkg/event_processor.(*eventWorker).Display()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:86 +0x3e
  ecapture/pkg/event_processor.(*eventWorker).Close()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:150 +0x67
  ecapture/pkg/event_processor.(*eventWorker).Run()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:134 +0x1e4
  ecapture/pkg/event_processor.NewEventWorker.func1()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:58 +0x2e

Previous write at 0x00c0000162c0 by goroutine 12:
  ecapture/pkg/event_processor.(*HTTPResponse).detect()
      /home/rtzhong/ecapture/pkg/event_processor/http_response.go:104 +0x1f8
  ecapture/pkg/event_processor.NewParser()
      /home/rtzhong/ecapture/pkg/event_processor/iparser.go:89 +0x22d
  ecapture/pkg/event_processor.(*eventWorker).parserEvents()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:117 +0xf1
  ecapture/pkg/event_processor.(*eventWorker).Display()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:86 +0x3e
  ecapture/pkg/event_processor.(*eventWorker).Close()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:150 +0x67
  ecapture/pkg/event_processor.(*eventWorker).Run()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:134 +0x1e4
  ecapture/pkg/event_processor.NewEventWorker.func1()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:58 +0x2e

Goroutine 10 (running) created at:
  ecapture/pkg/event_processor.NewEventWorker()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:57 +0x11c
  ecapture/pkg/event_processor.(*EventProcessor).dispatch()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:68 +0x86
  ecapture/pkg/event_processor.(*EventProcessor).Serve()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:57 +0x65
  ecapture/pkg/event_processor.TestEventProcessor_Serve.func1()
      /home/rtzhong/ecapture/pkg/event_processor/processor_test.go:46 +0x25

Goroutine 12 (running) created at:
  ecapture/pkg/event_processor.NewEventWorker()
      /home/rtzhong/ecapture/pkg/event_processor/iworker.go:57 +0x11c
  ecapture/pkg/event_processor.(*EventProcessor).dispatch()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:68 +0x86
  ecapture/pkg/event_processor.(*EventProcessor).Serve()
      /home/rtzhong/ecapture/pkg/event_processor/processor.go:57 +0x65
  ecapture/pkg/event_processor.TestEventProcessor_Serve.func1()
      /home/rtzhong/ecapture/pkg/event_processor/processor_test.go:46 +0x25

```