### PR TITLE
style: unified space

### DIFF
--- a/cli/cmd/gotls.go
+++ b/cli/cmd/gotls.go
@@ -40,8 +40,8 @@ ecapture gotls -m pcap --pcapfile=save_android.pcapng -i wlan0 --elfpath=/home/c
 
 func init() {
 	gotlsCmd.PersistentFlags().StringVarP(&goc.Path, "elfpath", "e", "", "ELF path to binary built with Go toolchain.")
-	gotlsCmd.PersistentFlags().StringVarP(&goc.PcapFile, "pcapfile", "w", "ecapture_gotls.pcapng", "write the  raw packets to file as pcapng format.")
-	gotlsCmd.PersistentFlags().StringVarP(&goc.Model, "model", "m", "text", "capture model, such as : text, pcap/pcapng, key/keylog")
+	gotlsCmd.PersistentFlags().StringVarP(&goc.PcapFile, "pcapfile", "w", "ecapture_gotls.pcapng", "write the raw packets to file as pcapng format.")
+	gotlsCmd.PersistentFlags().StringVarP(&goc.Model, "model", "m", "text", "capture model, such as: text, pcap/pcapng, key/keylog")
 	gotlsCmd.PersistentFlags().StringVarP(&goc.KeylogFile, "keylogfile", "k", "ecapture_gotls_key.log", "The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.")
 	gotlsCmd.PersistentFlags().StringVarP(&goc.Ifname, "ifname", "i", "", "(TC Classifier) Interface name on which the probe will be attached.")
 	rootCmd.AddCommand(gotlsCmd)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -73,7 +73,7 @@ var rootCmd = &cobra.Command{
 such as HTTPS and TLS without installing a CA certificate.
 It can also capture bash commands, which is suitable for 
 security auditing scenarios, such as database auditing of mysqld, etc (disabled on Android).
-Support Linux(Android)  X86_64 4.18/aarch64 5.5 or newer.
+Support Linux(Android) X86_64 4.18/aarch64 5.5 or newer.
 Repository: https://github.com/gojue/ecapture
 HomePage: https://ecapture.cc
 

--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -49,11 +49,11 @@ func init() {
 	// opensslCmd.PersistentFlags().StringVar(&oc.Curlpath, "curl", "", "curl or wget file path, use to dectet openssl.so path, default:/usr/bin/curl. (Deprecated)")
 	opensslCmd.PersistentFlags().StringVar(&oc.Openssl, "libssl", "", "libssl.so file path, will automatically find it from curl default.")
 	opensslCmd.PersistentFlags().StringVar(&oc.CGroupPath, "cgroup_path", "/sys/fs/cgroup", "cgroup path, default: /sys/fs/cgroup.")
-	opensslCmd.PersistentFlags().StringVarP(&oc.Model, "model", "m", "text", "capture model, such as : text, pcap/pcapng, key/keylog")
+	opensslCmd.PersistentFlags().StringVarP(&oc.Model, "model", "m", "text", "capture model, such as: text, pcap/pcapng, key/keylog")
 	opensslCmd.PersistentFlags().StringVarP(&oc.KeylogFile, "keylogfile", "k", "ecapture_openssl_key.og", "The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.")
 	opensslCmd.PersistentFlags().StringVarP(&oc.PcapFile, "pcapfile", "w", "save.pcapng", "write the raw packets to file as pcapng format.")
 	opensslCmd.PersistentFlags().StringVarP(&oc.Ifname, "ifname", "i", "", "(TC Classifier) Interface name on which the probe will be attached.")
-	opensslCmd.PersistentFlags().StringVar(&oc.SslVersion, "ssl_version", "", "openssl/boringssl version， e.g: --ssl_version=\"openssl 1.1.1g\" or  --ssl_version=\"boringssl 1.1.1\"")
+	opensslCmd.PersistentFlags().StringVar(&oc.SslVersion, "ssl_version", "", "openssl/boringssl version， e.g: --ssl_version=\"openssl 1.1.1g\" or --ssl_version=\"boringssl 1.1.1\"")
 	rootCmd.AddCommand(opensslCmd)
 }
 

--- a/kern/bash_kern.c
+++ b/kern/bash_kern.c
@@ -60,7 +60,7 @@ int uretprobe_bash_readline(struct pt_regs *ctx) {
     event.pid = pid;
     event.uid = uid;
     event.type = BASH_EVENT_TYPE_READLINE;
-    // bpf_printk("!! uretprobe_bash_readline pid:%d",target_pid );
+    // bpf_printk("!! uretprobe_bash_readline pid: %d", target_pid );
     bpf_probe_read_user(&event.line, sizeof(event.line),
                         (void *)PT_REGS_RC(ctx));
     bpf_get_current_comm(&event.comm, sizeof(event.comm));

--- a/kern/boringssl_const.h
+++ b/kern/boringssl_const.h
@@ -58,6 +58,6 @@
 // bssl::SSL_HANDSHAKE->expected_client_finished_
 #define SSL_HANDSHAKE_EXPECTED_CLIENT_FINISHED_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*6
 
-///////////////////////////  END   ///////////////////////////
+///////////////////////////  END  ///////////////////////////
 
 #endif

--- a/kern/boringssl_masterkey.h
+++ b/kern/boringssl_masterkey.h
@@ -55,7 +55,7 @@ struct mastersecret_bssl_t {
     u8 exporter_secret[EVP_MAX_MD_SIZE];
 };
 
-// ssl/internal.h line 2653   SSL3_STATE
+// ssl/internal.h line 2653  SSL3_STATE
 struct ssl3_state_st {
     u64 read_sequence;
     //  确保BORINGSSL的state_st 中client_random 的偏移量是48
@@ -74,14 +74,14 @@ struct ssl3_state_st {
  * The judgment mechanism for TLS 1.3 follows the same approach.
  */
 // constant of boringssl SSL state
-#define CLIENT_STATE13_READ_SERVER_FINISHED 8  // ssl/tls13_client.cc line 51: state_read_server_finished
-#define CLIENT_STATE13_DONE 14  // ssl/tls13_client.cc line 51: state_done
+#define CLIENT_STATE13_READ_SERVER_FINISHED 8 // ssl/tls13_client.cc line 51: state_read_server_finished
+#define CLIENT_STATE13_DONE 14 // ssl/tls13_client.cc line 51: state_done
 #define SERVER_STATE13_READ_CLIENT_FINISHED 14 // ssl/internal.h line 1786: state13_read_client_finished
 #define SERVER_STATE13_SEND_NEW_SESSION_TICKET 15 // ssl/internal.h line 1786: state13_send_new_session_ticket
 #define SERVER_STATE13_DONE 16 // ssl/internal.h line 1786: state13_done
 
-#define CLIENT_STATE12_SEND_CLIENT_FINISHED 16  // ssl/handshake_client.cc line 201: state_send_client_finished
-#define CLIENT_STATE12_DONE 22  // ssl/handshake_client.cc line 201: state_done
+#define CLIENT_STATE12_SEND_CLIENT_FINISHED 16 // ssl/handshake_client.cc line 201: state_send_client_finished
+#define CLIENT_STATE12_DONE 22 // ssl/handshake_client.cc line 201: state_done
 #define SERVER_STATE12_READ_CLIENT_FINISHED 18 // ssl/internal.h line 1766: state12_read_client_finished
 #define SERVER_STATE12_DONE 21 // ssl/internal.h line 1766: state12_done
 
@@ -123,7 +123,7 @@ struct {
     __uint(max_entries, 1);
 } bpf_context_gen SEC(".maps");
 
-/////////////////////////COMMON FUNCTIONS ////////////////////////////////
+///////////////////////// COMMON FUNCTIONS /////////////////////////
 // 这个函数用来规避512字节栈空间限制，通过在堆上创建内存的方式，避开限制
 static __always_inline struct mastersecret_bssl_t *make_event() {
     u32 key_gen = 0;
@@ -151,7 +151,7 @@ static __always_inline u64 get_session_addr(void *ssl_st_ptr, u64 s3_address,
     // ssl_st
     if (ret == 0 && tmp_address != 0) {
         debug_bpf_printk(
-            "ssl_st->s3->hs->new_session is not null, address :%llx\n",
+            "ssl_st->s3->hs->new_session is not null, address: %llx\n",
             tmp_address);
         return tmp_address;
     }
@@ -162,8 +162,8 @@ static __always_inline u64 get_session_addr(void *ssl_st_ptr, u64 s3_address,
                               ssl_session_st_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_st_ptr:%llx, "
-            "ssl_session_st_ptr:%llx  failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_st_ptr: %llx, "
+            "ssl_session_st_ptr: %llx failed, ret: %d\n",
             ssl_st_ptr, ssl_new_session_st_ptr, ret);
         return 0;
     }
@@ -207,7 +207,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     int ret =
         bpf_probe_read_user(&version, sizeof(version), (void *)ssl_version_ptr);
     if (ret) {
-        debug_bpf_printk("bpf_probe_read tls_version failed, ret :%d\n", ret);
+        debug_bpf_printk("bpf_probe_read tls_version failed, ret: %d\n", ret);
         return 0;
     }
     mastersecret->version = version & 0xFFFF;  //  uint16_t version;
@@ -216,7 +216,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     ret = bpf_probe_read_user(&address, sizeof(address), ssl_s3_st_ptr);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl_s3_st_ptr pointer failed, ret :%d\n", ret);
+            "bpf_probe_read ssl_s3_st_ptr pointer failed, ret: %d\n", ret);
         return 0;
     }
     s3_address = address;
@@ -225,7 +225,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     ret = bpf_probe_read_user(&ssl3_stat, sizeof(ssl3_stat), (void *)address);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl3_state_st struct failed, ret :%d\n", ret);
+            "bpf_probe_read ssl3_state_st struct failed, ret: %d\n", ret);
         return 0;
     }
 
@@ -234,7 +234,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                                 (void *)&ssl3_stat.client_random);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read_kernel ssl3_stat.client_random failed, ret :%d\n",
+            "bpf_probe_read_kernel ssl3_stat.client_random failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -245,8 +245,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     ret = bpf_probe_read_user(&ssl_hs_st_addr, sizeof(ssl_hs_st_addr),
                               ssl_hs_st_ptr);
     if (ret || ssl_hs_st_addr == 0) {
-        //        debug_bpf_printk("bpf_probe_read ssl_hs_st_ptr failed, ret
-        //        :%d\n", ret);
+        //        debug_bpf_printk("bpf_probe_read ssl_hs_st_ptr failed, ret: "
+        //        "%d\n", ret);
         return 0;
     }
 
@@ -256,7 +256,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     ret = bpf_probe_read_user(&hash_len, sizeof(hash_len), ssl_hs_hashlen_ptr);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl_hs_st_ptr failed, ret :%d, hash_len:%d\n", ret,
+            "bpf_probe_read ssl_hs_st_ptr failed, ret: %d, hash_len: %d\n", ret,
             hash_len);
         return 0;
     }
@@ -270,7 +270,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     //    if (ret || client_version == 0) {
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl_hs_st_ptr failed, ret :%d, client_version:%d\n",
+            "bpf_probe_read ssl_hs_st_ptr failed, ret: %d, client_version: %d\n",
             ret, hash_len);
         return 0;
     }
