### PR TITLE
kern: support openssl 3.3.*

### DIFF
--- a/kern/openssl_1_0_2a_kern.c
+++ b/kern/openssl_1_0_2a_kern.c
@@ -19,6 +19,9 @@
 // ssl_st->wbio
 #define SSL_ST_WBIO 0x18
 
+// ssl_st->server
+#define SSL_ST_SERVER 0x38
+
 // ssl_session_st->master_key
 #define SSL_SESSION_ST_MASTER_KEY 0x14
 

--- a/kern/openssl_1_1_0a_kern.c
+++ b/kern/openssl_1_1_0a_kern.c
@@ -19,6 +19,9 @@
 // ssl_st->wbio
 #define SSL_ST_WBIO 0x18
 
+// ssl_st->server
+#define SSL_ST_SERVER 0x38
+
 // ssl_session_st->master_key
 #define SSL_SESSION_ST_MASTER_KEY 0x8
 

--- a/kern/openssl_1_1_1a_kern.c
+++ b/kern/openssl_1_1_1a_kern.c
@@ -19,6 +19,9 @@
 // ssl_st->wbio
 #define SSL_ST_WBIO 0x18
 
+// ssl_st->server
+#define SSL_ST_SERVER 0x38
+
 // ssl_session_st->master_key
 #define SSL_SESSION_ST_MASTER_KEY 0x50
 

--- a/kern/openssl_1_1_1b_kern.c
+++ b/kern/openssl_1_1_1b_kern.c
@@ -19,6 +19,9 @@
 // ssl_st->wbio
 #define SSL_ST_WBIO 0x18
 
+// ssl_st->server
+#define SSL_ST_SERVER 0x38
+
 // ssl_session_st->master_key
 #define SSL_SESSION_ST_MASTER_KEY 0x50
 

--- a/kern/openssl_1_1_1d_kern.c
+++ b/kern/openssl_1_1_1d_kern.c
@@ -19,6 +19,9 @@
 // ssl_st->wbio
 #define SSL_ST_WBIO 0x18
 
+// ssl_st->server
+#define SSL_ST_SERVER 0x38
+
 // ssl_session_st->master_key
 #define SSL_SESSION_ST_MASTER_KEY 0x50
 

--- a/kern/openssl_1_1_1j_kern.c
+++ b/kern/openssl_1_1_1j_kern.c
@@ -1,8 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_1_1_1_J_KERN_H
 #define ECAPTURE_OPENSSL_1_1_1_J_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1u  30 May 2023 */
-/* OPENSSL_VERSION_NUMBER: 269488479 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1w  11 Sep 2023 */
+/* OPENSSL_VERSION_NUMBER: 269488511 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -18,6 +18,9 @@
 
 // ssl_st->wbio
 #define SSL_ST_WBIO 0x18
+
+// ssl_st->server
+#define SSL_ST_SERVER 0x38
 
 // ssl_session_st->master_key
 #define SSL_SESSION_ST_MASTER_KEY 0x50

--- a/kern/openssl_3_0_0_kern.c
+++ b/kern/openssl_3_0_0_kern.c
@@ -1,8 +1,8 @@
-#ifndef ECAPTURE_OPENSSL_3_0_0_KERN_H
-#define ECAPTURE_OPENSSL_3_0_0_KERN_H
+#ifndef ECAPTURE_OPENSSL_3_0_6_KERN_H
+#define ECAPTURE_OPENSSL_3_0_6_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 3.0.9 30 May 2023 */
-/* OPENSSL_VERSION_NUMBER: 805306512 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.1.6 4 Jun 2024 */
+/* OPENSSL_VERSION_NUMBER: 806355040 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -18,6 +18,9 @@
 
 // ssl_st->wbio
 #define SSL_ST_WBIO 0x18
+
+// ssl_st->server
+#define SSL_ST_SERVER 0x38
 
 // ssl_session_st->master_key
 #define SSL_SESSION_ST_MASTER_KEY 0x50

--- a/kern/openssl_3_2_0_kern.c
+++ b/kern/openssl_3_2_0_kern.c
@@ -1,8 +1,8 @@
-#ifndef ECAPTURE_OPENSSL_3_2_0_KERN_H
-#define ECAPTURE_OPENSSL_3_2_0_KERN_H
+#ifndef ECAPTURE_OPENSSL_3_2_2_KERN_H
+#define ECAPTURE_OPENSSL_3_2_2_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 3.2.0 23 Nov 2023 */
-/* OPENSSL_VERSION_NUMBER: 807403520 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.2.2 4 Jun 2024 */
+/* OPENSSL_VERSION_NUMBER: 807403552 */
 
 // ssl_st->type
 #define SSL_ST_TYPE 0x0
@@ -21,6 +21,9 @@
 
 // ssl_connection_st->wbio
 #define SSL_CONNECTION_ST_WBIO 0x50
