### PR TITLE
add possible linux kernel config path

### DIFF
--- a/pkg/util/ebpf/bpf.go
+++ b/pkg/util/ebpf/bpf.go
@@ -38,6 +38,7 @@ var (
 		"/proc/config.gz",
 		"/boot/config",
 		"/boot/config-%s",
+		"/lib/modules/%s/build/.config",
 	}
 )
 


### PR DESCRIPTION
There are several paths to obtain current kernel config on Linux:

1. `/proc/config.gz`: available since Linux 2.6 and needs `CONFIG_IKCONFIG_PROC=y`;
2. `/boot/config` and `/boot/config-%s`: available in most Debian-based distros, but NOT in Arch Linux or Gentoo.

However, for those kernels where `CONFIG_IKCONFIG_PROC` is not set, both of them are unavailable. According to [proc(5)](https://man7.org/linux/man-pages/man5/proc.5.html), the kernel config can be found at `/lib/modules/$(uname -r)/build/.config`. 

This PR adds it to the search paths.

**Q: Is there really any kernel that is compiled without `CONFIG_IKCONFIG_PROC`?**

Yes. [Xanmod](https://xanmod.org) is a popular kernel among users which [does not have `CONFIG_IKCONFIG` enabled](https://gitlab.com/xanmod/linux/-/blob/6.9/CONFIGS/xanmod/gcc/config_x86-64-v3).