@@ -281,7 +281,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)ssl_hs_state_ptr);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl_hs_state_ptr struct failed, ret :%d\n", ret);
+            "bpf_probe_read ssl_hs_state_ptr struct failed, ret: %d\n", ret);
         return 0;
     }
 
@@ -290,13 +290,13 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     //    if (ssl3_hs_state.state == 5 && ssl3_hs_state.tls13_state < 8) {
     //        return 0;
     //    }
-    ///////////// debug info  /////////
+    ///////////// debug info /////////////
 
-    debug_bpf_printk("client_version:%d, state:%d, tls13_state:%d\n",
+    debug_bpf_printk("client_version: %d, state: %d, tls13_state: %d\n",
                      client_version, ssl3_hs_state.state,
                      ssl3_hs_state.tls13_state);
-    //    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID :%d\n", pid);
-    debug_bpf_printk("TLS version :%d, hash_len:%d, \n", mastersecret->version,
+    //    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID: %d\n", pid);
+    debug_bpf_printk("TLS version: %d, hash_len: %d,\n", mastersecret->version,
                      hash_len);
     // 判断当前tls链接状态
     // handshake->handshake_finalized = hs_st_addr + BSSL__SSL_HANDSHAKE_HINTS +
@@ -305,12 +305,12 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     ret = bpf_probe_read_user(&all_bool, sizeof(all_bool), hs_ptr_ab);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read BSSL__SSL_HANDSHAKE_HINTS failed, ret "
-            ":%d, ssl_hs_st_ptr:%lx\n",
+            "bpf_probe_read BSSL__SSL_HANDSHAKE_HINTS failed, ret: "
+            "%d, ssl_hs_st_ptr: %lx\n",
             ret, ssl_hs_st_addr);
         return 0;
     }
-    debug_bpf_printk("SSL_HANDSHAKE_ALLBOOL:%d, ssl_hs_st_addr:%lx\n", all_bool,
+    debug_bpf_printk("SSL_HANDSHAKE_ALLBOOL: %d, ssl_hs_st_addr: %lx\n", all_bool,
                      ssl_hs_st_addr);
 
     ///////////////////////// get TLS 1.2 master secret ////////////////////
@@ -327,7 +327,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
             //            debug_bpf_printk("ssl_session_st_addr is null\n");
             return 0;
         }
-        debug_bpf_printk("s3_address:%llx, ssl_session_st_addr addr :%llx\n",
+        debug_bpf_printk("s3_address: %llx, ssl_session_st_addr addr: %llx\n",
                          s3_address, ssl_session_st_addr);
 
         s32 secret_length;
@@ -338,21 +338,21 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         if (ret) {
             debug_bpf_printk(
                 "bpf_probe_read SSL_SESSION_ST_SECRET_LENGTH failed, "
-                "ms_len_ptr:%llx, ret "
-                ":%d\n",
+                "ms_len_ptr: %llx, ret: "
+                "%d\n",
                 ms_len_ptr, ret);
             return 0;
         }
         mastersecret->hash_len = secret_length;
-        debug_bpf_printk(" secret_length:%d\n", secret_length);
+        debug_bpf_printk("secret_length: %d\n", secret_length);
 
         u64 *ms_ptr = (u64 *)(ssl_session_st_addr + SSL_SESSION_ST_SECRET);
         ret = bpf_probe_read_user(&mastersecret->secret_,
                                   sizeof(mastersecret->secret_), ms_ptr);
         if (ret) {
             debug_bpf_printk(
-                "bpf_probe_read SSL_SESSION_ST_SECRET failed, ms_ptr:%llx, ret "
-                ":%d\n",
+                "bpf_probe_read SSL_SESSION_ST_SECRET failed, ms_ptr: %llx, ret: "
+                "%d\n",
                 ms_ptr, ret);
             return 0;
         }
@@ -378,8 +378,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)hs_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_HANDSHAKE_CLIENT_HANDSHAKE_SECRET_ failed, ret "
-            ":%d\n",
+            "bpf_probe_read SSL_HANDSHAKE_CLIENT_HANDSHAKE_SECRET_ failed, ret: "
+            "%d\n",
             ret);
         return 0;
     }
@@ -393,8 +393,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)hth_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_HANDSHAKE_SERVER_TRAFFIC_SECRET_0_ failed, ret "
-            ":%d\n",
+            "bpf_probe_read SSL_HANDSHAKE_SERVER_TRAFFIC_SECRET_0_ failed, ret: "
+            "%d\n",
             ret);
         return 0;
     }
@@ -406,8 +406,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)cats_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_HANDSHAKE_CLIENT_TRAFFIC_SECRET_0_ failed, ret "
-            ":%d\n",
+            "bpf_probe_read SSL_HANDSHAKE_CLIENT_TRAFFIC_SECRET_0_ failed, ret: "
+            "%d\n",
             ret);
         return 0;
     }
@@ -419,8 +419,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)sats_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_HANDSHAKE_SERVER_TRAFFIC_SECRET_0_ failed, ret "
-            ":%d\n",
+            "bpf_probe_read SSL_HANDSHAKE_SERVER_TRAFFIC_SECRET_0_ failed, ret: "
+            "%d\n",
             ret);
         return 0;
     }
@@ -433,7 +433,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     if (ret) {
         debug_bpf_printk(
             "bpf_probe_read SSL_HANDSHAKE_EXPECTED_CLIENT_FINISHED_ failed, "
-            "ret :%d\n",
+            "ret: %d\n",
             ret);
         return 0;
     }

