### PR TITLE
fix: truncated body dump error

### DIFF
--- a/pkg/event_processor/http_response.go
+++ b/pkg/event_processor/http_response.go
@@ -18,7 +18,6 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -116,24 +115,43 @@ func (hr *HTTPResponse) Reset() {
 }
 
 func (hr *HTTPResponse) Display() []byte {
+	rawData, err := io.ReadAll(hr.response.Body)
+	rawLength := int64(len(rawData))
+	switch err {
+	case nil:
+		// Passed
+	case io.ErrUnexpectedEOF:
+		// If the server declared the Content-Length, Body is a LimitedReader
+		// Raw data length smaller than "Content-Length" will cause UnexpectedEOF error
+		// e.g. Head Method response with "Content-Length" header, raw data length is 0
+		if rawLength > 0 && hr.response.ContentLength > rawLength {
+			log.Println("[http response] Truncated response body")
+		}
+	default:
+		log.Println("[http response] Read response body error:", err)
+		return hr.reader.Bytes()
+	}
+	if hr.response.ContentLength < 0 {
+		log.Println("[http response] Chunked response body")
+	}
 	var reader io.ReadCloser
-	var err error
 	switch hr.response.Header.Get("Content-Encoding") {
 	case "gzip":
-		reader, err = gzip.NewReader(hr.response.Body)
-		if err != nil {
-			log.Println(err)
+		if rawLength == 0 {
 			break
 		}
-		gbuf, err := io.ReadAll(reader)
+		reader, err = gzip.NewReader(bytes.NewReader(rawData))
 		if err != nil {
-			log.Println(err)
+			log.Println("[http response] Create gzip reader error:", err)
 			break
 		}
-
-		hr.response.Body = io.NopCloser(bytes.NewReader(gbuf))
+		rawData, err = io.ReadAll(reader)
+		if err != nil {
+			log.Println("[http response] Uncompress gzip data error:", err)
+			break
+		}
 		// gzip uncompressed success
-		hr.response.ContentLength = int64(len(gbuf))
+		// hr.response.ContentLength = int64(len(raw))
 		hr.packerType = PacketTypeGzip
 		defer reader.Close()
 	default:
@@ -141,28 +159,21 @@ func (hr *HTTPResponse) Display() []byte {
 		hr.packerType = PacketTypeNull
 		//TODO for debug
 	}
-	headerMap := bytes.NewBufferString("")
-	for k, v := range hr.response.Header {
-		headerMap.WriteString(fmt.Sprintf("\t%s\t=>\t%s\n", k, v))
-	}
-
-	var b []byte
-	var e error
-
-	if hr.response.ContentLength == 0 {
-		b, e = httputil.DumpResponse(hr.response, false)
-	} else {
-		b, e = httputil.DumpResponse(hr.response, true)
-		// Method is HEAD, no respones body will raise UnexpectedEOF
-		if e == io.ErrUnexpectedEOF {
-			b, e = httputil.DumpResponse(hr.response, false)
-		}
-	}
-	if e != nil {
-		log.Println("[http response] DumpResponse error:", e)
+	//	headerMap := bytes.NewBufferString("")
+	//	for k, v := range hr.response.Header {
+	//		headerMap.WriteString(fmt.Sprintf("\t%s\t=>\t%s\n", k, v))
+	//	}
+	b, err := httputil.DumpResponse(hr.response, false)
+	if err != nil {
+		log.Println("[http response] DumpResponse error:", err)
 		return hr.reader.Bytes()
 	}
-	return b
+	var buff bytes.Buffer
+	buff.Write(b)
+	if rawLength > 0 {
+		buff.Write(rawData)
+	}
+	return buff.Bytes()
 }
 
 func init() {


### PR DESCRIPTION
this is the extend of #572 .

The request/response body may be truncated in events, so the 'Content-Length' header value not match the real data length, ReadAll/Close will always raise UnexpectedEOF error.  #572 can only fix the real data length is 0, the pr will fix the others.
