### PR TITLE
kern: support uid/pid filter in ebpf TC hook.

### DIFF
--- a/kern/mysqld_kern.c
+++ b/kern/mysqld_kern.c
@@ -63,10 +63,15 @@ int mysql56_query(struct pt_regs *ctx) {
 
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    u64 current_uid_gid = bpf_get_current_uid_gid();
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
     if (target_pid != 0 && target_pid != pid) {
+        return 0;
+    }
+    if (target_uid != 0 && target_uid != uid) {
         return 0;
     }
 #endif
@@ -111,10 +116,15 @@ int mysql56_query_return(struct pt_regs *ctx) {
 
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    u64 current_uid_gid = bpf_get_current_uid_gid();
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
     if (target_pid != 0 && target_pid != pid) {
+        return 0;
+    }
+    if (target_uid != 0 && target_uid != uid) {
         return 0;
     }
 #endif
@@ -184,10 +194,14 @@ int mysql57_query(struct pt_regs *ctx) {
 
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
-
+    u64 current_uid_gid = bpf_get_current_uid_gid();
+    u32 uid = current_uid_gid;
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
     if (target_pid != 0 && target_pid != pid) {
+        return 0;
+    }
+    if (target_uid != 0 && target_uid != uid) {
         return 0;
     }
 #endif
@@ -223,10 +237,16 @@ SEC("uretprobe/dispatch_command_57")
 int mysql57_query_return(struct pt_regs *ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
+    u64 current_uid_gid = bpf_get_current_uid_gid();
+    u32 uid = current_uid_gid;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
     if (target_pid != 0 && target_pid != pid) {
+        return 0;
+    }
+
+    if (target_uid != 0 && target_uid != uid) {
         return 0;
     }
 #endif

--- a/kern/postgres_kern.c
+++ b/kern/postgres_kern.c
@@ -36,10 +36,14 @@ SEC("uprobe/exec_simple_query")
 int postgres_query(struct pt_regs *ctx) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
-
+    u64 current_uid_gid = bpf_get_current_uid_gid();
+    u32 uid = current_uid_gid;
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
     if (target_pid != 0 && target_pid != pid) {
+        return 0;
+    }
+    if (target_uid != 0 && target_uid != uid) {
         return 0;
     }
 #endif

--- a/user/module/probe_openssl_pcap.go
+++ b/user/module/probe_openssl_pcap.go
@@ -76,7 +76,7 @@ func (m *MOpenSSLProbe) setupManagersPcap() error {
 
 	pcapFilter := m.conf.(*config.OpensslConfig).PcapFilter
 	m.logger.Info().Str("binrayPath", binaryPath).Str("IFname", m.ifName).Int("IFindex", m.ifIdex).
-		Str("PcapFilter", pcapFilter).Uint8("ElfType", m.conf.(*config.OpensslConfig).ElfType).Msg("HOOK type:Golang elf")
+		Str("PcapFilter", pcapFilter).Uint8("ElfType", m.conf.(*config.OpensslConfig).ElfType).Msg("HOOK type:Openssl elf")
 	m.logger.Info().Strs("Functions", m.masterHookFuncs).Msg("Hook masterKey function")
 
 	// create pcapng writer


### PR DESCRIPTION
remove uid/pid filter in kprobe/tcp_sendmsg.

tcp_sendmsg hook all processes are monitored, so there is no need to filter pid and uid, otherwise pid\uid cannot be used in the TC capture_packets function to filter network packets