### PR TITLE
user: fix #553, `hashLen` is not allowed to be more than 64 bytes

### DIFF
--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -142,7 +142,7 @@ func (m *Module) autoDetectBTF() {
 			m.isCoreUsed = true
 		}
 	} else {
-		m.logger.Warn().Err(err).Msg("Failed to detect container environment, error:%v,This may cause eCapture not to work.\n" + BtfNotSupport)
+		m.logger.Warn().Err(err).Msg("Failed to detect container environment,This may cause eCapture not to work.\n" + BtfNotSupport)
 	}
 }
 func (m *Module) geteBPFName(filename string) string {

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -589,6 +589,11 @@ func (m *MOpenSSLProbe) mk13NullSecrets(hashLen int,
 ) bool {
 	isNUllCount := 5
 
+	// The mandatory setting is 64 bytes, and the length of the XXXX secret is not allowed to be more than 64 bytes.
+	if hashLen > 64 {
+		hashLen = 64
+	}
+
 	var chsChecked, ctsChecked, shsChecked, stsChecked, esChecked bool
 	for i := 0; i < hashLen; i++ {
 		if !chsChecked && ClientHandshakeSecret[i] != 0 {


### PR DESCRIPTION
 fix #553 