### PR TITLE
makefile: Optimized the generation mechanism of kernel header files

### DIFF
--- a/builder/init_env.sh
+++ b/builder/init_env.sh
@@ -65,7 +65,8 @@ cd /usr/src
 sudo tar -xf linux-source-${kernel_ver}.tar.bz2
 cd /usr/src/linux-source-${kernel_ver}
 test -f .config || yes "" | sudo make oldconfig
-yes "" | sudo make ARCH=${ARCH} CROSS_COMPILE=aarch64-linux-gnu- prepare V=0
+yes "" | sudo make ARCH=${ARCH} CROSS_COMPILE=aarch64-linux-gnu- prepare V=0 > /dev/null
+yes "" | sudo make prepare V=0 > /dev/null
 ls -al /usr/src/linux-source-${kernel_ver}
 
 clang --version

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -91,7 +91,7 @@ func init() {
 	// when this action is called directly.
 	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	rootCmd.PersistentFlags().BoolVarP(&globalFlags.Debug, "debug", "d", false, "enable debug logging.(coming soon)")
-	rootCmd.PersistentFlags().Uint8VarP(&globalFlags.BtfMode, "btf", "b", 0, "enable BTF mode.(0:auto; 1:core; 2:non-core))")
+	rootCmd.PersistentFlags().Uint8VarP(&globalFlags.BtfMode, "btf", "b", 0, "enable BTF mode.(0:auto; 1:core; 2:non-core)")
 	rootCmd.PersistentFlags().BoolVar(&globalFlags.IsHex, "hex", false, "print byte strings as hex encoded strings")
 	rootCmd.PersistentFlags().IntVar(&globalFlags.mapSizeKB, "mapsize", 1024, "eBPF map size per CPU,for events buffer. default:1024 * PAGESIZE. (KB)")
 	rootCmd.PersistentFlags().Uint64VarP(&globalFlags.Pid, "pid", "p", defaultPid, "if pid is 0 then we target all pids")

--- a/variables.mk
+++ b/variables.mk
@@ -149,8 +149,8 @@ endif
 ifeq ($(TARGET_ARCH),aarch64)
 	 LINUX_ARCH = arm64
 	 GOARCH = arm64
-	 AUTOGENCMD = ls -al kern/bpf/arm64/vmlinux.h
-	 BPFHEADER += -I ./kern/bpf/arm64
+	 BPFHEADER += -I ./kern/bpf/$(LINUX_ARCH)
+	 AUTOGENCMD = ls -al kern/bpf/$(LINUX_ARCH)/vmlinux.h
 	 # sh lib/libpcap/config.sub arm64-linux for ARCH value
 	 LIBPCAP_ARCH = aarch64-unknown-linux-gnu
 	 # Constant replacement is not supported in the current version because the bpf_probe_read_user function
@@ -161,8 +161,8 @@ else
 	# x86_64 default
 	LINUX_ARCH = x86
 	GOARCH = amd64
-	BPFHEADER += -I ./kern/bpf/x86
-	AUTOGENCMD = test -f kern/bpf/x86/vmlinux.h || $(CMD_BPFTOOL) btf dump file /sys/kernel/btf/vmlinux format c > kern/bpf/x86/vmlinux.h
+	BPFHEADER += -I ./kern/bpf/$(LINUX_ARCH)
+	AUTOGENCMD = test -f kern/bpf/$(LINUX_ARCH)/vmlinux.h || $(CMD_BPFTOOL) btf dump file /sys/kernel/btf/vmlinux format c > kern/bpf/$(LINUX_ARCH)/vmlinux.h
 	 # sh lib/libpcap/config.sub amd64-linux or x86_64-linux for ARCH value
 	LIBPCAP_ARCH = x86_64-pc-linux-gnu
 endif
@@ -171,7 +171,7 @@ endif
 # include vpath
 #
 ifdef CROSS_ARCH
-	KERNEL_HEADER_GEN = yes "" | $(SUDO) make ARCH=$(LINUX_ARCH) CROSS_COMPILE=$(CMD_CC_PREFIX) prepare V=0
+	KERNEL_HEADER_GEN = test -e arch/$(LINUX_ARCH)/kernel/asm-offsets.s || yes "" | $(SUDO) make ARCH=$(LINUX_ARCH) CROSS_COMPILE=$(CMD_CC_PREFIX) prepare V=0
 	KERN_HEADERS = $(LINUX_SOURCE_PATH)
 endif
 KERN_RELEASE ?= $(UNAME_R)


### PR DESCRIPTION
Run the `make prepare` command only if the `arch/$(LINUX_ARCH)/kernel/asm-offsets.s` file does not exist. This is because this file is generated during the make phase.


### CROSS_ARCH=amd64 (on arm64 ubuntu 22.04)
```shell
  CC      kernel/bounds.s
  CC      arch/x  86/kernel/asm-offsets.s
  CALL    scripts/checksyscalls.sh
  CALL    scripts/atomic/check-atomics.sh
```

### arm64(aarch64)
```shell
  CC      kernel/bounds.s
  UPD     include/generated/bounds.h
  CC      arch/arm64/kernel/asm-offsets.s
  UPD     include/generated/asm-offsets.h
  CALL    scripts/checksyscalls.sh
  CALL    scripts/atomic/check-atomics.sh
```