### PR TITLE
makefile: used CC=$(CROSS_COMPILE)gcc for CGO compile.

### DIFF
--- a/.github/workflows/go-c-cpp.yml
+++ b/.github/workflows/go-c-cpp.yml
@@ -155,7 +155,7 @@ jobs:
           install: |
             uname -a
             apt-get update
-            apt-get install --yes wget git build-essential pkgconf libelf-dev llvm-12 clang-12  linux-tools-generic linux-tools-common flex bison
+            apt-get install --yes wget git build-essential pkgconf libelf-dev llvm-12 clang-12  linux-tools-generic linux-tools-common flex bison file
             wget https://go.dev/dl/go1.21.0.linux-arm64.tar.gz
             rm -rf /usr/local/go
             tar -C /usr/local -xzf go1.21.0.linux-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           install: |
             uname -a
             apt-get update
-            apt-get install --yes wget git build-essential pkgconf libelf-dev llvm-12 clang-12  linux-tools-generic linux-tools-common flex bison
+            apt-get install --yes wget git build-essential pkgconf libelf-dev llvm-12 clang-12  linux-tools-generic linux-tools-common flex bison file
             wget https://go.dev/dl/go1.21.0.linux-arm64.tar.gz
             rm -rf /usr/local/go
             tar -C /usr/local -xzf go1.21.0.linux-arm64.tar.gz

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ make nocore
 bin/ecapture --help
 ```
 
+## cross-compiltion (eBPF CO-RE model supported only)
+To build an `arm64` artifact on an ubuntu `amd64` system, you can set the `CROSS_ARCH` environment variable to achieve cross-compilation.
+```shell
+CROSS_ARCH=arm64 make
+```
 
 ## Stargazers over time
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -215,6 +215,11 @@ cd ecapture
 make nocore
 bin/ecapture
 ```
+## 交叉编译 (仅限eBPF CO-RE模式)
+要在ubuntu `amd64` 系统上构建 `arm64`的产物，您可以设置 `CROSS_ARCH`环境变量来实现交叉编译。
+```shell
+CROSS_ARCH=arm64 make
+```
 
 ## Stargazers over time
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -168,6 +168,11 @@ make nocore
 bin/ecapture --help
 ```
 
+## クロスコンパイル（eBPF CO-REモードのみ）
+Ubuntuの `amd64` システムで `arm64` の成果物をビルドするには、`CROSS_ARCH`環境変数を設定してクロスコンパイルを実行できます。
+```shell
+CROSS_ARCH=arm64 make
+```
 ## Stargazers over time
 
 [![Stargazers over time](https://starchart.cc/gojue/ecapture.svg)](https://starchart.cc/gojue/ecapture)

--- a/functions.mk
+++ b/functions.mk
@@ -45,11 +45,10 @@ define allow-override
 endef
 
 define gobuild
+	CGO_ENABLED=1 \
 	CGO_CFLAGS='-O2 -g -gdwarf-4 -I$(CURDIR)/lib/libpcap/' \
-	CGO_LDFLAGS='-O2 -g -L$(CURDIR)/lib/libpcap -lpcap -static' \
-	GOOS=linux GOARCH=$(GOARCH) CC=$(CMD_CLANG) \
-	$(CMD_GO) build -tags $(TARGET_TAG) -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=$(TARGET_TAG)_$(UNAME_M):$(VERSION):$(VERSION_FLAG)' -X 'main.enableCORE=$(ENABLECORE)'" -o $(OUT_BIN)
-    @if [$(1) -eq 0 ]; then
-		$(OUT_BIN) -v
-    fi
+	CGO_LDFLAGS='-O2 -g -L$(CURDIR)/lib/libpcap/ -lpcap -static' \
+	GOOS=linux GOARCH=$(GOARCH) CC=$(CROSS_COMPILE)gcc \
+	$(CMD_GO) build -tags $(TARGET_TAG) -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=$(TARGET_TAG)_$(GOARCH):$(VERSION):$(VERSION_FLAG)' -X 'main.enableCORE=$(ENABLECORE)' -linkmode=external -extldflags -static " -o $(OUT_BIN)
+	$(CMD_FILE) $(OUT_BIN)
 endef

--- a/variables.mk
+++ b/variables.mk
@@ -4,6 +4,7 @@ CMD_TR ?= tr
 CMD_CUT ?= cut
 CMD_AWK ?= awk
 CMD_SED ?= sed
+CMD_FILE ?= file
 CMD_GIT ?= git
 CMD_CLANG ?= clang
 CMD_GCC ?= gcc
@@ -151,6 +152,7 @@ ifeq ($(TARGET_ARCH),aarch64)
 	 GOARCH = arm64
 	 AUTOGENCMD = ls -al kern/bpf/arm64/vmlinux.h
 	 BPFHEADER += -I ./kern/bpf/arm64
+	 # sh lib/libpcap/config.sub arm64-linux for ARCH value
 	 LIBPCAP_ARCH = aarch64-unknown-linux-gnu
 else
 	# x86_64 default
@@ -158,7 +160,8 @@ else
 	GOARCH = amd64
 	BPFHEADER += -I ./kern/bpf/x86
 	AUTOGENCMD = test -f kern/bpf/x86/vmlinux.h || $(CMD_BPFTOOL) btf dump file /sys/kernel/btf/vmlinux format c > kern/bpf/x86/vmlinux.h
-	LIBPCAP_ARCH = x86_64-unknown-linux-gnu
+	 # sh lib/libpcap/config.sub amd64-linux or x86_64-linux for ARCH value
+	LIBPCAP_ARCH = x86_64-pc-linux-gnu
 endif
 
 #


### PR DESCRIPTION
Fix bug that prevents compiling `jschwinger233/elibpcap` package during cross-compilation.

#### arm64 ubuntu 22.04
```shell
/home/cfc4n/project/ecapture $ CROSS_ARCH=amd64 make
make[1]: Leaving directory '/home/cfc4n/project/ecapture/lib/libpcap'
CGO_CFLAGS='-O2 -g -gdwarf-4 -I/home/cfc4n/project/ecapture/lib/libpcap/' CGO_LDFLAGS='-O2 -g -L/home/cfc4n/project/ecapture/lib/libpcap/ -lpcap -static' GOOS=linux GOARCH=amd64 CC=clang go build -tags linux -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=linux_amd64:0.7.5-20240303-bfb4a8c:[CORE]' -X 'main.enableCORE=true' " -o bin/ecapture
file bin/ecapture
# github.com/jschwinger233/elibpcap
../../go/pkg/mod/github.com/jschwinger233/elibpcap@v0.0.0-20231010035657-e99300096f5e/elibpcap.go:25:22: undefined: CompileEbpf
bin/ecapture: cannot open `bin/ecapture' (No such file or directory)
```


