### PR TITLE
add dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,3 +64,30 @@ jobs:
       - name: Publish
         run: |
           make -f builder/Makefile.release publish SNAPSHOT_VERSION=${{ github.ref_name }}
+  build-docker-image:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Update submodule
+        run: git submodule update --init
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          build-args: VERSION=${{ github.ref_name }}
+          file: ./builder/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/ecapture:${{ github.ref_name }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/ecapture:latest

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ command `./ecapture --help`.
 * Linux kernel version >= 4.18 is required.
 * Enable BTF [BPF Type Format (BTF)](https://www.kernel.org/doc/html/latest/bpf/btf.html)  (Optional, 2022-04-17)
 
+## use docker image
+
+```shell
+# pull docker image
+docker pull gojue/ecapture:latest
+# run
+docker run --rm --privileged=true --net=host -v ${HOST_PATH}:${CONTAINER_PATH} gojue/ecapture ARGS
+```
+
 ## Command line options
 
 > **Note**

--- a/README_CN.md
+++ b/README_CN.md
@@ -73,6 +73,16 @@ eBPF `Uprobe`/`Traffic Control`实现的各种用户空间/内核空间的数据
 * 系统linux kernel版本必须高于4.18。
 * 开启BTF [BPF Type Format (BTF)](https://www.kernel.org/doc/html/latest/bpf/btf.html) 支持。 (可选, 2022-04-17)
 
+## docker 容器化运行
+
+```shell
+# 拉取镜像
+docker pull gojue/ecapture:latest
+# 运行
+docker run --rm --privileged=true --net=host -v ${宿主机文件路径}:${容器内路径} gojue/ecapture ARGS
+```
+
+
 ## 命令参数
 
 > **Note**

--- a/README_JA.md
+++ b/README_JA.md
@@ -57,6 +57,15 @@ ELF zip ファイル[リリース](https://github.com/gojue/ecapture/releases)�
 * Linux kernel version >= 4.18 is required.
 * Enable BTF [BPF Type Format (BTF)](https://www.kernel.org/doc/html/latest/bpf/btf.html)  (Optional, 2022-04-17)
 
+## docker containerised run
+
+```shell
+## イメージをプルする
+docker pull gojue/ecapture:latest
+# 実行
+docker run --rm --privileged=true --net=host -v ${hostファイルパス}:${コンテナ内パス} gojue/ecapture ARGS
+```
+
 ## コマンドラインオプション
 
 > **注**
@@ -100,7 +109,7 @@ openssl模块支持3中捕获模式
 ./ecapture tls -m keylog -keylogfile=openssl_keylog.log
 ```
 
-也可以直接使用`tshark`软件实时解密展示。
+也可以直接使用`Wireshark`软件实时解密展示。
 ```shell
 tshark -o tls.keylog_file:ecapture_masterkey.log -Y http -T fields -e http.file_data -f "port 443" -i eth0
 ```

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:22.04 as ecapture_builder
+
+# Install Compilers
+RUN apt-get update &&\
+  apt-get install --yes build-essential pkgconf libelf-dev llvm-14 clang-14 linux-tools-common linux-tools-$(uname -r) make gcc flex bison file wget &&\
+  # the for-shell built-in instruction does not count as a command 
+  # and the shell used to execute the script is sh by default and not bash.
+  rm -f /usr/bin/clang && ln -s /usr/bin/clang-14 /usr/bin/clang &&\
+  rm -f /usr/bin/llc && ln -s /usr/bin/llc-14 /usr/bin/llc &&\
+  rm -f /usr/bin/llvm-strip && ln -s /usr/bin/llvm-strip-14 /usr/bin/llvm-strip
+
+# Install golang
+ARG TARGETARCH
+RUN if [ "$TARGETARCH" = "arm64" ] || [ "$TARGETARCH" = "amd64" ]; then\
+  wget -O go.tar.gz https://golang.google.cn/dl/go1.22.2.linux-${TARGETARCH}.tar.gz; \
+  else \
+  echo "unsupport arch" && /bin/false ; \
+  fi && \
+  tar -C /usr/local -xzf go.tar.gz && \
+  export PATH=$PATH:/usr/local/go/bin && \
+  rm go.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Build ecapture
+COPY ./ /build/ecapture
+
+ARG VERSION
+
+RUN cd /build/ecapture &&\
+  make clean &&\
+  make -j $(nproc) all SNAPSHOT_VERSION=${VERSION}_docker
+
+# ecapture release image
+FROM alpine:latest as ecapture
+
+COPY --from=ecapture_builder /build/ecapture/bin/ecapture /ecapture
+
+ENTRYPOINT ["/ecapture"]


### PR DESCRIPTION
This PR provides a way to run ecapture containerized. for better deployment in the background.

Specifically, a docker image will be built and uploaded to dockerhub at release tag time

I have done some simple tests, and ecapture works fine:
```shell
bash:
  sudo docker run --rm --privileged=true -v /usr/bin/bash:/usr/bin/bash sancpp/ecapture bash --bash="/usr/bin/bash"

gotls:
  sudo docker run --rm --privileged=true --net=host -v  ${HOME}/test/test_gotls:/test sancpp/ecapture gotls --elfpath="/test/main" --hex

tls:
  sudo docker run --rm --privileged=true --net=host -v /etc:/etc -v /usr:/usr -v ${PWD}:/output sancpp/ecapture tls -m pcap -i wlp3s0 --pcapfile=/output/ecapture.pcapng tcp port 443

mysqld:
  sudo docker run --rm -v mysqld-file:/usr/sbin --name mysql_test -e MYSQL_ROOT_PASSWORD=123456 mysql:8.0
  sudo docker run --rm --privileged=true --volumes-from mysql_test sancpp/ecapture mysqld -m="/usr/sbin/mysqld"
  sudo docker exec -it mysql_test bash
    mysql -u root -p # password=123456
      show databases;
```

![CleanShot_2024-05-05_at_13 21 25@2x](https://github.com/gojue/ecapture/assets/67474179/2caa94af-f6d2-4697-b63a-032f63d2aa21)


Todo List:

- [ ] You need to register a docker hub account and configure DOCKERHUB_USERNAME as well as DOCKERHUB_TOKEN.(https://github.com/marketplace/actions/docker-login#docker-hub)
- [ ] Replace TODO in the README with the dockerhub username