--- a/kern/gnutls_kern.c
+++ b/kern/gnutls_kern.c
@@ -126,7 +126,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("gnutls uprobe/gnutls_record_send pid :%d\n", pid);
+    debug_bpf_printk("gnutls uprobe/gnutls_record_send pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -150,7 +150,7 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("gnutls uretprobe/gnutls_record_send pid :%d\n", pid);
+    debug_bpf_printk("gnutls uretprobe/gnutls_record_send pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -182,7 +182,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("gnutls uprobe/gnutls_record_recv pid :%d\n", pid);
+    debug_bpf_printk("gnutls uprobe/gnutls_record_recv pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -206,7 +206,7 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("gnutls uretprobe/gnutls_record_recv pid :%d\n", pid);
+    debug_bpf_printk("gnutls uretprobe/gnutls_record_recv pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids

--- a/kern/gotls_kern.c
+++ b/kern/gotls_kern.c
@@ -109,7 +109,7 @@ static __always_inline int gotls_write(struct pt_regs *ctx,
     if (len == 0) {
         return 0;
     }
-    debug_bpf_printk("gotls_write record_type:%d, len:%d\n", record_type, len);
+    debug_bpf_printk("gotls_write record_type: %d, len: %d\n", record_type, len);
     if (record_type != recordTypeApplicationData) {
         return 0;
     }
@@ -124,7 +124,7 @@ static __always_inline int gotls_write(struct pt_regs *ctx,
         bpf_probe_read_user(&event->data, sizeof(event->data), (void *)str);
     if (ret < 0) {
         debug_bpf_printk(
-            "gotls_write bpf_probe_read_user_str failed, ret:%d, str:%d\n", ret,
+            "gotls_write bpf_probe_read_user_str failed, ret: %d, str: %d\n", ret,
             str);
         return 0;
     }
@@ -172,8 +172,8 @@ static __always_inline int gotls_read(struct pt_regs *ctx,
         return 0;
     }
 
-    debug_bpf_printk("gotls_read event, str addr:%p, len:%d\n", len_ptr, len);
-    debug_bpf_printk("gotls_read event, str ret_len_ptr:%d, ret_len:%d\n",
+    debug_bpf_printk("gotls_read event, str addr: %p, len: %d\n", len_ptr, len);
+    debug_bpf_printk("gotls_read event, str ret_len_ptr: %d, ret_len: %d\n",
                      ret_len_ptr, ret_len);
     event->data_len = len;
     event->event_type = GOTLS_EVENT_TYPE_READ;
@@ -181,7 +181,7 @@ static __always_inline int gotls_read(struct pt_regs *ctx,
         bpf_probe_read_user(&event->data, sizeof(event->data), (void *)str);
     if (ret < 0) {
         debug_bpf_printk(
-            "gotls_text bpf_probe_read_user_str failed, ret:%d, str:%d\n", ret,
+            "gotls_text bpf_probe_read_user_str failed, ret: %d, str: %d\n", ret,
             str);
         return 0;
     }
@@ -238,8 +238,8 @@ static __always_inline int gotls_mastersecret(struct pt_regs *ctx,
     }
 
     debug_bpf_printk(
-        "gotls_mastersecret read params length success, lab_len:%d, cr_len:%d, "
-        "secret_len:%d\n",
+        "gotls_mastersecret read params length success, lab_len: %d, cr_len: %d, "
+        "secret_len: %d\n",
         lab_len, cr_len, secret_len);
 
     struct mastersecret_gotls_t mastersecret_gotls = {};
@@ -251,13 +251,13 @@ static __always_inline int gotls_mastersecret(struct pt_regs *ctx,
                                       (void *)lab_ptr);
     if (ret < 0) {
         debug_bpf_printk(
-            "gotls_mastersecret read mastersecret label failed, ret:%d, "
-            "lab_ptr:%p\n",
+            "gotls_mastersecret read mastersecret label failed, ret: %d, "
+            "lab_ptr: %p\n",
             ret, lab_ptr);
         return 0;
     }
 
-    debug_bpf_printk("gotls_mastersecret read mastersecret label:%s\n",
+    debug_bpf_printk("gotls_mastersecret read mastersecret label: %s\n",
                      mastersecret_gotls.label);
     ret = bpf_probe_read_user_str(&mastersecret_gotls.client_random,
                                   sizeof(mastersecret_gotls.client_random),
@@ -265,7 +265,7 @@ static __always_inline int gotls_mastersecret(struct pt_regs *ctx,
     if (ret < 0) {
         debug_bpf_printk(
             "gotls_mastersecret read mastersecret client_random failed, "
-            "ret:%d, cr_ptr:%p\n",
+            "ret: %d, cr_ptr: %p\n",
             ret, cr_ptr);
         return 0;
     }
@@ -275,8 +275,8 @@ static __always_inline int gotls_mastersecret(struct pt_regs *ctx,
                                   (void *)secret_ptr);
     if (ret < 0) {
         debug_bpf_printk(
-            "gotls_mastersecret read mastersecret secret_ failed, ret:%d, "
-            "secret_ptr:%p\n",
+            "gotls_mastersecret read mastersecret secret_ failed, ret: %d, "
+            "secret_ptr: %p\n",
             ret, secret_ptr);
         return 0;
     }

--- a/kern/mysqld_kern.c
+++ b/kern/mysqld_kern.c
@@ -134,9 +134,9 @@ int mysql56_query_return(struct pt_regs *ctx) {
     if (!data) {
         return 0;  // missed start
     }
-    debug_bpf_printk("mysql query:%s\n", data->query);
+    debug_bpf_printk("mysql query: %s\n", data->query);
     data->retval = command_return;
-    debug_bpf_printk("mysql query return :%d\n", command_return);
+    debug_bpf_printk("mysql query return: %d\n", command_return);
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, data,
                           sizeof(struct data_t));
     return 0;
@@ -256,8 +256,8 @@ int mysql57_query_return(struct pt_regs *ctx) {
     if (!data) {
         return 0;  // missed start
     }
-    debug_bpf_printk("mysql57+ query:%s\n", data->query);
-    debug_bpf_printk("mysql57+ query return :%d\n", command_return);
+    debug_bpf_printk("mysql57+ query: %s\n", data->query);
+    debug_bpf_printk("mysql57+ query return: %d\n", command_return);
     if (command_return == 1) {
         data->retval = DISPATCH_COMMAND_V57_FAILED;
     } else {

--- a/kern/nspr_kern.c
+++ b/kern/nspr_kern.c
@@ -123,7 +123,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("nspr uprobe/PR_Write pid :%d\n", pid);
+    debug_bpf_printk("nspr uprobe/PR_Write pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -147,7 +147,7 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("nspr uretprobe/PR_Write pid :%d\n", pid);
+    debug_bpf_printk("nspr uretprobe/PR_Write pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -180,7 +180,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("nspr uprobe/PR_Read pid :%d\n", pid);
+    debug_bpf_printk("nspr uprobe/PR_Read pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -204,7 +204,7 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("nspr uretprobe/PR_Read pid :%d\n", pid);
+    debug_bpf_printk("nspr uretprobe/PR_Read pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids

--- a/kern/openssl.h
+++ b/kern/openssl.h
@@ -186,7 +186,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
         return 0;
     }
 #endif
-    debug_bpf_printk("openssl uprobe/SSL_write pid :%d\n", pid);
+    debug_bpf_printk("openssl uprobe/SSL_write pid: %d\n", pid);
 
     void* ssl = (void*)PT_REGS_PARM1(ctx);
     // https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/bio/bio_local.h
@@ -200,7 +200,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
                               ssl_ver_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_ver_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_ver_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -210,7 +210,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
                               ssl_wbio_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_wbio_addr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_wbio_addr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -221,7 +221,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
                               ssl_wbio_num_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_wbio_num_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_wbio_num_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -236,7 +236,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
         } else {
         }
     }
-    debug_bpf_printk("openssl uprobe SSL_write FD:%d, version:%d\n", fd, ssl_version);
+    debug_bpf_printk("openssl uprobe SSL_write FD: %d, version: %d\n", fd, ssl_version);
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     struct active_ssl_buf active_ssl_buf_t;
@@ -266,7 +266,7 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
         return 0;
     }
 #endif
-    debug_bpf_printk("openssl uretprobe/SSL_write pid :%d\n", pid);
+    debug_bpf_printk("openssl uretprobe/SSL_write pid: %d\n", pid);
     struct active_ssl_buf* active_ssl_buf_t =
         bpf_map_lookup_elem(&active_ssl_write_args_map, &current_pid_tgid);
     if (active_ssl_buf_t != NULL) {
@@ -288,7 +288,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("openssl uprobe/SSL_read pid :%d\n", pid);
+    debug_bpf_printk("openssl uprobe/SSL_read pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -312,7 +312,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
                               ssl_ver_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_ver_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_ver_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -322,7 +322,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
                               ssl_rbio_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_rbio_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_rbio_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -333,7 +333,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
                               ssl_rbio_num_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_rbio_num_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_rbio_num_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -347,7 +347,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
         } else {
         }
     }
-    debug_bpf_printk("openssl uprobe PID:%d, SSL_read FD:%d\n", pid, fd);
+    debug_bpf_printk("openssl uprobe PID: %d, SSL_read FD: %d\n", pid, fd);
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     struct active_ssl_buf active_ssl_buf_t;
@@ -366,7 +366,7 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("openssl uretprobe/SSL_read pid :%d\n", pid);
+    debug_bpf_printk("openssl uretprobe/SSL_read pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -423,7 +423,7 @@ int probe_connect(struct pt_regs* ctx) {
         return 0;
     }
 
-    debug_bpf_printk("@ sockaddr FM :%d\n", address_family);
+    debug_bpf_printk("@ sockaddr FM: %d\n", address_family);
 
     struct connect_event_t conn;
     __builtin_memset(&conn, 0, sizeof(conn));
@@ -454,6 +454,6 @@ int probe_SSL_set_fd(struct pt_regs* ctx) {
     u64 ssl_addr = (u64)PT_REGS_PARM1(ctx);
     u64 fd = (u64)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&ssl_st_fd, &ssl_addr, &fd, BPF_ANY);
-    debug_bpf_printk("SSL_set_fd hook!!, ssl_addr:%d, fd:%d\n", ssl_addr, fd);
+    debug_bpf_printk("SSL_set_fd hook!!, ssl_addr: %d, fd: %d\n", ssl_addr, fd);
     return 0;
 }

--- a/kern/openssl_masterkey.h
+++ b/kern/openssl_masterkey.h
@@ -94,7 +94,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         return 0;
     }
 #endif
-    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID :%d\n", pid);
+    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID: %d\n", pid);
 
     // mastersecret_t sent to userspace
     struct mastersecret_t *mastersecret = make_event();
@@ -114,17 +114,17 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     int ret =
         bpf_probe_read_user(&version, sizeof(version), (void *)ssl_version_ptr);
     if (ret) {
-        debug_bpf_printk("bpf_probe_read tls_version failed, ret :%d\n", ret);
+        debug_bpf_printk("bpf_probe_read tls_version failed, ret: %d\n", ret);
         return 0;
     }
     mastersecret->version = version;  // int version;
-    debug_bpf_printk("TLS version :%d\n", mastersecret->version);
+    debug_bpf_printk("TLS version: %d\n", mastersecret->version);
 
     // Get ssl3_state_st pointer
     ret = bpf_probe_read_user(&address, sizeof(address), ssl_s3_st_ptr);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl_s3_st_ptr pointer failed, ret :%d\n", ret);
+            "bpf_probe_read ssl_s3_st_ptr pointer failed, ret: %d\n", ret);
         return 0;
     }
 
@@ -135,7 +135,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)s3_st_client_random_ptr);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl3_state_st struct failed, ret :%d\n", ret);
+            "bpf_probe_read ssl3_state_st struct failed, ret: %d\n", ret);
         return 0;
     }
     debug_bpf_printk("client_random: %x %x %x\n", mastersecret->client_random[0],
@@ -150,7 +150,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               ssl_session_st_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_session_st_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_session_st_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -163,8 +163,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                                   sizeof(mastersecret->master_key), ms_ptr);
         if (ret) {
             debug_bpf_printk(
-                "bpf_probe_read MASTER_KEY_OFFSET failed, ms_ptr:%llx, ret "
-                ":%d\n",
+                "bpf_probe_read MASTER_KEY_OFFSET failed, ms_ptr: %llx, ret: "
+                "%d\n",
                 ms_ptr, ret);
             return 0;
         }
@@ -188,7 +188,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     ret = bpf_probe_read_user(&address, sizeof(address), ssl_cipher_st_ptr);
     if (ret || address == 0) {
         debug_bpf_printk(
-            "bpf_probe_read ssl_cipher_st_ptr failed, ret :%d, address:%x\n",
+            "bpf_probe_read ssl_cipher_st_ptr failed, ret: %d, address: %x\n",
             ret, address);
         // return 0;
         void *cipher_id_ptr =
@@ -199,7 +199,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         if (ret) {
             debug_bpf_printk(
                 "bpf_probe_read SSL_SESSION_ST_CIPHER_ID failed from "
-                "SSL_SESSION->cipher_id, ret :%d\n",
+                "SSL_SESSION->cipher_id, ret: %d\n",
                 ret);
             return 0;
         }
@@ -212,7 +212,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         if (ret) {
             debug_bpf_printk(
                 "bpf_probe_read SSL_CIPHER_ST_ID failed from "
-                "ssl_cipher_st->id, ret :%d\n",
+                "ssl_cipher_st->id, ret: %d\n",
                 ret);
             return 0;
         }
@@ -228,7 +228,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)hs_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_HANDSHAKE_SECRET failed, ret :%d\n", ret);
+            "bpf_probe_read SSL_ST_HANDSHAKE_SECRET failed, ret: %d\n", ret);
         return 0;
     }
 
@@ -238,7 +238,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)hth_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_HANDSHAKE_TRAFFIC_HASH failed, ret :%d\n",
+            "bpf_probe_read SSL_ST_HANDSHAKE_TRAFFIC_HASH failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -250,7 +250,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)cats_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_CLIENT_APP_TRAFFIC_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_ST_CLIENT_APP_TRAFFIC_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -262,7 +262,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)sats_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_SERVER_APP_TRAFFIC_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_ST_SERVER_APP_TRAFFIC_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -273,7 +273,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)ems_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_EXPORTER_MASTER_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_ST_EXPORTER_MASTER_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }

--- a/kern/openssl_masterkey_3.0.h
+++ b/kern/openssl_masterkey_3.0.h
@@ -94,7 +94,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         return 0;
     }
 #endif
-    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID :%d\n", pid);
+    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID: %d\n", pid);
 
     // mastersecret_t sent to userspace
     struct mastersecret_t *mastersecret = make_event();
@@ -112,11 +112,11 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     int ret =
         bpf_probe_read_user(&version, sizeof(version), (void *)ssl_version_ptr);
     if (ret) {
-        debug_bpf_printk("bpf_probe_read tls_version failed, ret :%d\n", ret);
+        debug_bpf_printk("bpf_probe_read tls_version failed, ret: %d\n", ret);
         return 0;
     }
     mastersecret->version = version;  // int version;
-    debug_bpf_printk("TLS version :%d\n", mastersecret->version);
+    debug_bpf_printk("TLS version: %d\n", mastersecret->version);
 
     u64 *ssl_client_random_ptr = (u64 *)(ssl_st_ptr + SSL_ST_S3_CLIENT_RANDOM);
     // get SSL_ST_S3_CLIENT_RANDOM
@@ -125,7 +125,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)ssl_client_random_ptr);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl3_ssl_client_random_ptr_st failed, ret :%d\n",
+            "bpf_probe_read ssl3_ssl_client_random_ptr_st failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -136,7 +136,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                                 (void *)&client_random);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read_kernel ssl3_stat.client_random failed, ret :%d\n",
+            "bpf_probe_read_kernel ssl3_stat.client_random failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -150,7 +150,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               ssl_session_st_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_session_st_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_session_st_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -163,8 +163,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                                   sizeof(mastersecret->master_key), ms_ptr);
         if (ret) {
             debug_bpf_printk(
-                "bpf_probe_read MASTER_KEY_OFFSET failed, ms_ptr:%llx, ret "
-                ":%d\n",
+                "bpf_probe_read MASTER_KEY_OFFSET failed, ms_ptr: %llx, ret: "
+                "%d\n",
                 ms_ptr, ret);
             return 0;
         }
