### PR TITLE
fix: DumpResponse error in HEAD request

### DIFF
--- a/pkg/event_processor/http_response.go
+++ b/pkg/event_processor/http_response.go
@@ -153,6 +153,10 @@ func (hr *HTTPResponse) Display() []byte {
 		b, e = httputil.DumpResponse(hr.response, false)
 	} else {
 		b, e = httputil.DumpResponse(hr.response, true)
+		// Method is HEAD, no respones body will raise UnexpectedEOF
+		if e == io.ErrUnexpectedEOF {
+			b, e = httputil.DumpResponse(hr.response, false)
+		}
 	}
 	if e != nil {
 		log.Println("[http response] DumpResponse error:", e)


### PR DESCRIPTION
fix:
```
bin/ecapture tls -m text
curl -I --http1.1  https://www.google.com/
......
2024-06-18T10:19:58+08:00 INF UUID:104243_104243_curl_0_1_0.0.0.0, Name:HTTPRequest, Type:1, Length:75
HEAD / HTTP/1.1
Host: www.google.com
Accept: */*
User-Agent: curl/7.88.1



2024/06/18 10:19:58 [http response] DumpResponse error: unexpected EOF
......
```