### PR TITLE
adjust eventWorker.incoming channel length

### DIFF
--- a/pkg/event_processor/iworker.go
+++ b/pkg/event_processor/iworker.go
@@ -40,7 +40,7 @@ type IWorker interface {
 
 const (
 	MaxTickerCount = 10 // 1 Sencond/(eventWorker.ticker.C) = 10
-	MaxChanLen     = 16 // 包队列长度
+	MaxChanLen     = 128 // 包队列长度
 	//MAX_EVENT_LEN    = 16 // 事件数组长度
 )
 


### PR DESCRIPTION
adjust `eventWorker.incoming` channel length to reduce `eventWorker Write failed, incoming chan is full` error.

change to `128` is work good now, but maybe a better value to instead it?

reproduce:

run ecapture and use `openconnect`

```
./ecapture gnutls 
2024-09-23T16:45:00+08:00 INF AppName="eCapture(旁观者)"
2024-09-23T16:45:00+08:00 INF HomePage=https://ecapture.cc
2024-09-23T16:45:00+08:00 INF Repository=https://github.com/gojue/ecapture
2024-09-23T16:45:00+08:00 INF Author="CFC4N <cfc4ncs@gmail.com>"
2024-09-23T16:45:00+08:00 INF Description="Capturing SSL/TLS plaintext without a CA certificate using eBPF. Supported on Linux/Android kernels for amd64/arm64."
2024-09-23T16:45:00+08:00 INF Version=linux_amd64:-20240916-d50ee78:6.1.0-22-amd64
2024-09-23T16:45:00+08:00 INF Listen=localhost:28256
2024-09-23T16:45:00+08:00 INF eCapture running logs logger=
2024-09-23T16:45:00+08:00 INF the file handler that receives the captured event eventCollector=
2024-09-23T16:45:00+08:00 INF listen=localhost:28256
2024-09-23T16:45:00+08:00 INF https server starting...You can update the configuration file via the HTTP interface.
2024-09-23T16:45:00+08:00 WRN ========== module starting. ==========
2024-09-23T16:45:00+08:00 INF Kernel Info=6.1.0 Pid=96897
2024-09-23T16:45:00+08:00 INF BTF bytecode mode: CORE. btfMode=0
2024-09-23T16:45:00+08:00 INF module initialization. isReload=false moduleName=EBPFProbeGNUTLS
2024-09-23T16:45:00+08:00 INF Module.Run()
2024-09-23T16:45:00+08:00 INF BPF bytecode loaded bytecode filename=user/bytecode/gnutls_kern_core.o
2024-09-23T16:45:00+08:00 INF gnutls binary path binaryPath=/lib/x86_64-linux-gnu/libgnutls.so.30 elfType=2
2024-09-23T16:45:00+08:00 INF target all process.
2024-09-23T16:45:00+08:00 INF perfEventReader created mapSize(MB)=4
2024-09-23T16:45:00+08:00 INF module started successfully. isReload=false moduleName=EBPFProbeGNUTLS
2024-09-23T16:45:02+08:00 WRN Module closed,message recived from errChan="EBPFProbeGNUTLS\tprocessor.Serve error:eventWorker Write failed, incoming chan is full\nEventProcessor.Close(): workerQueue is not empty:2."
^C2024-09-23T16:45:11+08:00 INF iModule module close
panic: close of closed channel

goroutine 1 [running]:
github.com/gojue/ecapture/pkg/event_processor.(*EventProcessor).Close(0xc0000ac2d0)
	/usr/local/src/ecapture/pkg/event_processor/processor.go:145 +0x7e
github.com/gojue/ecapture/user/module.(*Module).Close(0xc0000cc000)
	/usr/local/src/ecapture/user/module/imodule.go:414 +0xab
github.com/gojue/ecapture/user/module.(*MGnutlsProbe).Close(0xc0000cc000)
	/usr/local/src/ecapture/user/module/probe_gnutls.go:103 +0x75
github.com/gojue/ecapture/cli/cmd.runModule({0xdcd14f, 0xf}, {0xf178a8, 0xc00048df80})
	/usr/local/src/ecapture/cli/cmd/root.go:277 +0xc8f
github.com/gojue/ecapture/cli/cmd.gnuTlsCommandFunc(0xc000092400?, {0xdad6cb?, 0x4?, 0xdad683?})
	/usr/local/src/ecapture/cli/cmd/gnutls.go:50 +0x2d
github.com/spf13/cobra.(*Command).execute(0x1464f80, {0x243f5e0, 0x0, 0x0})
	/root/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:987 +0xaa3
github.com/spf13/cobra.(*Command).ExecuteC(0x14649c0)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
	/root/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/gojue/ecapture/cli/cmd.Execute()
	/usr/local/src/ecapture/cli/cmd/root.go:106 +0x10b
github.com/gojue/ecapture/cli.Start(...)
	/usr/local/src/ecapture/cli/main.go:22
main.main()
	/usr/local/src/ecapture/main.go:32 +0x93
```