### PR TITLE
fix #500 to avoid potential hang and event loss

### DIFF
--- a/pkg/event_processor/iworker.go
+++ b/pkg/event_processor/iworker.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"ecapture/user/event"
 	"encoding/hex"
+	"runtime"
 	"sync/atomic"
 	"time"
 )
@@ -165,6 +166,7 @@ func (ew *eventWorker) Run() {
 						ew.writeEvent(e)
 					default:
 						if ew.IfUsed() {
+							time.Sleep(10 * time.Millisecond)
 							continue
 						}
 						ew.Close()

--- a/pkg/event_processor/iworker.go
+++ b/pkg/event_processor/iworker.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"ecapture/user/event"
 	"encoding/hex"
+	"sync/atomic"
 	"time"
 )
 
@@ -30,6 +31,9 @@ type IWorker interface {
 	// 收包
 	Write(event.IEventStruct) error
 	GetUUID() string
+	IfUsed() bool
+	Get()
+	Put()
 }
 
 const (
@@ -49,6 +53,7 @@ type eventWorker struct {
 	processor   *EventProcessor
 	parser      IParser
 	payload     *bytes.Buffer
+	used        atomic.Bool
 }
 
 func NewEventWorker(uuid string, processor *EventProcessor) IWorker {
@@ -127,12 +132,43 @@ func (ew *eventWorker) parserEvents() []byte {
 func (ew *eventWorker) Run() {
 	for {
 		select {
-		case _ = <-ew.ticker.C:
+		case <-ew.ticker.C:
 			// 输出包
 			if ew.tickerCount > MaxTickerCount {
 				//ew.processor.GetLogger().Printf("eventWorker TickerCount > %d, event closed.", MaxTickerCount)
 				ew.Close()
-				return
+				/*
+					When returned from ew.Close(), there are two possiblities:
+					1) no routine can touch it.
+					2) one routine can still touch ew because getWorkerByUUID()
+					*happen before* ew.Close()
+
+					When no routine can touch it (i.e.,ew.IfUsed == false),
+					we just drain the ew.incoming and return.
+
+					When one routine can touch it (i.e.,ew.IfUsed == true), we ensure
+					that we only return after the routine can not touch it
+					(i.e.,ew.IfUsed == false). At this point, we can ensure that no
+					other routine will touch it and send events through the ew.incoming.
+					So, we return.
+
+					Because eworker has been deleted from workqueue after ew.Close()
+					(ordered by a workqueue lock), at this point, we can ensure that
+					no ew will not be touched even **in the future**. So the return is
+					safe.
+
+				*/
+				for {
+					select {
+					case e := <-ew.incoming:
+						ew.writeEvent(e)
+					default:
+						if ew.IfUsed() {
+							continue
+						}
+						return
+					}
+				}
 			}
 			ew.tickerCount++
 		case e := <-ew.incoming:
@@ -150,4 +186,22 @@ func (ew *eventWorker) Close() {
 	ew.Display()
 	ew.tickerCount = 0
 	ew.processor.delWorkerByUUID(ew)
+}
+
+func (ew *eventWorker) Get() {
+	if !ew.used.CompareAndSwap(false, true) {
+		panic("unexpected behavior and incorrect usage for eventWorker")
+	}
+}
+
+func (ew *eventWorker) Put() {
+	if !ew.used.CompareAndSwap(true, false) {
+		panic("unexpected behavior and incorrect usage for eventWorker")
+	}
+
+}
+
+func (ew *eventWorker) IfUsed() bool {
+
+	return ew.used.Load()
 }

--- a/pkg/event_processor/iworker.go
+++ b/pkg/event_processor/iworker.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"ecapture/user/event"
 	"encoding/hex"
-	"runtime"
 	"sync/atomic"
 	"time"
 )

--- a/pkg/event_processor/processor.go
+++ b/pkg/event_processor/processor.go
@@ -70,6 +70,7 @@ func (this *EventProcessor) dispatch(e event.IEventStruct) {
 	}
 
 	err := eWorker.Write(e)
+	eWorker.Put() // never touch eWorker again
 	if err != nil {
 		//...
 		this.GetLogger().Fatalf("write event failed , error:%v", err)
@@ -89,6 +90,7 @@ func (this *EventProcessor) getWorkerByUUID(uuid string) (bool, IWorker) {
 	if !found {
 		return false, eWorker
 	}
+	eWorker.Get()
 	return true, eWorker
 }
 
@@ -96,6 +98,7 @@ func (this *EventProcessor) addWorkerByUUID(worker IWorker) {
 	this.Lock()
 	defer this.Unlock()
 	this.workerQueue[worker.GetUUID()] = worker
+	worker.Get()
 }
 
 // 每个worker调用该方法，从处理器中删除自己

--- a/pkg/event_processor/processor_test.go
+++ b/pkg/event_processor/processor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -70,10 +71,11 @@ func TestEventProcessor_Serve(t *testing.T) {
 		ep.Write(&BaseEvent{Data_len: eventSSL.Data_len, Data: eventSSL.Data, DataType: eventSSL.DataType, Timestamp: eventSSL.Timestamp, Pid: eventSSL.Pid, Tid: eventSSL.Tid, Comm: eventSSL.Comm, Fd: eventSSL.Fd, Version: eventSSL.Version})
 	}
 
-	tick := time.NewTicker(time.Second * 3)
+	tick := time.NewTicker(time.Second * 10)
 	<-tick.C
 
 	err = ep.Close()
+	logger.SetOutput(io.Discard)
 	lines = strings.Split(buf.String(), "\n")
 	ok := true
 	for _, line := range lines {


### PR DESCRIPTION
* add `IfUsed()` for worker to check if it is used.
* add `Get()` for  routine that generates event before using the worker and `Put()` when after using the worker. They should not be called concurently(only one producer). So it panics if unexpected behavior happen. 
* add clean up logic for ew.incoming and return only after both the ew.incoming is empty and  ew is not used. 

The reasoning for that is as follows.

When returned from ew.Close(), there are two possiblities:
1) no routine can touch it.
2) one routine can still touch ew because getWorkerByUUID()
**happen before** ew.Close()

When no routine can touch it (i.e.,ew.IfUsed == false),
we just drain the ew.incoming and return.

When one routine can touch it (i.e.,ew.IfUsed == true), we ensure
that we only return after the routine can not touch it
(i.e.,ew.IfUsed == false). At this point, we can ensure that no
other routine will touch it and send events through the ew.incoming.
So, we return.

Because eworker has been deleted from workqueue after ew.Close()
(ordered by a workqueue lock), at this point, we can ensure that
no ew will not be touched even **in the future**. So the return is
safe.

Finally, to verify it, in https://github.com/ruitianzhong/ecapture/commit/e5bce57a5b97425383ba12ee41b56f433caaa8aa , run `go test  -v ./pkg/event_processor/  -run TestHang ` , no hang happened.

Because the `poc` inject delay to reliably reproduce the hang, I do not add it as a unit test in bug-fix branch.