+
+// ssl_connection_st->server
+#define SSL_CONNECTION_ST_SERVER 0x70
 
 // ssl_session_st->master_key
 #define SSL_SESSION_ST_MASTER_KEY 0x50

--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -30,6 +30,7 @@ const (
 	Linuxdefaulefilename30  = "linux_default_3_0"
 	Linuxdefaulefilename31  = "linux_default_3_0"
 	Linuxdefaulefilename320 = "linux_default_3_2"
+	Linuxdefaulefilename330 = "linux_default_3_3"
 	AndroidDefauleFilename  = "android_default"
 
 	OpenSslVersionLen = 30 // openssl version string length
@@ -39,9 +40,10 @@ const (
 	MaxSupportedOpenSSL102Version = 'u'
 	MaxSupportedOpenSSL110Version = 'l'
 	MaxSupportedOpenSSL111Version = 'w'
-	MaxSupportedOpenSSL30Version  = 13
-	MaxSupportedOpenSSL31Version  = 5
-	MaxSupportedOpenSSL32Version  = 1
+	MaxSupportedOpenSSL30Version  = 14
+	MaxSupportedOpenSSL31Version  = 6
+	MaxSupportedOpenSSL32Version  = 2
+	MaxSupportedOpenSSL33Version  = 1
 )
 
 // initOpensslOffset initial BpfMap
@@ -107,6 +109,12 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 	// openssl 3.2.0
 	for ch := 0; ch <= MaxSupportedOpenSSL32Version; ch++ {
 		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.2.%d", ch)] = "openssl_3_2_0_kern.o"
+	}
+
+	// openssl 3.3.0
+	for ch := 0; ch <= MaxSupportedOpenSSL33Version; ch++ {
+		// The OpenSSL 3.3.* series is the same as the 3.2.* series of offsets
+		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.3.%d", ch)] = "openssl_3_2_0_kern.o"
 	}
 
 	// openssl 1.1.0a - 1.1.0l

--- a/utils/openssl_1_0_2_offset.c
+++ b/utils/openssl_1_0_2_offset.c
@@ -10,6 +10,7 @@
     X(ssl_st, s3)                   \
     X(ssl_st, rbio)                 \
     X(ssl_st, wbio)                 \
+    X(ssl_st, server)               \
     X(ssl_session_st, master_key)   \
     X(ssl3_state_st, client_random) \
     X(ssl_session_st, cipher)       \

--- a/utils/openssl_1_1_0_offset.c
+++ b/utils/openssl_1_1_0_offset.c
@@ -11,6 +11,7 @@
     X(ssl_st, s3)                   \
     X(ssl_st, rbio)                 \
     X(ssl_st, wbio)                 \
+    X(ssl_st, server)                    \
     X(ssl_session_st, master_key)   \
     X(ssl3_state_st, client_random) \
     X(ssl_session_st, cipher)       \

--- a/utils/openssl_1_1_1_offset.c
+++ b/utils/openssl_1_1_1_offset.c
@@ -21,6 +21,7 @@
     X(ssl_st, s3)                        \
     X(ssl_st, rbio)                      \
     X(ssl_st, wbio)                      \
+    X(ssl_st, server)                    \
     X(ssl_session_st, master_key)        \
     X(ssl3_state_st, client_random)      \
     X(ssl_session_st, cipher)            \

--- a/utils/openssl_3_0_offset.c
+++ b/utils/openssl_3_0_offset.c
@@ -11,6 +11,7 @@
     X(ssl_st, s3)                        \
     X(ssl_st, rbio)                      \
     X(ssl_st, wbio)                      \
+    X(ssl_st, server)                    \
     X(ssl_session_st, master_key)        \
     X(ssl_st, s3.client_random)          \
     X(ssl_session_st, cipher)            \

--- a/utils/openssl_3_2_0_offset.c
+++ b/utils/openssl_3_2_0_offset.c
@@ -12,6 +12,7 @@
     X(ssl_connection_st, s3)                        \
     X(ssl_connection_st, rbio)                      \
     X(ssl_connection_st, wbio)                      \
+    X(ssl_connection_st, server)                    \
     X(ssl_session_st, master_key)                   \
     X(ssl_connection_st, s3.client_random)          \
     X(ssl_session_st, cipher)                       \

--- a/utils/openssl_offset_3.1.sh
+++ b/utils/openssl_offset_3.1.sh
@@ -31,6 +31,7 @@ function run() {
   sslVerMap["3"]="0"
   sslVerMap["4"]="0"
   sslVerMap["5"]="0"
+  sslVerMap["6"]="0"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do

--- a/utils/openssl_offset_3.2.sh
+++ b/utils/openssl_offset_3.2.sh
@@ -27,6 +27,7 @@ function run() {
   declare -A sslVerMap=()
   sslVerMap["0"]="0"
   sslVerMap["1"]="0"
+  sslVerMap["2"]="0"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do


### PR DESCRIPTION
Add the offset of the `ssl_st->server` field to determine whether the current *SSL is in server mode.