#### Fixed
```shell
/home/cfc4n/project/ecapture $ CROSS_ARCH=amd64 make
make[1]: Leaving directory '/home/cfc4n/project/ecapture/lib/libpcap'
CGO_ENABLED=1 CGO_CFLAGS='-O2 -g -gdwarf-4 -I/home/cfc4n/project/ecapture/lib/libpcap/' CGO_LDFLAGS='-O2 -g -L/home/cfc4n/project/ecapture/lib/libpcap/ -lpcap -static' GOOS=linux GOARCH=amd64 CC=x86_64-linux-gnu-gcc go build -tags linux -ldflags "-w -s -X 'ecapture/cli/cmd.GitVersion=linux_amd64:0.7.5-20240303-bfb4a8c:[CORE]' -X 'main.enableCORE=true' -linkmode=external -extldflags -static " -o bin/ecapture
file bin/ecapture
# ecapture
/usr/lib/gcc-cross/x86_64-linux-gnu/11/../../../../x86_64-linux-gnu/bin/ld: /tmp/go-link-3421481706/000004.o: in function `_cgo_9c8efe9babca_C2func_getaddrinfo':
/tmp/go-build/cgo-gcc-prolog:58: warning: Using 'getaddrinfo' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/gcc-cross/x86_64-linux-gnu/11/../../../../x86_64-linux-gnu/bin/ld: /home/cfc4n/project/ecapture/lib/libpcap//libpcap.a(nametoaddr.o): in function `pcap_nametoaddr':
/home/cfc4n/project/ecapture/lib/libpcap/./nametoaddr.c:181: warning: Using 'gethostbyname' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/gcc-cross/x86_64-linux-gnu/11/../../../../x86_64-linux-gnu/bin/ld: /home/cfc4n/project/ecapture/lib/libpcap//libpcap.a(nametoaddr.o): in function `pcap_nametonetaddr':
/home/cfc4n/project/ecapture/lib/libpcap/./nametoaddr.c:270: warning: Using 'getnetbyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/lib/gcc-cross/x86_64-linux-gnu/11/../../../../x86_64-linux-gnu/bin/ld: /home/cfc4n/project/ecapture/lib/libpcap//libpcap.a(nametoaddr.o): in function `pcap_nametoproto':
/home/cfc4n/project/ecapture/lib/libpcap/./nametoaddr.c:527: warning: Using 'getprotobyname_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
bin/ecapture: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, BuildID[sha1]=048ccf5df926a5aabc7f99c59b33867063b9a2ca, for GNU/Linux 3.2.0, stripped
Fri Apr 12 16:28:59 UTC 2024
```