### PR TITLE
user: split loggers, which are divided into loggers and event collectors

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,16 @@
+ignore:
+  - tests/**
+
+beta_groups:
+  - "labels"
+
+flag_management:
+  individual_flags:
+    - name: "smart-labels"
+      carryforward: true
+      carryforward_mode: "labels"
+
+cli:
+  plugins:
+    pycoverage:
+      report_type: "json"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,7 +9,11 @@ flag_management:
     - name: "smart-labels"
       carryforward: true
       carryforward_mode: "labels"
-
+flags:
+  unittests-Solution:
+    carryforward: true
+    paths:
+      - ./**
 cli:
   plugins:
     pycoverage:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -93,14 +93,14 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@main
         with:
-          python-version: 3.10
+          python-version: 3.12.5
       - name: Generate coverage report
         run: |
           pip install pytest
           pip install pytest-cov
           pytest --cov=./ --cov-report=xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v4.5.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/reports/

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -100,13 +100,6 @@ jobs:
           pip install pytest-cov
           pytest --cov=./ --cov-report=xml
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.5.0
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/reports/
-          codecov_yml_path: .github/codecov.yml
-          fail_ci_if_error: true # optional (default = false)
-          files: ./coverage1.xml,./coverage2.xml # optional
-          flags: unittests # optional
-          name: codecov-umbrella # optional
-          verbose: true # optional (default = false)

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -90,7 +90,23 @@ jobs:
           make nocore -j4
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
+      - name: Setup Python
+        uses: actions/setup-python@main
+        with:
+          python-version: 3.10
+      - name: Generate coverage report
+        run: |
+          pip install pytest
+          pip install pytest-cov
+          pytest --cov=./ --cov-report=xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/reports/
+          codecov_yml_path: .github/codecov.yml
+          fail_ci_if_error: true # optional (default = false)
+          files: ./coverage1.xml,./coverage2.xml # optional
+          flags: unittests # optional
+          name: codecov-umbrella # optional
+          verbose: true # optional (default = false)

--- a/.github/workflows/go-c-cpp.yml
+++ b/.github/workflows/go-c-cpp.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           args: --disable-all -E errcheck -E staticcheck
           skip-cache: true
-          skip-pkg-cache: true
-          skip-build-cache: true
           problem-matchers: true
       - name: Build NOCORE
         run: |
@@ -87,12 +85,11 @@ jobs:
           cd ./lib/libpcap/ && sudo make install
           cd $GITHUB_WORKSPACE
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --disable-all -E errcheck -E staticcheck
           skip-cache: true
-          skip-pkg-cache: true
-          skip-build-cache: true
+          problem-matchers: true
       - name: Build non-CO-RE
         run: |
           make clean

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -33,8 +33,8 @@ type IConfig interface {
 	SetBTF(uint8)
 	SetDebug(bool)
 	SetAddrType(uint8)
-	SetLoggerTCPAddr(string)
-	GetLoggerTCPAddr() string
+	SetEventCollectorAddr(string)
+	GetEventCollectorAddr() string
 	GetPerCpuMapSize() int
 	SetPerCpuMapSize(int)
 	EnableGlobalVar() bool //
@@ -61,13 +61,13 @@ type BaseConfig struct {
 	Listen string `json:"listen"` // listen address, default: 127.0.0.1:28256
 
 	// mapSizeKB
-	PerCpuMapSize int    `json:"per_cpu_map_size"` // ebpf map size for per Cpu.   see https://github.com/gojue/ecapture/issues/433 .
-	IsHex         bool   `json:"is_hex"`
-	Debug         bool   `json:"debug"`
-	BtfMode       uint8  `json:"btf_mode"`
-	LoggerAddr    string `json:"logger_addr"` // save file
-	LoggerType    uint8  `json:"logger_type"` // 0:stdout, 1:file, 2:tcp
-	LoggerTCPAddr string `json:"logger_tcp_addr"`
+	PerCpuMapSize      int    `json:"per_cpu_map_size"` // ebpf map size for per Cpu.   see https://github.com/gojue/ecapture/issues/433 .
+	IsHex              bool   `json:"is_hex"`
+	Debug              bool   `json:"debug"`
+	BtfMode            uint8  `json:"btf_mode"`
+	LoggerAddr         string `json:"logger_addr"`          // logger address
+	LoggerType         uint8  `json:"logger_type"`          // 0:stdout, 1:file, 2:tcp
+	EventCollectorAddr string `json:"event_collector_addr"` // the server address that receives the captured event
 }
 
 func (c *BaseConfig) GetPid() uint64 {
@@ -94,12 +94,12 @@ func (c *BaseConfig) SetUid(uid uint64) {
 	c.Uid = uid
 }
 
-func (c *BaseConfig) SetLoggerTCPAddr(addr string) {
-	c.LoggerTCPAddr = addr
+func (c *BaseConfig) SetEventCollectorAddr(addr string) {
+	c.EventCollectorAddr = addr
 }
 
-func (c *BaseConfig) GetLoggerTCPAddr() string {
-	return c.LoggerTCPAddr
+func (c *BaseConfig) GetEventCollectorAddr() string {
+	return c.EventCollectorAddr
 }
 
 func (c *BaseConfig) SetAddrType(t uint8) {

--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -378,7 +378,7 @@ func (m *Module) Dispatcher(e event.IEventStruct) {
 				return
 			}
 			//m.logger.Info().Msg(s)
-			m.eventCollector.Write([]byte(s))
+			_, _ = m.eventCollector.Write([]byte(s))
 			return
 		}
 	}
@@ -392,7 +392,7 @@ func (m *Module) Dispatcher(e event.IEventStruct) {
 			return
 		}
 		//m.logger.Info().Msg(s)
-		m.eventCollector.Write([]byte(s))
+		_, _ = m.eventCollector.Write([]byte(s))
 	case event.EventTypeEventProcessor:
 		m.processor.Write(e)
 	case event.EventTypeModuleData:

--- a/user/module/probe_bash.go
+++ b/user/module/probe_bash.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gojue/ecapture/user/config"
 	"github.com/gojue/ecapture/user/event"
 	"github.com/rs/zerolog"
+	"io"
 	"math"
 
 	"github.com/cilium/ebpf"
@@ -46,8 +47,8 @@ type MBashProbe struct {
 }
 
 // 对象初始化
-func (b *MBashProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig) error {
-	b.Module.Init(ctx, logger, conf)
+func (b *MBashProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
+	b.Module.Init(ctx, logger, conf, ecw)
 	b.conf = conf
 	b.Module.SetChild(b)
 	b.eventMaps = make([]*ebpf.Map, 0, 2)
@@ -278,9 +279,11 @@ func (b *MBashProbe) handleLine(be *event.BashEvent) {
 		return
 	}
 	if b.conf.GetHex() {
-		b.logger.Println(be.StringHex())
+		//b.logger.Println(be.StringHex())
+		b.eventCollector.Write([]byte(be.StringHex()))
 	} else {
-		b.logger.Println(be.String())
+		//b.logger.Println(be.String())
+		b.eventCollector.Write([]byte(be.String()))
 	}
 }
 

--- a/user/module/probe_bash.go
+++ b/user/module/probe_bash.go
@@ -48,7 +48,10 @@ type MBashProbe struct {
 
 // 对象初始化
 func (b *MBashProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
-	b.Module.Init(ctx, logger, conf, ecw)
+	err := b.Module.Init(ctx, logger, conf, ecw)
+	if err != nil {
+		return err
+	}
 	b.conf = conf
 	b.Module.SetChild(b)
 	b.eventMaps = make([]*ebpf.Map, 0, 2)
@@ -280,10 +283,10 @@ func (b *MBashProbe) handleLine(be *event.BashEvent) {
 	}
 	if b.conf.GetHex() {
 		//b.logger.Println(be.StringHex())
-		b.eventCollector.Write([]byte(be.StringHex()))
+		_, _ = b.eventCollector.Write([]byte(be.StringHex()))
 	} else {
 		//b.logger.Println(be.String())
-		b.eventCollector.Write([]byte(be.String()))
+		_, _ = b.eventCollector.Write([]byte(be.String()))
 	}
 }
 

--- a/user/module/probe_gnutls.go
+++ b/user/module/probe_gnutls.go
@@ -42,7 +42,10 @@ type MGnutlsProbe struct {
 
 // 对象初始化
 func (g *MGnutlsProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
-	g.Module.Init(ctx, logger, conf, ecw)
+	err := g.Module.Init(ctx, logger, conf, ecw)
+	if err != nil {
+		return err
+	}
 	g.conf = conf
 	g.Module.SetChild(g)
 	g.eventMaps = make([]*ebpf.Map, 0, 2)

--- a/user/module/probe_gnutls.go
+++ b/user/module/probe_gnutls.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gojue/ecapture/user/event"
 	"github.com/rs/zerolog"
 	"golang.org/x/sys/unix"
+	"io"
 	"math"
 	"os"
 	"path"
@@ -40,8 +41,8 @@ type MGnutlsProbe struct {
 }
 
 // 对象初始化
-func (g *MGnutlsProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig) error {
-	g.Module.Init(ctx, logger, conf)
+func (g *MGnutlsProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
+	g.Module.Init(ctx, logger, conf, ecw)
 	g.conf = conf
 	g.Module.SetChild(g)
 	g.eventMaps = make([]*ebpf.Map, 0, 2)

--- a/user/module/probe_gotls.go
+++ b/user/module/probe_gotls.go
@@ -55,7 +55,10 @@ type GoTLSProbe struct {
 }
 
 func (g *GoTLSProbe) Init(ctx context.Context, l *zerolog.Logger, cfg config.IConfig, ecw io.Writer) error {
-	g.Module.Init(ctx, l, cfg, ecw)
+	e := g.Module.Init(ctx, l, cfg, ecw)
+	if e != nil {
+		return e
+	}
 	g.conf = cfg
 	g.Module.SetChild(g)
 

--- a/user/module/probe_gotls.go
+++ b/user/module/probe_gotls.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/rs/zerolog"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -53,8 +54,8 @@ type GoTLSProbe struct {
 	isRegisterABI     bool
 }
 
-func (g *GoTLSProbe) Init(ctx context.Context, l *zerolog.Logger, cfg config.IConfig) error {
-	g.Module.Init(ctx, l, cfg)
+func (g *GoTLSProbe) Init(ctx context.Context, l *zerolog.Logger, cfg config.IConfig, ecw io.Writer) error {
+	g.Module.Init(ctx, l, cfg, ecw)
 	g.conf = cfg
 	g.Module.SetChild(g)
 

--- a/user/module/probe_gotls_keylog.go
+++ b/user/module/probe_gotls_keylog.go
@@ -46,7 +46,7 @@ func (g *GoTLSProbe) setupManagersKeylog() error {
 		g.logger.Warn().Msg("Golang elf buildmode with pie")
 	}
 	g.logger.Info().Str("Function", config.GoTlsMasterSecretFunc).
-		Str("LoggerTCPAddr", fmt.Sprintf("%X", gotlsConf.GoTlsMasterSecretAddr)).Msg("Hook masterKey function")
+		Str("EventCollectorAddr", fmt.Sprintf("%X", gotlsConf.GoTlsMasterSecretAddr)).Msg("Hook masterKey function")
 	var (
 		sec string
 		fn  string

--- a/user/module/probe_gotls_pcap.go
+++ b/user/module/probe_gotls_pcap.go
@@ -55,7 +55,7 @@ func (g *GoTLSProbe) setupManagersPcap() error {
 	g.logger.Info().Str("binrayPath", g.path).Str("IFname", g.ifName).Int("IFindex", g.ifIdex).
 		Str("PcapFilter", pcapFilter).Msg("HOOK type:Golang elf")
 	g.logger.Info().Str("Function", config.GoTlsMasterSecretFunc).
-		Str("LoggerTCPAddr", fmt.Sprintf("%X", g.conf.(*config.GoTLSConfig).GoTlsMasterSecretAddr)).Msg("Hook masterKey function")
+		Str("EventCollectorAddr", fmt.Sprintf("%X", g.conf.(*config.GoTLSConfig).GoTlsMasterSecretAddr)).Msg("Hook masterKey function")
 
 	// create pcapng writer
 	netIfs, err := net.Interfaces()

--- a/user/module/probe_mysqld.go
+++ b/user/module/probe_mysqld.go
@@ -44,7 +44,10 @@ type MMysqldProbe struct {
 
 // 对象初始化
 func (m *MMysqldProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
-	m.Module.Init(ctx, logger, conf, ecw)
+	err := m.Module.Init(ctx, logger, conf, ecw)
+	if err != nil {
+		return err
+	}
 	m.conf = conf
 	m.Module.SetChild(m)
 	m.eventMaps = make([]*ebpf.Map, 0, 2)

--- a/user/module/probe_mysqld.go
+++ b/user/module/probe_mysqld.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gojue/ecapture/user/event"
 	"github.com/rs/zerolog"
 	"golang.org/x/sys/unix"
+	"io"
 	"math"
 	"os"
 )
@@ -42,8 +43,8 @@ type MMysqldProbe struct {
 }
 
 // 对象初始化
-func (m *MMysqldProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig) error {
-	m.Module.Init(ctx, logger, conf)
+func (m *MMysqldProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
+	m.Module.Init(ctx, logger, conf, ecw)
 	m.conf = conf
 	m.Module.SetChild(m)
 	m.eventMaps = make([]*ebpf.Map, 0, 2)

--- a/user/module/probe_nspr.go
+++ b/user/module/probe_nspr.go
@@ -42,7 +42,10 @@ type MNsprProbe struct {
 
 // 对象初始化
 func (n *MNsprProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
-	n.Module.Init(ctx, logger, conf, ecw)
+	err := n.Module.Init(ctx, logger, conf, ecw)
+	if err != nil {
+		return err
+	}
 	n.conf = conf
 	n.Module.SetChild(n)
 	n.eventMaps = make([]*ebpf.Map, 0, 2)

--- a/user/module/probe_nspr.go
+++ b/user/module/probe_nspr.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gojue/ecapture/user/event"
 	"github.com/rs/zerolog"
 	"golang.org/x/sys/unix"
+	"io"
 	"math"
 	"os"
 	"path"
@@ -40,8 +41,8 @@ type MNsprProbe struct {
 }
 
 // 对象初始化
-func (n *MNsprProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig) error {
-	n.Module.Init(ctx, logger, conf)
+func (n *MNsprProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
+	n.Module.Init(ctx, logger, conf, ecw)
 	n.conf = conf
 	n.Module.SetChild(n)
 	n.eventMaps = make([]*ebpf.Map, 0, 2)

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -96,7 +96,11 @@ type MOpenSSLProbe struct {
 
 // 对象初始化
 func (m *MOpenSSLProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
-	m.Module.Init(ctx, logger, conf, ecw)
+	var err error
+	err = m.Module.Init(ctx, logger, conf, ecw)
+	if err != nil {
+		return err
+	}
 	m.conf = conf
 	m.Module.SetChild(m)
 	m.eventMaps = make([]*ebpf.Map, 0, 2)
@@ -108,7 +112,6 @@ func (m *MOpenSSLProbe) Init(ctx context.Context, logger *zerolog.Logger, conf c
 	m.masterHookFuncs = masterKeyHookFuncs
 
 	// fd := os.Getpid()
-	var err error
 	model := m.conf.(*config.OpensslConfig).Model
 	switch model {
 	case config.TlsCaptureModelKeylog, config.TlsCaptureModelKey:

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/rs/zerolog"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,8 +95,8 @@ type MOpenSSLProbe struct {
 }
 
 // 对象初始化
-func (m *MOpenSSLProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig) error {
-	m.Module.Init(ctx, logger, conf)
+func (m *MOpenSSLProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
+	m.Module.Init(ctx, logger, conf, ecw)
 	m.conf = conf
 	m.Module.SetChild(m)
 	m.eventMaps = make([]*ebpf.Map, 0, 2)

--- a/user/module/probe_postgres.go
+++ b/user/module/probe_postgres.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gojue/ecapture/user/config"
 	"github.com/gojue/ecapture/user/event"
 	"github.com/rs/zerolog"
+	"io"
 	"math"
 	"os"
 
@@ -43,8 +44,8 @@ type MPostgresProbe struct {
 }
 
 // init probe
-func (p *MPostgresProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig) error {
-	p.Module.Init(ctx, logger, conf)
+func (p *MPostgresProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
+	p.Module.Init(ctx, logger, conf, ecw)
 	p.conf = conf
 	p.Module.SetChild(p)
 	p.eventMaps = make([]*ebpf.Map, 0, 2)

--- a/user/module/probe_postgres.go
+++ b/user/module/probe_postgres.go
@@ -45,7 +45,10 @@ type MPostgresProbe struct {
 
 // init probe
 func (p *MPostgresProbe) Init(ctx context.Context, logger *zerolog.Logger, conf config.IConfig, ecw io.Writer) error {
-	p.Module.Init(ctx, logger, conf, ecw)
+	err := p.Module.Init(ctx, logger, conf, ecw)
+	if err != nil {
+		return err
+	}
 	p.conf = conf
 	p.Module.SetChild(p)
 	p.eventMaps = make([]*ebpf.Map, 0, 2)


### PR DESCRIPTION
Distinguish between program operation logs and captured events; 

in the future, events will be read from the logger to generate HAR format records.