@@ -188,7 +188,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     ret = bpf_probe_read_user(&address, sizeof(address), ssl_cipher_st_ptr);
     if (ret || address == 0) {
         debug_bpf_printk(
-            "bpf_probe_read ssl_cipher_st_ptr failed, ret :%d, address:%x\n",
+            "bpf_probe_read ssl_cipher_st_ptr failed, ret: %d, address: %x\n",
             ret, address);
         // return 0;
         void *cipher_id_ptr =
@@ -199,7 +199,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         if (ret) {
             debug_bpf_printk(
                 "bpf_probe_read SSL_SESSION_ST_CIPHER_ID failed from "
-                "SSL_SESSION->cipher_id, ret :%d\n",
+                "SSL_SESSION->cipher_id, ret: %d\n",
                 ret);
             return 0;
         }
@@ -212,7 +212,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         if (ret) {
             debug_bpf_printk(
                 "bpf_probe_read SSL_CIPHER_ST_ID failed from "
-                "ssl_cipher_st->id, ret :%d\n",
+                "ssl_cipher_st->id, ret: %d\n",
                 ret);
             return 0;
         }
@@ -228,7 +228,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)hs_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_HANDSHAKE_SECRET failed, ret :%d\n", ret);
+            "bpf_probe_read SSL_ST_HANDSHAKE_SECRET failed, ret: %d\n", ret);
         return 0;
     }
 
@@ -238,7 +238,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)hth_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_HANDSHAKE_TRAFFIC_HASH failed, ret :%d\n",
+            "bpf_probe_read SSL_ST_HANDSHAKE_TRAFFIC_HASH failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -250,7 +250,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)cats_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_CLIENT_APP_TRAFFIC_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_ST_CLIENT_APP_TRAFFIC_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -262,7 +262,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)sats_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_SERVER_APP_TRAFFIC_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_ST_SERVER_APP_TRAFFIC_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -273,7 +273,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)ems_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_ST_EXPORTER_MASTER_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_ST_EXPORTER_MASTER_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }

--- a/kern/openssl_masterkey_3.2.h
+++ b/kern/openssl_masterkey_3.2.h
@@ -98,7 +98,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         return 0;
     }
 #endif
-    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID :%d\n", pid);
+    debug_bpf_printk("openssl uprobe/SSL_write masterKey PID: %d\n", pid);
 
     // mastersecret_t sent to userspace
     struct mastersecret_t *mastersecret = make_event();
@@ -124,11 +124,11 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     int ret =
         bpf_probe_read_user(&version, sizeof(version), (void *)ssl_version_ptr);
     if (ret) {
-        debug_bpf_printk("bpf_probe_read tls_version failed, ret :%d\n", ret);
+        debug_bpf_printk("bpf_probe_read tls_version failed, ret: %d\n", ret);
         return 0;
     }
     mastersecret->version = version;  // int version;
-    debug_bpf_printk("TLS version :%d\n", mastersecret->version);
+    debug_bpf_printk("TLS version: %d\n", mastersecret->version);
 
     u64 *ssl_client_random_ptr = (u64 *)(ssl_st_ptr + SSL_CONNECTION_ST_S3_CLIENT_RANDOM);
     // get SSL_CONNECTION_ST_S3_CLIENT_RANDOM
@@ -137,7 +137,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)ssl_client_random_ptr);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read ssl3_ssl_client_random_ptr_st failed, ret :%d\n",
+            "bpf_probe_read ssl3_ssl_client_random_ptr_st failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -148,7 +148,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                                 (void *)&client_random);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read_kernel ssl3_stat.client_random failed, ret :%d\n",
+            "bpf_probe_read_kernel ssl3_stat.client_random failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -162,7 +162,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               ssl_session_st_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_session_st_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_session_st_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -175,8 +175,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                                   sizeof(mastersecret->master_key), ms_ptr);
         if (ret) {
             debug_bpf_printk(
-                "bpf_probe_read MASTER_KEY_OFFSET failed, ms_ptr:%llx, ret "
-                ":%d\n",
+                "bpf_probe_read MASTER_KEY_OFFSET failed, ms_ptr: %llx, ret: "
+                "%d\n",
                 ms_ptr, ret);
             return 0;
         }
@@ -200,7 +200,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     ret = bpf_probe_read_user(&address, sizeof(address), ssl_cipher_st_ptr);
     if (ret || address == 0) {
         debug_bpf_printk(
-            "bpf_probe_read ssl_cipher_st_ptr failed, ret :%d, address:%x\n",
+            "bpf_probe_read ssl_cipher_st_ptr failed, ret: %d, address: %x\n",
             ret, address);
         // return 0;
         void *cipher_id_ptr =
@@ -211,7 +211,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         if (ret) {
             debug_bpf_printk(
                 "bpf_probe_read SSL_SESSION_ST_CIPHER_ID failed from "
-                "SSL_SESSION->cipher_id, ret :%d\n",
+                "SSL_SESSION->cipher_id, ret: %d\n",
                 ret);
             return 0;
         }
@@ -224,7 +224,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         if (ret) {
             debug_bpf_printk(
                 "bpf_probe_read SSL_CIPHER_ST_ID failed from "
-                "ssl_cipher_st->id, ret :%d\n",
+                "ssl_cipher_st->id, ret: %d\n",
                 ret);
             return 0;
         }
@@ -240,7 +240,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)hs_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_CONNECTION_ST_HANDSHAKE_SECRET failed, ret :%d\n", ret);
+            "bpf_probe_read SSL_CONNECTION_ST_HANDSHAKE_SECRET failed, ret: %d\n", ret);
         return 0;
     }
 
@@ -250,7 +250,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)hth_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_CONNECTION_ST_HANDSHAKE_TRAFFIC_HASH failed, ret :%d\n",
+            "bpf_probe_read SSL_CONNECTION_ST_HANDSHAKE_TRAFFIC_HASH failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -262,7 +262,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)cats_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_CONNECTION_ST_CLIENT_APP_TRAFFIC_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_CONNECTION_ST_CLIENT_APP_TRAFFIC_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -274,7 +274,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)sats_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_CONNECTION_ST_SERVER_APP_TRAFFIC_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_CONNECTION_ST_SERVER_APP_TRAFFIC_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -285,7 +285,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
                               (void *)ems_ptr_tls13);
     if (ret) {
         debug_bpf_printk(
-            "bpf_probe_read SSL_CONNECTION_ST_EXPORTER_MASTER_SECRET failed, ret :%d\n",
+            "bpf_probe_read SSL_CONNECTION_ST_EXPORTER_MASTER_SECRET failed, ret: %d\n",
             ret);
         return 0;
     }

--- a/kern/tc.h
+++ b/kern/tc.h
@@ -219,7 +219,7 @@ static __always_inline int capture_packets(struct __sk_buff *skb, bool is_ingres
                                  l4_hdr_off + sizeof(struct tcphdr))) {
             return TC_ACT_OK;
         }
-        // debug_bpf_printk("!!!capture_packets src_ip4 : %d, dst_ip4 port :%d\n", conn_id.src_ip4, conn_id.dst_ip4);
+        // debug_bpf_printk("!!!capture_packets src_ip4: %d, dst_ip4 port: %d\n", conn_id.src_ip4, conn_id.dst_ip4);
         // udp protocol reuse tcphdr
         struct tcphdr *hdr = (struct tcphdr *)(data_start + l4_hdr_off);
 
@@ -230,7 +230,7 @@ static __always_inline int capture_packets(struct __sk_buff *skb, bool is_ingres
 
         conn_id.src_port = bpf_ntohs(hdr->source);
         conn_id.dst_port = bpf_ntohs(hdr->dest);
-        // debug_bpf_printk("!!!capture_packets port : %d, dest port :%d\n", conn_id.src_port, conn_id.dst_port);
+        // debug_bpf_printk("!!!capture_packets port: %d, dest port: %d\n", conn_id.src_port, conn_id.dst_port);
         net_ctx = bpf_map_lookup_elem(&network_map, &conn_id);
         if (net_ctx == NULL) {
             // exchange src and dst
@@ -259,7 +259,7 @@ static __always_inline int capture_packets(struct __sk_buff *skb, bool is_ingres
 #endif
         event.pid = net_ctx->pid;
         __builtin_memcpy(event.comm, net_ctx->comm, TASK_COMM_LEN);
-        debug_bpf_printk("capture packet process found, pid: %d, comm :%s\n", event.pid, event.comm);
+        debug_bpf_printk("capture packet process found, pid: %d, comm: %s\n", event.pid, event.comm);
     }
 
     event.ts = bpf_ktime_get_ns();
@@ -280,7 +280,7 @@ static __always_inline int capture_packets(struct __sk_buff *skb, bool is_ingres
     bpf_perf_event_output(skb, &skb_events, flags, &event, pkt_size);
 
     //    debug_bpf_printk("new packet captured on egress/ingress (TC),
-    //    length:%d\n", data_len);
+    //    length: %d\n", data_len);
     return TC_ACT_OK;
 }
 
@@ -350,7 +350,7 @@ int tcp_sendmsg(struct pt_regs *ctx){
     net_ctx.uid = uid;
     bpf_get_current_comm(&net_ctx.comm, sizeof(net_ctx.comm));
 
-    debug_bpf_printk("tcp_sendmsg pid : %d, comm :%s\n", net_ctx.pid, net_ctx.comm);
+    debug_bpf_printk("tcp_sendmsg pid: %d, comm: %s\n", net_ctx.pid, net_ctx.comm);
     bpf_map_update_elem(&network_map, &conn_id, &net_ctx, BPF_ANY);
     return 0;
 };

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 			log.Fatalf("The Linux/Android Kernel version %v (aarch64) is not supported. Requires a version greater than 5.5.", kv)
 		}
 	default:
-		log.Fatalf("Unsupported CPU arch:%v. ", runtime.GOARCH)
+		log.Fatalf("Unsupported CPU arch: %v.", runtime.GOARCH)
 	}
 
 	cli.Start()

--- a/pkg/event_processor/base_event.go
+++ b/pkg/event_processor/base_event.go
@@ -147,7 +147,7 @@ func (be *BaseEvent) StringHex() string {
 	b := dumpByteSlice(be.Data[:be.DataLen], prefix)
 
 	v := tlsVersion{version: be.Version}
-	s := fmt.Sprintf("PID:%d, Comm:%s, TID:%d, %s, Version:%s, Payload:\n%s", be.Pid, CToGoString(be.Comm[:]), be.Tid, connInfo, v.String(), b.String())
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, %s, Version: %s, Payload:\n%s", be.Pid, CToGoString(be.Comm[:]), be.Tid, connInfo, v.String(), b.String())
 	return s
 }
 
@@ -163,7 +163,7 @@ func (be *BaseEvent) String() string {
 		connInfo = fmt.Sprintf("UNKNOW_%d", be.DataType)
 	}
 	v := tlsVersion{version: be.Version}
-	s := fmt.Sprintf("PID:%d, Comm:%s, TID:%d, Version:%s, %s, Payload:\n%s", be.Pid, bytes.TrimSpace(be.Comm[:]), be.Tid, v.String(), connInfo, string(be.Data[:be.DataLen]))
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, Version: %s, %s, Payload:\n%s", be.Pid, bytes.TrimSpace(be.Comm[:]), be.Tid, v.String(), connInfo, string(be.Data[:be.DataLen]))
 	return s
 }
 

