### PR TITLE
kern: Support for the non-Android boringssl library has been added.

### DIFF
--- a/kern/boringssl_na_kern.c
+++ b/kern/boringssl_na_kern.c
@@ -1,0 +1,74 @@
+#ifndef ECAPTURE_BORINGSSL_NA_KERN_H
+#define ECAPTURE_BORINGSSL_NA_KERN_H
+
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1 (compatible; BoringSSL) */
+/* OPENSSL_VERSION_NUMBER: 269488255 */
+
+// ssl_st->version
+#define SSL_ST_VERSION 0x10
+
+// ssl_st->session
+#define SSL_ST_SESSION 0x58
+
+// ssl_st->rbio
+#define SSL_ST_RBIO 0x18
+
+// ssl_st->wbio
+#define SSL_ST_WBIO 0x20
+
+// ssl_st->s3
+#define SSL_ST_S3 0x30
+
+// ssl_session_st->secret_length
+#define SSL_SESSION_ST_SECRET_LENGTH 0xa
+
+// ssl_session_st->secret
+#define SSL_SESSION_ST_SECRET 0xb
+
+// ssl_session_st->cipher
+#define SSL_SESSION_ST_CIPHER 0xc8
+
+// bio_st->num
+#define BIO_ST_NUM 0x20
+
+// ssl_cipher_st->id
+#define SSL_CIPHER_ST_ID 0x10
+
+// bssl::SSL3_STATE->hs
+#define BSSL__SSL3_STATE_HS 0x118
+
+// bssl::SSL3_STATE->client_random
+#define BSSL__SSL3_STATE_CLIENT_RANDOM 0x30
+
+// bssl::SSL3_STATE->exporter_secret
+#define BSSL__SSL3_STATE_EXPORTER_SECRET 0x180
+
+// bssl::SSL3_STATE->established_session
+#define BSSL__SSL3_STATE_ESTABLISHED_SESSION 0x1d0
+
+// bssl::SSL_HANDSHAKE->new_session
+#define BSSL__SSL_HANDSHAKE_NEW_SESSION 0x5e0
+
+// bssl::SSL_HANDSHAKE->early_session
+#define BSSL__SSL_HANDSHAKE_EARLY_SESSION 0x5e8
+
+// bssl::SSL_HANDSHAKE->hints
+#define BSSL__SSL_HANDSHAKE_HINTS 0x618
+
+// bssl::SSL_HANDSHAKE->client_version
+#define BSSL__SSL_HANDSHAKE_CLIENT_VERSION 0x624
+
+// bssl::SSL_HANDSHAKE->state
+#define BSSL__SSL_HANDSHAKE_STATE 0x14
+
+// bssl::SSL_HANDSHAKE->tls13_state
+#define BSSL__SSL_HANDSHAKE_TLS13_STATE 0x18
+
+// bssl::SSL_HANDSHAKE->max_version
+#define BSSL__SSL_HANDSHAKE_MAX_VERSION 0x1e
+
+#include "boringssl_const.h"
+#include "boringssl_masterkey.h"
+#include "openssl.h"
+
+#endif

--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -63,10 +63,16 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 		Linuxdefaulefilename320: "openssl_3_2_0_kern.o",
 
 		// boringssl
+		// git repo: https://android.googlesource.com/platform/external/boringssl/+/refs/heads/android12-release
 		"boringssl 1.1.1":      "boringssl_a_13_kern.o",
 		"boringssl_a_13":       "boringssl_a_13_kern.o",
 		"boringssl_a_14":       "boringssl_a_14_kern.o",
 		AndroidDefauleFilename: "boringssl_a_13_kern.o",
+
+		// non-Android boringssl
+		// "boringssl na" is a special version for non-android
+		// git repo: https://github.com/google/boringssl
+		"boringssl na": "boringssl_na_kern.o",
 	}
 
 	// in openssl source files, there are 4 offset groups for all 1.1.1* version.

--- a/utils/boringssl_non_android_offset.sh
+++ b/utils/boringssl_non_android_offset.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+PROJECT_ROOT_DIR=$(pwd)
 # for non android boringssl , git repo : https://github.com/google/boringssl
 BORINGSSL_REPO=https://github.com/google/boringssl.git
 BORINGSSL_DIR="${PROJECT_ROOT_DIR}/deps/boringssl_non_android"
@@ -23,15 +24,14 @@ function run() {
   git fetch --tags
   cp -f ${PROJECT_ROOT_DIR}/utils/boringssl-offset.c ${BORINGSSL_DIR}/offset.c
   declare -A sslVerMap=()
-  sslVerMap["0"]="12" # android12-release
-  sslVerMap["1"]="13" # android13-release
-  sslVerMap["2"]="14" # android14-release
+  sslVerMap["0"]="master" # master
+#  sslVerMap["1"]="fips-20220613" # fips-20220613
+#  sslVerMap["2"]="fips-20210429" # android14-release
 
   # shellcheck disable=SC2068
   # shellcheck disable=SC2034
   for ver in ${!sslVerMap[@]}; do
-    tag="android${ver}-release"
-    val=${sslVerMap[$ver]}
+    tag=${sslVerMap[$ver]}
 
     header_file="${OUTPUT_DIR}/boringssl_na_kern.c"
     header_define="BORINGSSL_NA_KERN_H"

--- a/variables.mk
+++ b/variables.mk
@@ -183,7 +183,8 @@ BPF_NOCORE_TAG = $(subst .,_,$(KERN_RELEASE)).$(subst .,_,$(VERSION_NUM))
 #
 # BPF Source file
 #
-TARGETS := kern/boringssl_a_13
+TARGETS := kern/boringssl_na
+TARGETS += kern/boringssl_a_13
 TARGETS += kern/boringssl_a_14
 TARGETS += kern/openssl_1_1_1a
 TARGETS += kern/openssl_1_1_1b


### PR DESCRIPTION
feat: #552

You should know that the version management of boringssl is chaotic, divided into Android version and non-Android version, corresponding to two different code repositories. Also, the `OPENSSL_VERSION_TEXT` content has not been modified and remains unchanged. It is impossible to distinguish versions based on this field.

Therefore, if you expect eCapture to better support the non-Android boringssl, you need to confirm the version matching situation by yourself. When necessary, you will need to patch it yourself.

Android Boringssl: https://android.googlesource.com/platform/external/boringssl/

Non-Android Boringssl: https://boringssl.googlesource.com/boringssl aka https://github.com/google/boringssl