### PR TITLE
fix: amd64, offset read error issue for PIE executable. PR #516

### DIFF
--- a/user/config/config_gotls.go
+++ b/user/config/config_gotls.go
@@ -340,7 +340,7 @@ func (gc *GoTLSConfig) findRetOffsetsPie(lfunc string) ([]int, error) {
 			continue
 		}
 		data := make([]byte, funcLen)
-		_, err = prog.ReadAt(data, int64(address))
+		_, err = prog.ReadAt(data, int64(address-prog.Vaddr))
 		if err != nil {
 			return offsets, fmt.Errorf("finding function return: %w", err)
 		}


### PR DESCRIPTION
fix  PR  #516

On amd64, when the executable program in PIE format compiled by golang reads the return instruction of the function, the start address of inst is incorrect, resulting in an exception, see PR #516 for details.


ref: https://github.com/golang/go/blob/bdd27c4debfb51fe42df0c0532c1c747777b7a32/src/cmd/internal/objfile/elf.go#L175