### PR TITLE
Fix bash module v2

### DIFF
--- a/cli/cmd/bash.go
+++ b/cli/cmd/bash.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"ecapture/user/config"
 	"ecapture/user/module"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/spf13/cobra"
 )
 
 var bc = config.NewBashConfig()
@@ -58,7 +59,7 @@ func bashCommandFunc(command *cobra.Command, args []string) {
 	stopper := make(chan os.Signal, 1)
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 	ctx, cancelFun := context.WithCancel(context.TODO())
-
+	ctx = context.WithValue(ctx, config.CONTEXT_KEY_MODULE_NAME, module.ModuleNameBash)
 	mod := module.GetModuleByName(module.ModuleNameBash)
 
 	logger := log.New(os.Stdout, "bash_", log.LstdFlags)

--- a/cli/cmd/gnutls.go
+++ b/cli/cmd/gnutls.go
@@ -58,7 +58,7 @@ func gnuTlsCommandFunc(command *cobra.Command, args []string) {
 	stopper := make(chan os.Signal, 1)
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 	ctx, cancelFun := context.WithCancel(context.TODO())
-
+	ctx = context.WithValue(ctx, config.CONTEXT_KEY_MODULE_NAME, module.ModuleNameGnutls)
 	logger := log.New(os.Stdout, "tls_", log.LstdFlags)
 
 	// save global config

--- a/cli/cmd/mysqld.go
+++ b/cli/cmd/mysqld.go
@@ -53,7 +53,7 @@ func mysqldCommandFunc(command *cobra.Command, args []string) {
 	stopper := make(chan os.Signal, 1)
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 	ctx, cancelFun := context.WithCancel(context.TODO())
-
+	ctx = context.WithValue(ctx, config.CONTEXT_KEY_MODULE_NAME, module.ModuleNameMysqld)
 	mod := module.GetModuleByName(module.ModuleNameMysqld)
 
 	logger := log.New(os.Stdout, "mysqld_", log.LstdFlags)

--- a/cli/cmd/nss.go
+++ b/cli/cmd/nss.go
@@ -58,7 +58,7 @@ func nssCommandFunc(command *cobra.Command, args []string) {
 	stopper := make(chan os.Signal, 1)
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 	ctx, cancelFun := context.WithCancel(context.TODO())
-
+	ctx = context.WithValue(ctx, config.CONTEXT_KEY_MODULE_NAME, module.ModuleNameNspr)
 	logger := log.New(os.Stdout, "tls_", log.LstdFlags)
 
 	// save global config

--- a/cli/cmd/postgres.go
+++ b/cli/cmd/postgres.go
@@ -49,7 +49,7 @@ func postgresCommandFunc(command *cobra.Command, args []string) {
 	stopper := make(chan os.Signal, 1)
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 	ctx, cancelFun := context.WithCancel(context.TODO())
-
+	ctx = context.WithValue(ctx, config.CONTEXT_KEY_MODULE_NAME, module.ModuleNamePostgres)
 	mod := module.GetModuleByName(module.ModuleNamePostgres)
 
 	logger := log.New(os.Stdout, "postgress_", log.LstdFlags)

--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -72,7 +72,7 @@ func openSSLCommandFunc(command *cobra.Command, args []string) {
 	stopper := make(chan os.Signal, 1)
 	signal.Notify(stopper, os.Interrupt, syscall.SIGTERM)
 	ctx, cancelFun := context.WithCancel(context.TODO())
-
+	ctx = context.WithValue(ctx, config.CONTEXT_KEY_MODULE_NAME, module.ModuleNameOpenssl)
 	logger := log.New(os.Stdout, "tls_", log.LstdFlags)
 
 	// save global config

--- a/kern/bash_kern.c
+++ b/kern/bash_kern.c
@@ -15,6 +15,7 @@
 #include "ecapture.h"
 
 struct event {
+    u32 type;
     u32 pid;
     u32 uid;
     u8 line[MAX_DATA_SIZE_BASH];
@@ -32,9 +33,9 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, u32);
-    __type(value, struct event);
+    __type(value, u32);
     __uint(max_entries, 1024);
-} events_t SEC(".maps");
+} pid_temp SEC(".maps");
 // Force emitting struct event into the ELF.
 const struct event *unused __attribute__((unused));
 
@@ -55,15 +56,19 @@ int uretprobe_bash_readline(struct pt_regs *ctx) {
     }
 #endif
 
-    struct event event = {};
-    event.pid = pid;
-    event.uid = uid;
+    struct event event = {
+        .type = BASH_EVENT_TYPE_READLINE,
+        .pid = pid,
+        .uid = uid,
+        .retval = 0,
+    };
     // bpf_printk("!! uretprobe_bash_readline pid:%d",target_pid );
     bpf_probe_read_user(&event.line, sizeof(event.line),
                         (void *)PT_REGS_RC(ctx));
     bpf_get_current_comm(&event.comm, sizeof(event.comm));
-    bpf_map_update_elem(&events_t, &pid, &event, BPF_ANY);
-
+    bpf_map_update_elem(&pid_temp, &pid, &pid, BPF_ANY);
+    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event,
+                          sizeof(struct event));
     return 0;
 }
 SEC("uretprobe/bash_retval")
@@ -84,22 +89,19 @@ int uretprobe_bash_retval(struct pt_regs *ctx) {
     }
 #endif
 
-    struct event *event_p = bpf_map_lookup_elem(&events_t, &pid);
-
-#ifndef KERNEL_LESS_5_2
-    // if target_errno is 128 then we target all
-    if (target_errno != BASH_ERRNO_DEFAULT && target_errno != retval) {
-        if (event_p) bpf_map_delete_elem(&events_t, &pid);
-        return 0;
-    }
-#endif
-
-    if (event_p) {
-        event_p->retval = retval;
-        //        bpf_map_update_elem(&events_t, &pid, event_p, BPF_ANY);
-        bpf_map_delete_elem(&events_t, &pid);
-        bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event_p,
+    u32 *pid_p = bpf_map_lookup_elem(&pid_temp, &pid);
+    if (pid_p) {
+        struct event event_p = {
+            .type = BASH_EVENT_TYPE_RETVAL,
+            .pid = pid,
+            .uid = uid,
+            .retval = retval,
+        };
+        bpf_get_current_comm(&event_p.comm, sizeof(event_p.comm));
+        bpf_map_delete_elem(&pid_temp, &pid);
+        bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event_p,
                               sizeof(struct event));
     }
+
     return 0;
 }

--- a/kern/common.h
+++ b/kern/common.h
@@ -41,6 +41,9 @@
 #define SA_DATA_LEN 14
 #define BASH_ERRNO_DEFAULT 128
 
+#define BASH_EVENT_TYPE_READLINE 0
+#define BASH_EVENT_TYPE_RETVAL 1
+
 ///////// for TC & XDP ebpf programs in tc.h
 #define TC_ACT_OK 0
 #define ETH_P_IP 0x0800 /* Internet Protocol packet        */

--- a/pkg/event_processor/bash_parser.go
+++ b/pkg/event_processor/bash_parser.go
@@ -1,0 +1,62 @@
+package event_processor
+
+import (
+	"context"
+	"ecapture/user/config"
+	"errors"
+
+	"golang.org/x/sys/unix"
+)
+
+type BashParser struct {
+	line   string
+	isdone bool
+}
+
+func (b *BashParser) Display() []byte {
+	return []byte("Line: " + b.line)
+}
+
+func (b *BashParser) Init() {
+	b.isdone = false
+	b.line = ""
+}
+
+func (b *BashParser) IsDone() bool {
+	return b.isdone
+}
+
+func (b *BashParser) Name() string {
+	return "BashParser"
+}
+
+func (b *BashParser) PacketType() PacketType {
+	return PacketTypeBash
+}
+
+func (b *BashParser) ParserType() ParserType {
+	return ParserTypeBash
+}
+
+func (b *BashParser) Reset() {
+	b.isdone = false
+	b.line = ""
+}
+
+func (bp *BashParser) Write(b []byte) (int, error) {
+	bp.line += unix.ByteSliceToString((b[:]))
+	return len(bp.line), nil
+}
+
+func (bp *BashParser) detect(ctx context.Context, b []byte) error {
+	if ctx.Value(config.CONTEXT_KEY_MODULE_NAME) == "EBPFProbeBash" {
+		return nil
+	}
+	return errors.New("event is not about bash")
+}
+
+func init() {
+	be := &BashParser{}
+	be.Init()
+	Register(be)
+}

--- a/pkg/event_processor/http_request.go
+++ b/pkg/event_processor/http_request.go
@@ -17,6 +17,7 @@ package event_processor
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -24,7 +25,7 @@ import (
 
 type HTTPRequest struct {
 	request    *http.Request
-	packerType PacketType
+	packetType PacketType
 	isDone     bool
 	isInit     bool
 	reader     *bytes.Buffer
@@ -41,7 +42,7 @@ func (hr *HTTPRequest) Name() string {
 }
 
 func (hr *HTTPRequest) PacketType() PacketType {
-	return hr.packerType
+	return hr.packetType
 }
 
 func (hr *HTTPRequest) ParserType() ParserType {
@@ -77,7 +78,7 @@ func (hr *HTTPRequest) Write(b []byte) (int, error) {
 	return l, nil
 }
 
-func (hr *HTTPRequest) detect(payload []byte) error {
+func (hr *HTTPRequest) detect(ctx context.Context, payload []byte) error {
 	//hr.Init()
 	rd := bytes.NewReader(payload)
 	buf := bufio.NewReader(rd)

--- a/pkg/event_processor/http_response.go
+++ b/pkg/event_processor/http_response.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"log"
@@ -30,7 +31,7 @@ const HTTP_NEW_LINE_LENGTH = 4
 
 type HTTPResponse struct {
 	response     *http.Response
-	packerType   PacketType
+	packetType   PacketType
 	isDone       bool
 	receivedLen  int64
 	headerLength int64
@@ -51,7 +52,7 @@ func (hr *HTTPResponse) Name() string {
 }
 
 func (hr *HTTPResponse) PacketType() PacketType {
-	return hr.packerType
+	return hr.packetType
 }
 
 func (hr *HTTPResponse) ParserType() ParserType {
@@ -94,7 +95,7 @@ func (hr *HTTPResponse) Write(b []byte) (int, error) {
 	return l, nil
 }
 
-func (hr *HTTPResponse) detect(payload []byte) error {
+func (hr *HTTPResponse) detect(ctx context.Context, payload []byte) error {
 	rd := bytes.NewReader(payload)
 	buf := bufio.NewReader(rd)
 	_, err := http.ReadResponse(buf, nil)
@@ -134,11 +135,11 @@ func (hr *HTTPResponse) Display() []byte {
 		hr.response.Body = io.NopCloser(bytes.NewReader(gbuf))
 		// gzip uncompressed success
 		hr.response.ContentLength = int64(len(gbuf))
-		hr.packerType = PacketTypeGzip
+		hr.packetType = PacketTypeGzip
 		defer reader.Close()
 	default:
 		//reader = hr.response.Body
-		hr.packerType = PacketTypeNull
+		hr.packetType = PacketTypeNull
 		//TODO for debug
 		//return []byte("")
 	}

--- a/pkg/event_processor/processor_test.go
+++ b/pkg/event_processor/processor_test.go
@@ -2,6 +2,7 @@ package event_processor
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -41,7 +42,7 @@ func TestEventProcessor_Serve(t *testing.T) {
 		}
 		logger.SetOutput(f)
 	*/
-	ep := NewEventProcessor(logger, true)
+	ep := NewEventProcessor(context.Background(), logger, true)
 
 	go func() {
 		ep.Serve()

--- a/user/config/const.go
+++ b/user/config/const.go
@@ -18,3 +18,8 @@ const (
 	ElfTypeBin uint8 = 1
 	ElfTypeSo  uint8 = 2
 )
+
+// context info
+type contextKey string
+
+const CONTEXT_KEY_MODULE_NAME contextKey = "module_name"

--- a/user/event/event_bash.go
+++ b/user/event/event_bash.go
@@ -18,21 +18,25 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"strings"
 
 	"golang.org/x/sys/unix"
 )
 
 /*
- u32 pid;
- u8 line[MAX_DATE_SIZE_BASH];
- u32 Retval;
- char Comm[TASK_COMM_LEN];
+  u32 type;
+  u32 pid;
+  u32 uid;
+  u8 line[MAX_DATA_SIZE_BASH];
+  u32 retval;
+  char comm[TASK_COMM_LEN];
 */
 
 const MaxDataSizeBash = 256
 
 type BashEvent struct {
 	eventType EventType
+	Type      uint32                 `json:"type"`
 	Pid       uint32                 `json:"pid"`
 	Uid       uint32                 `json:"uid"`
 	Line      [MaxDataSizeBash]uint8 `json:"line"`
@@ -42,6 +46,9 @@ type BashEvent struct {
 
 func (be *BashEvent) Decode(payload []byte) (err error) {
 	buf := bytes.NewBuffer(payload)
+	if err = binary.Read(buf, binary.LittleEndian, &be.Type); err != nil {
+		return
+	}
 	if err = binary.Read(buf, binary.LittleEndian, &be.Pid); err != nil {
 		return
 	}
@@ -57,23 +64,22 @@ func (be *BashEvent) Decode(payload []byte) (err error) {
 	if err = binary.Read(buf, binary.LittleEndian, &be.Comm); err != nil {
 		return
 	}
-
 	return nil
 }
 
 func (be *BashEvent) String() string {
-	s := fmt.Sprintf("PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s", be.Pid, be.Uid, be.Comm, be.Retval, unix.ByteSliceToString((be.Line[:])))
+	s := fmt.Sprintf("TYPE:%d, PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s", be.Type, be.Pid, be.Uid, be.Comm, be.Retval, unix.ByteSliceToString((be.Line[:])))
 	return s
 }
 
 func (be *BashEvent) StringHex() string {
-	s := fmt.Sprintf("PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s,", be.Pid, be.Uid, be.Comm, be.Retval, dumpByteSlice([]byte(unix.ByteSliceToString((be.Line[:]))), ""))
+	s := fmt.Sprintf("TYPE:%d, PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s,", be.Type, be.Pid, be.Uid, be.Comm, be.Retval, dumpByteSlice([]byte(unix.ByteSliceToString((be.Line[:]))), ""))
 	return s
 }
 
 func (be *BashEvent) Clone() IEventStruct {
 	event := new(BashEvent)
-	event.eventType = EventTypeOutput
+	event.eventType = EventTypeEventProcessor
 	return event
 }
 
@@ -86,9 +92,18 @@ func (be *BashEvent) GetUUID() string {
 }
 
 func (be *BashEvent) Payload() []byte {
-	return be.Line[:]
+	if be.Type == 1 {
+		//RETVAL
+		return []byte("Retval: " + fmt.Sprint(be.Retval))
+	}
+	return []byte(unix.ByteSliceToString((be.Line[:])) + "\n")
 }
 
 func (be *BashEvent) PayloadLen() int {
+	line := strings.TrimSpace(unix.ByteSliceToString((be.Line[:])))
+	if be.Type == 1 || strings.HasPrefix(line, "exit") || strings.HasPrefix(line, "exec") {
+		//向eventworker传递立即输出信号
+		return 0
+	}
 	return len(be.Line)
 }

--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -22,11 +22,12 @@ import (
 	"ecapture/user/event"
 	"errors"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/perf"
 	"github.com/cilium/ebpf/ringbuf"
-	"log"
-	"strings"
 )
 
 type IModule interface {
@@ -83,7 +84,7 @@ type Module struct {
 func (m *Module) Init(ctx context.Context, logger *log.Logger, conf config.IConfig) {
 	m.ctx = ctx
 	m.logger = logger
-	m.processor = event_processor.NewEventProcessor(logger, conf.GetHex())
+	m.processor = event_processor.NewEventProcessor(ctx, logger, conf.GetHex())
 	m.isKernelLess5_2 = false //set false default
 	kv, _ := kernel.HostVersion()
 	// it's safe to ignore err because we have checked it in main funcition


### PR DESCRIPTION
Fix https://github.com/gojue/ecapture/issues/490.
in this PR:

- The BPF program in kernel space merely sends the collected data to user space.
- Change bashEvent.eventType from EventTypeOutput to EventTypeEventProcessor.
- Add context information about the Module name.
- Implement a bash IParser.
- Fix some typo.