--- a/pkg/event_processor/http2_request_test.go
+++ b/pkg/event_processor/http2_request_test.go
@@ -25,7 +25,7 @@ func TestHttp2RequestParser(t *testing.T) {
 	h2File := "testdata/952293616935738.bin"
 	httpBody, err := os.ReadFile(h2File)
 	if err != nil {
-		t.Fatalf("TestHttp2RequestParser: read payload file error: %s, file:%s", err.Error(), h2File)
+		t.Fatalf("TestHttp2RequestParser: read payload file error: %s, file: %s", err.Error(), h2File)
 	}
 
 	h2r := &HTTP2Request{}
@@ -38,27 +38,27 @@ func TestHttp2RequestParser(t *testing.T) {
 	if e != nil {
 		t.Errorf("TestHttp2RequestParser: write http request failed: %v", e)
 	}
-	t.Logf("TestHttp2RequestParser: wrot body:%d", i)
+	t.Logf("TestHttp2RequestParser: wrot body: %d", i)
 
 	_, err = h2r.bufReader.Discard(H2MagicLen)
 	if err != nil {
-		t.Logf("[http2 request] Discard HTTP2 Magic error:%v", err)
+		t.Logf("[http2 request] Discard HTTP2 Magic error: %v", err)
 	}
 	var frameTypes = make([]string, 0)
 	for {
 		f, err := h2r.framer.ReadFrame()
 		if err != nil {
 			if err != io.EOF {
-				t.Fatalf("[http2 response] read http2 response frame error:%v", err)
+				t.Fatalf("[http2 response] read http2 response frame error: %v", err)
 			}
 			break
 		}
 		switch f := f.(type) {
 		case *http2.MetaHeadersFrame:
-			t.Logf("TestHttp2RequestParser: frame type:%s", f.Type)
+			t.Logf("TestHttp2RequestParser: frame type: %s", f.Type)
 			frameTypes = append(frameTypes, f.Type.String())
 		case *http2.DataFrame:
-			t.Logf("TestHttp2RequestParser: frame type:%s", f.Type)
+			t.Logf("TestHttp2RequestParser: frame type: %s", f.Type)
 			frameTypes = append(frameTypes, f.Type.String())
 		default:
 			fh := f.Header()
@@ -67,6 +67,6 @@ func TestHttp2RequestParser(t *testing.T) {
 		}
 	}
 	if len(frameTypes) != 5 {
-		t.Fatalf("TestHttp2ResponseParser: frameTypes length error, want: 5, got:%d", len(frameTypes))
+		t.Fatalf("TestHttp2ResponseParser: frameTypes length error, want: 5, got: %d", len(frameTypes))
 	}
 }

--- a/pkg/event_processor/http2_response_test.go
+++ b/pkg/event_processor/http2_response_test.go
@@ -25,7 +25,7 @@ func TestHttp2ResponseParser(t *testing.T) {
 	h2ResponseFile := "testdata/952293616935739.bin"
 	httpBody, err := os.ReadFile(h2ResponseFile)
 	if err != nil {
-		t.Fatalf("TestHttp2ResponseParser: read payload file error: %s, file:%s", err.Error(), h2ResponseFile)
+		t.Fatalf("TestHttp2ResponseParser: read payload file error: %s, file: %s", err.Error(), h2ResponseFile)
 	}
 
 	h2r := &HTTP2Response{}
@@ -38,7 +38,7 @@ func TestHttp2ResponseParser(t *testing.T) {
 	if err != nil {
 		t.Errorf("TestHttp2ResponseParser: write http response failed: %v", err)
 	}
-	t.Logf("TestHttp2ResponseParser: wrot body:%d", i)
+	t.Logf("TestHttp2ResponseParser: wrot body: %d", i)
 
 	var frameTypes = make([]string, 0)
 	// for
@@ -46,16 +46,16 @@ func TestHttp2ResponseParser(t *testing.T) {
 		f, err := h2r.framer.ReadFrame()
 		if err != nil {
 			if err != io.EOF {
-				t.Fatalf("[http2 response] read http2 response frame error:%v", err)
+				t.Fatalf("[http2 response] read http2 response frame error: %v", err)
 			}
 			break
 		}
 		switch f := f.(type) {
 		case *http2.MetaHeadersFrame:
-			t.Logf("TestHttp2ResponseParser: frame type:%s", f.Type)
+			t.Logf("TestHttp2ResponseParser: frame type: %s", f.Type)
 			frameTypes = append(frameTypes, f.Type.String())
 		case *http2.DataFrame:
-			t.Logf("TestHttp2ResponseParser: frame type:%s", f.Type)
+			t.Logf("TestHttp2ResponseParser: frame type: %s", f.Type)
 			frameTypes = append(frameTypes, f.Type.String())
 		default:
 			fh := f.Header()
@@ -63,10 +63,10 @@ func TestHttp2ResponseParser(t *testing.T) {
 			t.Logf("TestHttp2ResponseParser: Frame Type\t=>\t%s", fh.Type.String())
 		}
 	}
-	t.Logf("frameTypes:%v", frameTypes)
+	t.Logf("frameTypes: %v", frameTypes)
 	if len(frameTypes) != 5 {
-		t.Fatalf("TestHttp2ResponseParser: frameTypes length error, want: 5, got:%d", len(frameTypes))
+		t.Fatalf("TestHttp2ResponseParser: frameTypes length error, want: 5, got: %d", len(frameTypes))
 	}
 	_ = h2r.Display()
-	//t.Logf("TestHttp2ResponseParser: http reponse body :%s", textBody)
+	//t.Logf("TestHttp2ResponseParser: http reponse body: %s", textBody)
 }

--- a/pkg/event_processor/http_response_test.go
+++ b/pkg/event_processor/http_response_test.go
@@ -45,10 +45,10 @@ Set-Cookie: BDORZ=27315; max-age=86400; domain=.baidu.com; path=/
 	if e != nil {
 		t.Errorf("write http response failed: %v", e)
 	}
-	t.Logf("wrot:%d", i)
+	t.Logf("wrot: %d", i)
 	if hr.response.Proto != "HTTP/1.1" {
-		t.Fatalf("TestHttpResponseParser: http response proto error, want: HTTP/1.1, got:%s", hr.response.Proto)
+		t.Fatalf("TestHttpResponseParser: http response proto error, want: HTTP/1.1, got: %s", hr.response.Proto)
 	}
-	//t.Logf("http reponse body :%s", hr.Display())
+	//t.Logf("http reponse body: %s", hr.Display())
 
 }

--- a/pkg/event_processor/iworker.go
+++ b/pkg/event_processor/iworker.go
@@ -117,7 +117,7 @@ func (ew *eventWorker) Display() error {
 	}
 
 	//iWorker只负责写入，不应该打印。
-	e := ew.writeToChan(fmt.Sprintf("UUID:%s, Name:%s, Type:%d, Length:%d\n%s\n", ew.UUID, ew.parser.Name(), ew.parser.ParserType(), len(b), b))
+	e := ew.writeToChan(fmt.Sprintf("UUID: %s, Name: %s, Type: %d, Length: %d\n%s\n", ew.UUID, ew.parser.Name(), ew.parser.ParserType(), len(b), b))
 	//ew.parser.Reset()
 	// 设定状态、重置包类型
 	ew.status = ProcessStateInit
@@ -140,7 +140,7 @@ func (ew *eventWorker) parserEvents() []byte {
 	ew.parser = parser
 	n, e := ew.parser.Write(ew.payload.Bytes())
 	if e != nil {
-		_ = ew.writeToChan(fmt.Sprintf("ew.parser write payload %d bytes, error:%v", n, e))
+		_ = ew.writeToChan(fmt.Sprintf("ew.parser write payload %d bytes, error: %v", n, e))
 	}
 	ew.status = ProcessStateDone
 	return ew.parser.Display()

--- a/pkg/event_processor/processor.go
+++ b/pkg/event_processor/processor.go
@@ -76,7 +76,7 @@ func (ep *EventProcessor) Serve() error {
 }
 
 func (ep *EventProcessor) dispatch(e event.IEventStruct) error {
-	//ep.logger.Printf("event ID:%s", e.GetUUID())
+	//ep.logger.Printf("event ID: %s", e.GetUUID())
 	var uuid = e.GetUUID()
 	found, eWorker := ep.getWorkerByUUID(uuid)
 	if !found {
@@ -89,7 +89,7 @@ func (ep *EventProcessor) dispatch(e event.IEventStruct) error {
 	eWorker.Put() // never touch eWorker again
 	if err != nil {
 		//...
-		//ep.GetLogger().Write("write event failed , error:%v", err)
+		//ep.GetLogger().Write("write event failed , error: %v", err)
 		return err
 	}
 	return nil
@@ -145,7 +145,7 @@ func (ep *EventProcessor) Close() error {
 	close(ep.closeChan)
 	close(ep.incoming)
 	if len(ep.workerQueue) > 0 {
-		return fmt.Errorf("EventProcessor.Close(): workerQueue is not empty:%d", len(ep.workerQueue))
+		return fmt.Errorf("EventProcessor.Close(): workerQueue is not empty: %d", len(ep.workerQueue))
 	}
 	return nil
 }

--- a/pkg/event_processor/processor_test.go
+++ b/pkg/event_processor/processor_test.go
@@ -52,7 +52,7 @@ func TestEventProcessor_Serve(t *testing.T) {
 	content, err := os.ReadFile(testFile)
 	if err != nil {
 		//Do something
-		t.Fatalf("open file error: %s, file:%s", err.Error(), testFile)
+		t.Fatalf("open file error: %s, file: %s", err.Error(), testFile)
 	}
 	lines := strings.Split(string(content), "\n")
 
@@ -63,12 +63,12 @@ func TestEventProcessor_Serve(t *testing.T) {
 		var eventSSL SSLDataEventTmp
 		err := json.Unmarshal([]byte(line), &eventSSL)
 		if err != nil {
-			t.Fatalf("json unmarshal error: %s, body:%v", err.Error(), line)
+			t.Fatalf("json unmarshal error: %s, body: %v", err.Error(), line)
 		}
 		payloadFile := fmt.Sprintf("testdata/%d.bin", eventSSL.Timestamp)
 		b, e := os.ReadFile(payloadFile)
 		if e != nil {
-			t.Fatalf("read payload file error: %s, file:%s", e.Error(), payloadFile)
+			t.Fatalf("read payload file error: %s, file: %s", e.Error(), payloadFile)
 		}
 		copy(eventSSL.Data[:], b)
 		ep.Write(&BaseEvent{DataLen: eventSSL.DataLen, Data: eventSSL.Data, DataType: eventSSL.DataType, Timestamp: eventSSL.Timestamp, Pid: eventSSL.Pid, Tid: eventSSL.Tid, Comm: eventSSL.Comm, Fd: eventSSL.Fd, Version: eventSSL.Version})

--- a/pkg/proc/go_elf/eprint.go
+++ b/pkg/proc/go_elf/eprint.go
@@ -5,5 +5,5 @@ import "fmt"
 
 //export eprint
 func eprint(i C.int) {
-	fmt.Printf("eCapture unit testing : i = %d\n", uint32(i))
+	fmt.Printf("eCapture unit testing: i = %d\n", uint32(i))
 }

--- a/pkg/proc/proc_test.go
+++ b/pkg/proc/proc_test.go
@@ -26,14 +26,14 @@ func TestExtraceGoVersion(t *testing.T) {
 func TestExtraceGoVersionGccgo(t *testing.T) {
 	e := os.Chdir("go_elf")
 	if e != nil {
-		t.Fatalf("chdir error:%v\n", e)
+		t.Fatalf("chdir error: %v\n", e)
 	}
 
 	p, e := os.Getwd()
 	if e != nil {
-		t.Fatalf("Getwd error:%v", e)
+		t.Fatalf("Getwd error: %v", e)
 	}
-	t.Logf("pwd:%s", p)
+	t.Logf("pwd: %s", p)
 
 	// go build go_elf
 	pathEnv := os.Getenv("PATH")
@@ -57,17 +57,17 @@ func TestExtraceGoVersionGccgo(t *testing.T) {
 	c.Stdout = &outb
 	c.Stderr = &errb
 	e = c.Run()
-	t.Logf("output:%s, errput:%s", outb.String(), errb.String())
+	t.Logf("output: %s, errput: %s", outb.String(), errb.String())
 	if e != nil {
 		c.Stderr = os.Stderr
-		t.Fatalf("go build failed:%v", e)
+		t.Fatalf("go build failed: %v", e)
 	}
 
 	p1 := filepath.Join(p, ELF_BUILD_BY_CGO)
 	ver, err := ExtraceGoVersion(p1)
-	t.Logf("Extrace GoVersion from CGO ELF :%s", p1)
+	t.Logf("Extrace GoVersion from CGO ELF: %s", p1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("version found :%v", ver)
+	t.Logf("version found: %v", ver)
 }

--- a/pkg/util/ebpf/bpf.go
+++ b/pkg/util/ebpf/bpf.go
@@ -155,13 +155,13 @@ func IsEnableBPF() (bool, error) {
 		bc, found := KernelConfig[item]
 		if !found {
 			// 没有这个配置项
-			return false, fmt.Errorf("Config not found,  item:%s.", item)
+			return false, fmt.Errorf("Config not found, item: %s.", item)
 		}
 
 		//如果有，在判断配置项的值
 		if bc != "y" {
 			// 没有开启
-			return false, fmt.Errorf("Config disabled, item :%s.", item)
+			return false, fmt.Errorf("Config disabled, item: %s.", item)
 		}
 	}
 

--- a/pkg/util/ebpf/bpf_test.go
+++ b/pkg/util/ebpf/bpf_test.go
@@ -24,7 +24,7 @@ func TestBpfConfig(t *testing.T) {
 	// 检测是否是容器
 	isContainer, err := IsContainer()
 	if err != nil {
-		t.Fatal("Check container error:", err)
+		t.Fatal("Check container error: ", err)
 	}
 
 	if isContainer {
@@ -39,7 +39,7 @@ func TestBpfConfig(t *testing.T) {
 	_, e := GetSystemConfig()
 	if e != nil {
 		// 正常情况 是没有找到配置文件
-		t.Logf("GetSystemConfig error:%s", e.Error())
+		t.Logf("GetSystemConfig error: %s", e.Error())
 	}
 
 	// 测试 config.gz 的解压，查找配置项
@@ -49,23 +49,23 @@ func TestBpfConfig(t *testing.T) {
 	}
 	m, e := GetSystemConfig()
 	if e != nil {
-		t.Fatalf("GetSystemConfig(gzip) error:%s", e.Error())
+		t.Fatalf("GetSystemConfig(gzip) error: %s", e.Error())
 	}
 	for _, item := range configCheckItems {
 		bc, found := m[item]
 		if !found {
 			// 没有这个配置项
-			t.Logf("Config not found,  item:%s.", item)
+			t.Logf("Config not found, item: %s.", item)
 		} else {
-			t.Logf("Config found, item:%s, value:%s.", item, bc)
+			t.Logf("Config found, item: %s, value: %s.", item, bc)
 		}
 
 		//如果有，在判断配置项的值
 		if bc != "y" {
 			// 没有开启
-			t.Logf("Config disabled, item :%s.", item)
+			t.Logf("Config disabled, item: %s.", item)
 		} else {
-			t.Logf("Config enabled, item :%s.", item)
+			t.Logf("Config enabled, item: %s.", item)
 		}
 	}
 
@@ -79,19 +79,19 @@ func TestBpfConfig(t *testing.T) {
 	}
 	m, e = GetSystemConfig()
 	if e != nil {
-		t.Fatalf("GetSystemConfig error:%s", e.Error())
+		t.Fatalf("GetSystemConfig error: %s", e.Error())
 	}
 	for _, item := range configCheckItems {
 		bc, found := m[item]
 		if !found {
 			// 没有这个配置项
-			t.Logf("Config not found,  item:%s.", item)
+			t.Logf("Config not found, item: %s.", item)
 		}
 
 		//如果有，在判断配置项的值
 		if bc != "y" {
 			// 没有开启
-			t.Logf("Config disabled, item :%s.", item)
+			t.Logf("Config disabled, item: %s.", item)
 		}
 	}
 	t.Logf("GetSystemConfig success")
@@ -100,7 +100,7 @@ func TestBpfConfig(t *testing.T) {
 func TestIsContainerCgroup(t *testing.T) {
 	isContainer, err := isContainerCgroup()
 	if err != nil {
-		t.Fatalf("TestIsContainerCgroup :: IsContainer error:%s", err.Error())
+		t.Fatalf("TestIsContainerCgroup :: IsContainer error: %s", err.Error())
 	}
 	if isContainer {
 		t.Logf("TestIsContainerCgroup :: IsContainer true")
@@ -112,7 +112,7 @@ func TestIsContainerCgroup(t *testing.T) {
 func TestIsContainerSched(t *testing.T) {
 	isContainer, err := isContainerSched()
 	if err != nil {
-		t.Fatalf("TestIsContainerSched :: IsContainer error:%s", err.Error())
+		t.Fatalf("TestIsContainerSched :: IsContainer error: %s", err.Error())
 	}
 	if isContainer {
 		t.Logf("TestIsContainerSched :: IsContainer true")

--- a/tests/golang_https.go
+++ b/tests/golang_https.go
@@ -24,7 +24,7 @@ func main() {
 	if e == nil {
 		fmt.Printf("response body: %s\n\n", b)
 	} else {
-		fmt.Printf("error :%v", e)
+		fmt.Printf("error: %v", e)
 	}
 }
 

--- a/user/config/common.go
+++ b/user/config/common.go
@@ -96,7 +96,7 @@ func ParseDynLibConf(pattern string) (dirs []string, err error) {
 		}
 	}
 	if len(dirs) <= 0 {
-		err = errors.New(fmt.Sprintf("read keylogger :%s error .", pattern))
+		err = errors.New(fmt.Sprintf("read keylogger: %s error.", pattern))
 	}
 	return dirs, err
 }
@@ -158,7 +158,7 @@ func recurseDynStrings(dynSym []string, searchPath []string, soName string) stri
 		}
 
 		if fd == nil {
-			log.Fatal(fmt.Sprintf("cant found lib so:%s in dirs:%v", el, searchPath))
+			log.Fatal(fmt.Sprintf("cant found lib so: %s in dirs: %v", el, searchPath))
 		}
 
 		bint, err := elf.NewFile(fd)

--- a/user/config/config_gotls.go
+++ b/user/config/config_gotls.go
@@ -77,9 +77,9 @@ type FuncOffsets struct {
 type GoTLSConfig struct {
 	BaseConfig
 	Path                  string    `json:"path"`       // golang application path to binary built with Go toolchain.
-	PcapFile              string    `json:"pcapFile"`   // pcapFile  the  raw  packets  to file rather than parsing and printing them out.
-	KeylogFile            string    `json:"keylogFile"` // keylogFile  The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.
-	Model                 string    `json:"model"`      // model  such as : text, pcapng/pcap, key/keylog.
+	PcapFile              string    `json:"pcapFile"`   // pcapFile the raw packets to file rather than parsing and printing them out.
+	KeylogFile            string    `json:"keylogFile"` // keylogFile The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.
+	Model                 string    `json:"model"`      // model such as: text, pcapng/pcap, key/keylog.
 	Ifname                string    `json:"ifName"`     // (TC Classifier) Interface name on which the probe will be attached.
 	PcapFilter            string    `json:"pcapFilter"` // pcap filter
 	goElfArch             string    //
@@ -137,14 +137,14 @@ func (gc *GoTLSConfig) Check() error {
 	}
 
 	if goElfArch != runtime.GOARCH {
-		err = fmt.Errorf("Go Application not match, want:%s, have:%s", runtime.GOARCH, goElfArch)
+		err = fmt.Errorf("Go Application not match, want: %s, have: %s", runtime.GOARCH, goElfArch)
 		return err
 	}
 	switch goElfArch {
 	case "amd64":
 	case "arm64":
 	default:
-		return fmt.Errorf("unsupport CPU arch :%s", goElfArch)
+		return fmt.Errorf("unsupport CPU arch: %s", goElfArch)
 	}
 	gc.goElfArch = goElfArch
 	gc.goElf = goElf
@@ -166,12 +166,12 @@ func (gc *GoTLSConfig) Check() error {
 		var addr uint64
 		addr, err = gc.findPieSymbolAddr(GoTlsWriteFunc)
 		if err != nil {
-			return fmt.Errorf("%s symbol address error:%s", GoTlsWriteFunc, err.Error())
+			return fmt.Errorf("%s symbol address error: %s", GoTlsWriteFunc, err.Error())
 		}
 		gc.GoTlsWriteAddr = addr
 		addr, err = gc.findPieSymbolAddr(GoTlsMasterSecretFunc)
 		if err != nil {
-			return fmt.Errorf("%s symbol address error:%s", GoTlsMasterSecretFunc, err.Error())
+			return fmt.Errorf("%s symbol address error: %s", GoTlsMasterSecretFunc, err.Error())
 		}
 		gc.GoTlsMasterSecretAddr = addr
 

--- a/user/config/config_openssl.go
+++ b/user/config/config_openssl.go
@@ -41,8 +41,8 @@ type OpensslConfig struct {
 	// Curlpath   string `json:"curlPath"` //curl的文件路径
 	Openssl    string `json:"openssl"`
 	Model      string `json:"model"`      // eCapture Openssl capture model. text:pcap:keylog
-	PcapFile   string `json:"pcapfile"`   // pcapFile  the  raw  packets  to file rather than parsing and printing them out.
-	KeylogFile string `json:"keylog"`     // Keylog  The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.
+	PcapFile   string `json:"pcapfile"`   // pcapFile the raw packets to file rather than parsing and printing them out.
+	KeylogFile string `json:"keylog"`     // Keylog The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.
 	Ifname     string `json:"ifname"`     // (TC Classifier) Interface name on which the probe will be attached.
 	PcapFilter string `json:"pcapfilter"` // pcap filter
 	SslVersion string `json:"sslversion"` // openssl version like 1.1.1a/1.1.1f/boringssl_1.1.1

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -61,7 +61,7 @@ type BaseConfig struct {
 	Listen string `json:"listen"` // listen address, default: 127.0.0.1:28256
 
 	// mapSizeKB
-	PerCpuMapSize      int    `json:"per_cpu_map_size"` // ebpf map size for per Cpu.   see https://github.com/gojue/ecapture/issues/433 .
+	PerCpuMapSize      int    `json:"per_cpu_map_size"`     // ebpf map size for per Cpu. see https://github.com/gojue/ecapture/issues/433 .
 	IsHex              bool   `json:"is_hex"`
 	Debug              bool   `json:"debug"`
 	BtfMode            uint8  `json:"btf_mode"`

--- a/user/event/event_bash.go
+++ b/user/event/event_bash.go
@@ -66,12 +66,12 @@ func (be *BashEvent) Decode(payload []byte) (err error) {
 }
 
 func (be *BashEvent) String() string {
-	s := fmt.Sprintf("PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s", be.Pid, be.Uid, be.Comm, be.ReturnValue, be.AllLines)
+	s := fmt.Sprintf("PID: %d, UID: %d, \tComm: %s, \tRetvalue: %d, \tLine:\n%s", be.Pid, be.Uid, be.Comm, be.ReturnValue, be.AllLines)
 	return s
 }
 
 func (be *BashEvent) StringHex() string {
-	s := fmt.Sprintf("PID:%d, UID:%d, \tComm:%s, \tRetvalue:%d, \tLine:\n%s,", be.Pid, be.Uid, be.Comm, be.ReturnValue, dumpByteSlice([]byte(be.AllLines), ""))
+	s := fmt.Sprintf("PID: %d, UID: %d, \tComm: %s, \tRetvalue: %d, \tLine:\n%s,", be.Pid, be.Uid, be.Comm, be.ReturnValue, dumpByteSlice([]byte(be.AllLines), ""))
 	return s
 }
 

--- a/user/event/event_gnutls.go
+++ b/user/event/event_gnutls.go
@@ -78,7 +78,7 @@ func (ge *GnutlsDataEvent) StringHex() string {
 
 	b := dumpByteSlice(ge.Data[:ge.DataLen], perfix)
 	b.WriteString(COLORRESET)
-	s := fmt.Sprintf("PID:%d, Comm:%s, Type:%s, TID:%d, DataLen:%d bytes, Payload:\n%s", ge.Pid, ge.Comm, packetType, ge.Tid, ge.DataLen, b.String())
+	s := fmt.Sprintf("PID: %d, Comm: %s, Type: %s, TID: %d, DataLen: %d bytes, Payload:\n%s", ge.Pid, ge.Comm, packetType, ge.Tid, ge.DataLen, b.String())
 	return s
 }
 
@@ -94,7 +94,7 @@ func (ge *GnutlsDataEvent) String() string {
 	default:
 		packetType = fmt.Sprintf("%sUNKNOW_%d%s", COLORRED, ge.DataType, COLORRESET)
 	}
-	s := fmt.Sprintf(" PID:%d, Comm:%s, TID:%d, TYPE:%s, DataLen:%d bytes, Payload:\n%s%s%s", ge.Pid, ge.Comm, ge.Tid, packetType, ge.DataLen, perfix, string(ge.Data[:ge.DataLen]), COLORRESET)
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, TYPE: %s, DataLen: %d bytes, Payload:\n%s%s%s", ge.Pid, ge.Comm, ge.Tid, packetType, ge.DataLen, perfix, string(ge.Data[:ge.DataLen]), COLORRESET)
 	return s
 }
 

--- a/user/event/event_gotls.go
+++ b/user/event/event_gotls.go
@@ -44,7 +44,7 @@ func (ge *GoTLSEvent) Decode(payload []byte) error {
 }
 
 func (ge *GoTLSEvent) String() string {
-	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, PayloadType:%d, Payload: %s\n", ge.Pid, string(ge.Comm[:]), ge.Tid, ge.inner.PayloadType, string(ge.Data[:ge.Len]))
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, PayloadType: %d, Payload: %s\n", ge.Pid, string(ge.Comm[:]), ge.Tid, ge.inner.PayloadType, string(ge.Data[:ge.Len]))
 	return s
 }
 
@@ -52,7 +52,7 @@ func (ge *GoTLSEvent) StringHex() string {
 	perfix := COLORGREEN
 	b := dumpByteSlice(ge.Data[:ge.Len], perfix)
 	b.WriteString(COLORRESET)
-	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, PayloadType:%d, Payload: \n%s\n", ge.Pid, string(ge.Comm[:]), ge.Tid, ge.inner.PayloadType, b.String())
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, PayloadType: %d, Payload: \n%s\n", ge.Pid, string(ge.Comm[:]), ge.Tid, ge.inner.PayloadType, b.String())
 	return s
 }
 

--- a/user/event/event_masterkey.go
+++ b/user/event/event_masterkey.go
@@ -87,7 +87,7 @@ func (mse *MasterSecretEvent) StringHex() string {
 	v := TlsVersion{
 		Version: mse.Version,
 	}
-	s := fmt.Sprintf("TLS Version:%s, ClientRandom:%02x", v.String(), mse.ClientRandom)
+	s := fmt.Sprintf("TLS Version: %s, ClientRandom: %02x", v.String(), mse.ClientRandom)
 	return s
 }
 
@@ -95,7 +95,7 @@ func (mse *MasterSecretEvent) String() string {
 	v := TlsVersion{
 		Version: mse.Version,
 	}
-	s := fmt.Sprintf("TLS Version:%s, ClientRandom:%02x", v.String(), mse.ClientRandom)
+	s := fmt.Sprintf("TLS Version: %s, ClientRandom: %02x", v.String(), mse.ClientRandom)
 	return s
 }
 
@@ -181,7 +181,7 @@ func (msbe *MasterSecretBSSLEvent) StringHex() string {
 	v := TlsVersion{
 		Version: msbe.Version,
 	}
-	s := fmt.Sprintf("TLS Version:%s, ClientRandom:%02x", v.String(), msbe.ClientRandom)
+	s := fmt.Sprintf("TLS Version: %s, ClientRandom: %02x", v.String(), msbe.ClientRandom)
 	return s
 }
 
@@ -189,7 +189,7 @@ func (msbe *MasterSecretBSSLEvent) String() string {
 	v := TlsVersion{
 		Version: msbe.Version,
 	}
-	s := fmt.Sprintf("TLS Version:%s, ClientRandom:%02x", v.String(), msbe.ClientRandom)
+	s := fmt.Sprintf("TLS Version: %s, ClientRandom: %02x", v.String(), msbe.ClientRandom)
 	return s
 }
 

--- a/user/event/event_mastersecret_gotls.go
+++ b/user/event/event_mastersecret_gotls.go
@@ -59,25 +59,25 @@ func (mge *MasterSecretGotlsEvent) Decode(payload []byte) (err error) {
 		return
 	}
 	if int(mge.LabelLen) > len(mge.Label) {
-		return fmt.Errorf("invalid label length, LablenLen:%d, len(Label):%d", mge.LabelLen, len(mge.Label))
+		return fmt.Errorf("invalid label length, LablenLen: %d, len(Label): %d", mge.LabelLen, len(mge.Label))
 	}
 	if int(mge.ClientRandomLen) > len(mge.ClientRandom) {
-		return fmt.Errorf("invalid label length, ClientRandomLen:%d, len(ClientRandom):%d", mge.ClientRandomLen, len(mge.ClientRandom))
+		return fmt.Errorf("invalid label length, ClientRandomLen: %d, len(ClientRandom): %d", mge.ClientRandomLen, len(mge.ClientRandom))
 	}
 	if int(mge.MasterSecretLen) > len(mge.MasterSecret) {
-		return fmt.Errorf("invalid label length, MasterSecretLen:%d, len(MasterSecret):%d", mge.MasterSecretLen, len(mge.MasterSecret))
+		return fmt.Errorf("invalid label length, MasterSecretLen: %d, len(MasterSecret): %d", mge.MasterSecretLen, len(mge.MasterSecret))
 	}
 	mge.payload = fmt.Sprintf("%s %02x %02x", mge.Label, mge.ClientRandom, mge.MasterSecret)
 	return nil
 }
 
 func (mge *MasterSecretGotlsEvent) StringHex() string {
-	s := fmt.Sprintf("Label%s, ClientRandom:%02x, secret:%02x", mge.Label[0:mge.LabelLen], mge.ClientRandom[0:mge.ClientRandomLen], mge.MasterSecret[0:mge.MasterSecretLen])
+	s := fmt.Sprintf("Label %s, ClientRandom: %02x, secret: %02x", mge.Label[0:mge.LabelLen], mge.ClientRandom[0:mge.ClientRandomLen], mge.MasterSecret[0:mge.MasterSecretLen])
 	return s
 }
 
 func (mge *MasterSecretGotlsEvent) String() string {
-	s := fmt.Sprintf("Label:%s, ClientRandom:%02x, secret:%02x", mge.Label[0:mge.LabelLen], mge.ClientRandom[0:mge.ClientRandomLen], mge.MasterSecret[0:mge.MasterSecretLen])
+	s := fmt.Sprintf("Label: %s, ClientRandom: %02x, secret: %02x", mge.Label[0:mge.LabelLen], mge.ClientRandom[0:mge.ClientRandomLen], mge.MasterSecret[0:mge.MasterSecretLen])
 	return s
 }
 

--- a/user/event/event_mysqld.go
+++ b/user/event/event_mysqld.go
@@ -107,12 +107,12 @@ func (me *MysqldEvent) Decode(payload []byte) (err error) {
 }
 
 func (me *MysqldEvent) String() string {
-	s := fmt.Sprintf(" PID:%d, Comm:%s, Time:%d,  length:(%d/%d),  return:%s, Line:%s", me.Pid, me.Comm, me.Timestamp, me.Len, me.Alllen, me.Retval, unix.ByteSliceToString((me.Query[:])))
+	s := fmt.Sprintf("PID: %d, Comm: %s, Time: %d, length: (%d/%d), return: %s, Line: %s", me.Pid, me.Comm, me.Timestamp, me.Len, me.Alllen, me.Retval, unix.ByteSliceToString((me.Query[:])))
 	return s
 }
 
 func (me *MysqldEvent) StringHex() string {
-	s := fmt.Sprintf(" PID:%d, Comm:%s, Time:%d,  length:(%d/%d),  return:%s, Line:%s", me.Pid, me.Comm, me.Timestamp, me.Len, me.Alllen, me.Retval, unix.ByteSliceToString((me.Query[:])))
+	s := fmt.Sprintf("PID: %d, Comm: %s, Time: %d, length: (%d/%d), return: %s, Line: %s", me.Pid, me.Comm, me.Timestamp, me.Len, me.Alllen, me.Retval, unix.ByteSliceToString((me.Query[:])))
 	return s
 }
 

--- a/user/event/event_nspr.go
+++ b/user/event/event_nspr.go
@@ -82,11 +82,11 @@ func (ne *NsprDataEvent) StringHex() string {
 	// disable filter default
 	if false && strings.Compare(fire_thread, "Socket Thread") != 0 {
 		b = bytes.NewBufferString(fmt.Sprintf("%s[ignore]%s", COLORBLUE, COLORRESET))
-		s = fmt.Sprintf("PID:%d, Comm:%s, Type:%s, TID:%d, DataLen:%d bytes, Payload:%s", ne.Pid, ne.Comm, packetType, ne.Tid, ne.DataLen, b.String())
+		s = fmt.Sprintf("PID: %d, Comm: %s, Type: %s, TID: %d, DataLen: %d bytes, Payload:%s", ne.Pid, ne.Comm, packetType, ne.Tid, ne.DataLen, b.String())
 	} else {
 		b = dumpByteSlice(ne.Data[:ne.DataLen], perfix)
 		b.WriteString(COLORRESET)
-		s = fmt.Sprintf("PID:%d, Comm:%s, Type:%s, TID:%d, DataLen:%d bytes, Payload:\n%s", ne.Pid, ne.Comm, packetType, ne.Tid, ne.DataLen, b.String())
+		s = fmt.Sprintf("PID: %d, Comm: %s, Type: %s, TID: %d, DataLen: %d bytes, Payload:\n%s", ne.Pid, ne.Comm, packetType, ne.Tid, ne.DataLen, b.String())
 	}
 
 	return s
@@ -113,7 +113,7 @@ func (ne *NsprDataEvent) String() string {
 	} else {
 		b = bytes.NewBuffer(ne.Data[:ne.DataLen])
 	}
-	s := fmt.Sprintf(" PID:%d, Comm:%s, TID:%d, TYPE:%s, DataLen:%d bytes, Payload:\n%s%s%s", ne.Pid, ne.Comm, ne.Tid, packetType, ne.DataLen, perfix, b.String(), COLORRESET)
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, TYPE: %s, DataLen: %d bytes, Payload:\n%s%s%s", ne.Pid, ne.Comm, ne.Tid, packetType, ne.DataLen, perfix, b.String(), COLORRESET)
 	return s
 }
 

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -150,7 +150,7 @@ func (se *SSLDataEvent) StringHex() string {
 	b.WriteString(COLORRESET)
 
 	v := TlsVersion{Version: se.Version}
-	s := fmt.Sprintf("PID:%d, Comm:%s, TID:%d, %s, Version:%s, Payload:\n%s", se.Pid, CToGoString(se.Comm[:]), se.Tid, connInfo, v.String(), b.String())
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, %s, Version: %s, Payload:\n%s", se.Pid, CToGoString(se.Comm[:]), se.Tid, connInfo, v.String(), b.String())
 	return s
 }
 
@@ -172,7 +172,7 @@ func (se *SSLDataEvent) String() string {
 		connInfo = fmt.Sprintf("%sUNKNOW_%d%s", COLORRED, se.DataType, COLORRESET)
 	}
 	v := TlsVersion{Version: se.Version}
-	s := fmt.Sprintf("PID:%d, Comm:%s, TID:%d, Version:%s, %s, Payload:\n%s%s%s", se.Pid, bytes.TrimSpace(se.Comm[:]), se.Tid, v.String(), connInfo, perfix, string(se.Data[:se.DataLen]), COLORRESET)
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, Version: %s, %s, Payload:\n%s%s%s", se.Pid, bytes.TrimSpace(se.Comm[:]), se.Tid, v.String(), connInfo, perfix, string(se.Data[:se.DataLen]), COLORRESET)
 	return s
 }
 
@@ -233,12 +233,12 @@ func (ce *ConnDataEvent) Decode(payload []byte) (err error) {
 }
 
 func (ce *ConnDataEvent) StringHex() string {
-	s := fmt.Sprintf("PID:%d, Comm:%s, TID:%d, FD:%d, Addr: %s", ce.Pid, bytes.TrimSpace(ce.Comm[:]), ce.Tid, ce.Fd, ce.Addr)
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, FD: %d, Addr: %s", ce.Pid, bytes.TrimSpace(ce.Comm[:]), ce.Tid, ce.Fd, ce.Addr)
 	return s
 }
 
 func (ce *ConnDataEvent) String() string {
-	s := fmt.Sprintf("PID:%d, Comm:%s, TID:%d, FD:%d, Addr: %s", ce.Pid, bytes.TrimSpace(ce.Comm[:]), ce.Tid, ce.Fd, ce.Addr)
+	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, FD: %d, Addr: %s", ce.Pid, bytes.TrimSpace(ce.Comm[:]), ce.Tid, ce.Fd, ce.Addr)
 	return s
 }
 

--- a/user/event/event_openssl_tc.go
+++ b/user/event/event_openssl_tc.go
@@ -69,13 +69,13 @@ func (te *TcSkbEvent) Decode(payload []byte) (err error) {
 func (te *TcSkbEvent) StringHex() string {
 	b := dumpByteSlice(te.payload, COLORGREEN)
 	b.WriteString(COLORRESET)
-	s := fmt.Sprintf("Pid:%d, Comm:%s, Length:%d, Ifindex:%d, Payload:%s", te.Pid, te.Comm, te.Len, te.Ifindex, b.String())
+	s := fmt.Sprintf("Pid: %d, Comm: %s, Length: %d, Ifindex: %d, Payload: %s", te.Pid, te.Comm, te.Len, te.Ifindex, b.String())
 	return s
 }
 
 func (te *TcSkbEvent) String() string {
 
-	s := fmt.Sprintf("Pid:%d, Comm:%s, Length:%d, Ifindex:%d, Payload:[internal data]", te.Pid, te.Comm, te.Len, te.Ifindex)
+	s := fmt.Sprintf("Pid: %d, Comm: %s, Length: %d, Ifindex: %d, Payload:[internal data]", te.Pid, te.Comm, te.Len, te.Ifindex)
 	return s
 }
 

--- a/user/event/event_postgres.go
+++ b/user/event/event_postgres.go
@@ -63,12 +63,12 @@ func (pe *PostgresEvent) Decode(payload []byte) (err error) {
 }
 
 func (pe *PostgresEvent) String() string {
-	s := fmt.Sprintf(" PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:])))
+	s := fmt.Sprintf("PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:])))
 	return s
 }
 
 func (pe *PostgresEvent) StringHex() string {
-	s := fmt.Sprintf(" PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:])))
+	s := fmt.Sprintf("PID: %d, Comm: %s, Time: %d, Query: %s", pe.Pid, pe.Comm, pe.Timestamp, unix.ByteSliceToString((pe.Query[:])))
 	return s
 }
 

--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -104,7 +104,7 @@ func (m *Module) Init(ctx context.Context, logger *zerolog.Logger, conf config.I
 	m.processor = event_processor.NewEventProcessor(eventCollector, conf.GetHex())
 	kv, err := kernel.HostVersion()
 	if err != nil {
-		m.logger.Warn().Err(err).Msg("Unable to detect kernel version due to an error:%v.used non-Less5_2 bytecode.")
+		m.logger.Warn().Err(err).Msg("Unable to detect kernel version due to an error: %v.used non-Less5_2 bytecode.")
 	} else {
 		// it's safe to ignore err because we have checked it in main funcition
 		if kv < kernel.VersionCode(5, 2, 0) {
@@ -143,7 +143,7 @@ func (m *Module) autoDetectBTF() {
 		}
 		enable, e := ebpfenv.IsEnableBTF()
 		if e != nil {
-			m.logger.Warn().Err(e).Msg("Unable to find BTF configuration due to an error:%v.\n" + BtfNotSupport)
+			m.logger.Warn().Err(e).Msg("Unable to find BTF configuration due to an error: %v.\n" + BtfNotSupport)
 		}
 		if enable {
 			m.isCoreUsed = true
@@ -203,7 +203,7 @@ func (m *Module) Run() error {
 	go func() {
 		err := m.processor.Serve()
 		if err != nil {
-			m.errChan <- fmt.Errorf("%s\tprocessor.Serve error:%v.", m.child.Name(), err)
+			m.errChan <- fmt.Errorf("%s\tprocessor.Serve error: %v.", m.child.Name(), err)
 			return
 		}
 	}()
@@ -255,7 +255,7 @@ func (m *Module) readEvents() error {
 		case e.Type() == ebpf.PerfEventArray:
 			m.perfEventReader(errChan, e)
 		default:
-			return fmt.Errorf("%s\tunsupported mapType:%s , mapinfo:%s",
+			return fmt.Errorf("%s\tunsupported mapType: %s , mapinfo: %s",
 				m.child.Name(), e.Type().String(), e.String())
 		}
 	}
@@ -351,7 +351,7 @@ func (m *Module) ringbufEventReader(errChan chan error, em *ebpf.Map) {
 func (m *Module) Decode(em *ebpf.Map, b []byte) (event event.IEventStruct, err error) {
 	es, found := m.child.DecodeFun(em)
 	if !found {
-		err = fmt.Errorf("%s\tcan't found decode function :%s, address:%p", m.child.Name(), em.String(), em)
+		err = fmt.Errorf("%s\tcan't found decode function: %s, address: %p", m.child.Name(), em.String(), em)
 		return
 	}
 

--- a/user/module/probe_gotls.go
+++ b/user/module/probe_gotls.go
@@ -69,7 +69,7 @@ func (g *GoTLSProbe) Init(ctx context.Context, l *zerolog.Logger, cfg config.ICo
 	g.path = cfg.(*config.GoTLSConfig).Path
 	ver, err := proc.ExtraceGoVersion(g.path)
 	if err != nil {
-		return fmt.Errorf("%s, error:%v", NotGoCompiledBin, err)
+		return fmt.Errorf("%s, error: %v", NotGoCompiledBin, err)
 	}
 
 	// supported at 1.17 via https://github.com/golang/go/issues/40724

--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -138,18 +138,18 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 func (m *MOpenSSLProbe) detectOpenssl(soPath string) error {
 	f, err := os.OpenFile(soPath, os.O_RDONLY, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("can not open %s, with error:%v", soPath, err)
+		return fmt.Errorf("can not open %s, with error: %v", soPath, err)
 	}
 	r, e := elf.NewFile(f)
 	if e != nil {
-		return fmt.Errorf("parse the ELF file  %s failed, with error:%v", soPath, err)
+		return fmt.Errorf("parse the ELF file %s failed, with error: %v", soPath, err)
 	}
 
 	switch r.FileHeader.Machine {
 	case elf.EM_X86_64:
 	case elf.EM_AARCH64:
 	default:
-		return fmt.Errorf("unsupported arch library ,ELF Header Machine is :%s, must be one of EM_X86_64 and EM_AARCH64", r.FileHeader.Machine.String())
+		return fmt.Errorf("unsupported arch library ,ELF Header Machine is: %s, must be one of EM_X86_64 and EM_AARCH64", r.FileHeader.Machine.String())
 	}
 
 	s := r.Section(".rodata")

--- a/utils/ecapture.lua
+++ b/utils/ecapture.lua
@@ -45,8 +45,8 @@ function ecapture.dissector(buffer, pinfo, tree)
   local magic = trailer(0, 4):uint()
   if(magic ~= ECAPTURE_MAGIC) then
 --     print("trailerlength:"..trailerlength)
---     print("magic:%x", magic)
---     print("trailer:%x", trailer)
+--     print("magic: %x", magic)
+--     print("trailer: %x", trailer)
     return
   end
 


### PR DESCRIPTION
调整了一些输出的空格风格，例如把 `str:{f}`、`str :{f}`、`str : {f}` 改为 `str: {f}`。 剪裁没必要的空格，例如部分字符串中间不规律的双重空格、尾部的空格
    
发现但未在此次 commit 更改，需要讨论的：
    
pkg/proc/proc_test.go#L40 建议 `:` 换成 `=`
pkg/event_processor/base_event.go#L150-166 + user/config/mysqld.go#L107 两个半型冒号
user/envent/event_gnutls.go#L81-97 `TID` 与 `Type` 位置对调且 `String()` 函数中 TYPE 全大写 user/envent/event_mastersec_gotls.go#L75 Label 似乎缺少半型冒号
user/envent/event_nspr.go#L85 `Payload` 输出似乎缺少换行
user/envent/event_openssl.go#L153-175 `String` 与 `StringHex` 日志输出 `Send`/`Recv` 与 `Version` 位置对调