### PR TITLE
workflows: change steps.get_tags.outputs.VERSION to github.ref_name

### DIFF
--- a/.github/workflows/go-c-cpp.yml
+++ b/.github/workflows/go-c-cpp.yml
@@ -158,7 +158,7 @@ jobs:
 
           # Pass some environment variables to the container
           env: | # YAML, but pipe character is necessary
-            artifact_name: ecapture-${{ steps.get_tags.outputs.VERSION }}
+            artifact_name: ecapture-${{ github.ref_name }}
 
           # The shell to run commands with in the container
           shell: /bin/sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,12 +55,12 @@ jobs:
         run: |
           make clean
           make env
-          make -f builder/Makefile.release release SNAPSHOT_VERSION=${{ steps.get_tags.outputs.VERSION }}
+          make -f builder/Makefile.release release SNAPSHOT_VERSION=${{ github.ref_name }}
       - name: Release arm64 (CROSS COMPILATION)
         run: |
           make clean
           make env
-          CROSS_ARCH=arm64 make -f builder/Makefile.release release SNAPSHOT_VERSION=${{ steps.get_tags.outputs.VERSION }}
+          CROSS_ARCH=arm64 make -f builder/Makefile.release release SNAPSHOT_VERSION=${{ github.ref_name }}
       - name: Publish
         run: |
-          make -f builder/Makefile.release publish SNAPSHOT_VERSION=${{ steps.get_tags.outputs.VERSION }}
+          make -f builder/Makefile.release publish SNAPSHOT_VERSION=${{ github.ref_name }}


### PR DESCRIPTION
about github action context {github.ref_name}:https://docs.github.com/en/actions/learn-github-actions/contexts#github-context:
> The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. 
For example, feature-branch-1.For pull requests, the format is <pr_number>/merge.
