### PR TITLE
fix: SSLDataEvent's fd is 0 Error

### DIFF
--- a/kern/boringssl_a_13_kern.c
+++ b/kern/boringssl_a_13_kern.c
@@ -31,6 +31,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x18
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x10
 

--- a/kern/boringssl_a_14_kern.c
+++ b/kern/boringssl_a_14_kern.c
@@ -31,6 +31,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x18
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x10
 

--- a/kern/boringssl_na_kern.c
+++ b/kern/boringssl_na_kern.c
@@ -31,6 +31,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x20
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x10
 

--- a/kern/openssl.h
+++ b/kern/openssl.h
@@ -482,7 +482,7 @@ int probe_connect(struct pt_regs* ctx) {
         return 0;
     }
 
-    //debug_bpf_printk("@ sockaddr FM :%d\n", address_family);
+    debug_bpf_printk("@ sockaddr FM :%d\n", address_family);
 
     struct connect_event_t conn;
     __builtin_memset(&conn, 0, sizeof(conn));

--- a/kern/openssl.h
+++ b/kern/openssl.h
@@ -240,11 +240,11 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
         debug_bpf_printk(
             "(OPENSSL) bpf_probe_read ssl_wbio_method_ptr failed, ret: %d\n",
             ret);
-        return 0;
+        // return 0;
     }
 
     // get ssl->bio->method->type
-    u32 bio_type;
+    u32 bio_type = defaultBioType;
     ssl_wbio_method_type_ptr = (u64 *)(ssl_wbio_method_addr + BIO_METHOD_ST_TYPE);
     ret = bpf_probe_read_user(&bio_type, sizeof(bio_type),
                               ssl_wbio_method_type_ptr);
@@ -252,7 +252,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
         debug_bpf_printk(
             "(OPENSSL) bpf_probe_read ssl_wbio_method_type_ptr failed, ret: %d\n",
             ret);
-        return 0;
+        // return 0;
     }
     debug_bpf_printk("openssl uprobe/SSL_write bio_type: %d\n", bio_type);
 
@@ -378,11 +378,11 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
         debug_bpf_printk(
             "(OPENSSL) bpf_probe_read ssl_rbio_method_ptr failed, ret: %d\n",
             ret);
-        return 0;
+        // return 0;
     }
 
     // get ssl->bio->method->type
-    u32 bio_type;
+    u32 bio_type = defaultBioType;
     ssl_rbio_method_type_ptr = (u64 *)(ssl_rbio_method_addr + BIO_METHOD_ST_TYPE);
     ret = bpf_probe_read_user(&bio_type, sizeof(bio_type),
                               ssl_rbio_method_type_ptr);
@@ -390,7 +390,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
         debug_bpf_printk(
             "(OPENSSL) bpf_probe_read ssl_rbio_method_type_ptr failed, ret: %d\n",
             ret);
-        return 0;
+        // return 0;
     }
 
     debug_bpf_printk("openssl uprobe/SSL_read bio_type: %d\n", bio_type);

--- a/kern/openssl.h
+++ b/kern/openssl.h
@@ -22,6 +22,7 @@
 
 enum ssl_data_event_type { kSSLRead, kSSLWrite };
 const u32 invalidFD = 0;
+const u32 noSetFd = 0;
 
 struct ssl_data_event_t {
     enum ssl_data_event_type type;
@@ -33,6 +34,7 @@ struct ssl_data_event_t {
     char comm[TASK_COMM_LEN];
     u32 fd;
     s32 version;
+    u32 is_set_fd;
 };
 
 struct connect_event_t {
@@ -128,6 +130,7 @@ static __inline struct ssl_data_event_t* create_ssl_data_event(
     event->pid = current_pid_tgid >> 32;
     event->tid = current_pid_tgid & kMask32b;
     event->fd = invalidFD;
+    event->is_set_fd = noSetFd;
 
     return event;
 }
@@ -138,7 +141,7 @@ static __inline struct ssl_data_event_t* create_ssl_data_event(
 
 static int process_SSL_data(struct pt_regs* ctx, u64 id,
                             enum ssl_data_event_type type, const char* buf,
-                            u32 fd, s32 version) {
+                            u32 fd, s32 version, u32 is_set_fd) {
     int len = (int)PT_REGS_RC(ctx);
     if (len < 0) {
         return 0;
@@ -151,6 +154,7 @@ static int process_SSL_data(struct pt_regs* ctx, u64 id,
 
     event->type = type;
     event->fd = fd;
+    event->is_set_fd = is_set_fd;
     event->version = version;
     // This is a max function, but it is written in such a way to keep older BPF
     // verifiers happy.
@@ -186,7 +190,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
         return 0;
     }
 #endif
-    debug_bpf_printk("openssl uprobe/SSL_write pid :%d\n", pid);
+    debug_bpf_printk("openssl uprobe/SSL_write pid: %d\n", pid);
 
     void* ssl = (void*)PT_REGS_PARM1(ctx);
     // https://github.com/openssl/openssl/blob/OpenSSL_1_1_1-stable/crypto/bio/bio_local.h
@@ -200,7 +204,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
                               ssl_ver_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_ver_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_ver_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -210,7 +214,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
                               ssl_wbio_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_wbio_addr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_wbio_addr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -221,7 +225,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
                               ssl_wbio_num_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_wbio_num_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_wbio_num_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -236,7 +240,7 @@ int probe_entry_SSL_write(struct pt_regs* ctx) {
         } else {
         }
     }
-    debug_bpf_printk("openssl uprobe SSL_write FD:%d, version:%d\n", fd, ssl_version);
+    debug_bpf_printk("openssl uprobe/SSL_write fd: %d, version: %d\n", fd, ssl_version);
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     struct active_ssl_buf active_ssl_buf_t;
@@ -266,15 +270,20 @@ int probe_ret_SSL_write(struct pt_regs* ctx) {
         return 0;
     }
 #endif
-    debug_bpf_printk("openssl uretprobe/SSL_write pid :%d\n", pid);
+    debug_bpf_printk("openssl uretprobe/SSL_write pid: %d\n", pid);
     struct active_ssl_buf* active_ssl_buf_t =
         bpf_map_lookup_elem(&active_ssl_write_args_map, &current_pid_tgid);
     if (active_ssl_buf_t != NULL) {
         const char* buf;
         u32 fd = active_ssl_buf_t->fd;
+        u32 is_set_fd = noSetFd;
+        if (fd > 0) {
+            is_set_fd = 1;
+        }
+        debug_bpf_printk("openssl uretprobe/SSL_write is_set_fd: %d\n", is_set_fd);
         s32 version = active_ssl_buf_t->version;
         bpf_probe_read(&buf, sizeof(const char*), &active_ssl_buf_t->buf);
-        process_SSL_data(ctx, current_pid_tgid, kSSLWrite, buf, fd, version);
+        process_SSL_data(ctx, current_pid_tgid, kSSLWrite, buf, fd, version, is_set_fd);
     }
     bpf_map_delete_elem(&active_ssl_write_args_map, &current_pid_tgid);
     return 0;
@@ -288,7 +297,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("openssl uprobe/SSL_read pid :%d\n", pid);
+    debug_bpf_printk("openssl uprobe/SSL_read pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -312,7 +321,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
                               ssl_ver_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_ver_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_ver_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -322,7 +331,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
                               ssl_rbio_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_rbio_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_rbio_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -333,7 +342,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
                               ssl_rbio_num_ptr);
     if (ret) {
         debug_bpf_printk(
-            "(OPENSSL) bpf_probe_read ssl_rbio_num_ptr failed, ret :%d\n",
+            "(OPENSSL) bpf_probe_read ssl_rbio_num_ptr failed, ret: %d\n",
             ret);
         return 0;
     }
@@ -347,7 +356,7 @@ int probe_entry_SSL_read(struct pt_regs* ctx) {
         } else {
         }
     }
-    debug_bpf_printk("openssl uprobe PID:%d, SSL_read FD:%d\n", pid, fd);
+    debug_bpf_printk("openssl uprobe/SSL_read fd: %d, version: %d\n", fd, ssl_version);
 
     const char* buf = (const char*)PT_REGS_PARM2(ctx);
     struct active_ssl_buf active_ssl_buf_t;
@@ -366,7 +375,7 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
-    debug_bpf_printk("openssl uretprobe/SSL_read pid :%d\n", pid);
+    debug_bpf_printk("openssl uretprobe/SSL_read pid: %d\n", pid);
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -383,9 +392,14 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     if (active_ssl_buf_t != NULL) {
         const char* buf;
         u32 fd = active_ssl_buf_t->fd;
+        u32 is_set_fd = noSetFd;
+        if (fd > 0) {
+            is_set_fd = 1;
+        }
+        debug_bpf_printk("openssl uretprobe/SSL_read is_set_fd: %d\n", is_set_fd);
         s32 version = active_ssl_buf_t->version;
         bpf_probe_read(&buf, sizeof(const char*), &active_ssl_buf_t->buf);
-        process_SSL_data(ctx, current_pid_tgid, kSSLRead, buf, fd, version);
+        process_SSL_data(ctx, current_pid_tgid, kSSLRead, buf, fd, version, is_set_fd);
     }
     bpf_map_delete_elem(&active_ssl_read_args_map, &current_pid_tgid);
     return 0;
@@ -454,6 +468,6 @@ int probe_SSL_set_fd(struct pt_regs* ctx) {
     u64 ssl_addr = (u64)PT_REGS_PARM1(ctx);
     u64 fd = (u64)PT_REGS_PARM2(ctx);
     bpf_map_update_elem(&ssl_st_fd, &ssl_addr, &fd, BPF_ANY);
-    debug_bpf_printk("SSL_set_fd hook!!, ssl_addr:%d, fd:%d\n", ssl_addr, fd);
+    debug_bpf_printk("SSL_set_fd hook!!, ssl_addr: %d, fd: %d\n", ssl_addr, fd);
     return 0;
 }

--- a/kern/openssl_1_0_2a_kern.c
+++ b/kern/openssl_1_0_2a_kern.c
@@ -40,6 +40,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x28
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 // openssl 1.0.2 does not support TLS 1.3, set 0 default
 #define SSL_ST_HANDSHAKE_SECRET 0
 #define SSL_ST_HANDSHAKE_TRAFFIC_HASH 0

--- a/kern/openssl_1_1_0a_kern.c
+++ b/kern/openssl_1_1_0a_kern.c
@@ -40,6 +40,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x28
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 // openssl 1.1.0 does not support TLS 1.3, set 0 default
 #define SSL_ST_HANDSHAKE_SECRET 0
 #define SSL_ST_HANDSHAKE_TRAFFIC_HASH 0

--- a/kern/openssl_1_1_1a_kern.c
+++ b/kern/openssl_1_1_1a_kern.c
@@ -55,6 +55,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x30
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 #include "openssl.h"
 #include "openssl_masterkey.h"
 

--- a/kern/openssl_1_1_1b_kern.c
+++ b/kern/openssl_1_1_1b_kern.c
@@ -55,6 +55,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x30
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 #include "openssl.h"
 #include "openssl_masterkey.h"
 

--- a/kern/openssl_1_1_1d_kern.c
+++ b/kern/openssl_1_1_1d_kern.c
@@ -55,6 +55,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x30
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 #include "openssl.h"
 #include "openssl_masterkey.h"
 

--- a/kern/openssl_1_1_1j_kern.c
+++ b/kern/openssl_1_1_1j_kern.c
@@ -55,6 +55,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x30
 
+// bio_st->method
+#define BIO_ST_METHOD 0x0
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 #include "openssl.h"
 #include "openssl_masterkey.h"
 

--- a/kern/openssl_3_0_0_kern.c
+++ b/kern/openssl_3_0_0_kern.c
@@ -1,8 +1,8 @@
-#ifndef ECAPTURE_OPENSSL_3_0_6_KERN_H
-#define ECAPTURE_OPENSSL_3_0_6_KERN_H
+#ifndef ECAPTURE_OPENSSL_3_0_0_KERN_H
+#define ECAPTURE_OPENSSL_3_0_0_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 3.1.6 4 Jun 2024 */
-/* OPENSSL_VERSION_NUMBER: 806355040 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.0.9 30 May 2023 */
+/* OPENSSL_VERSION_NUMBER: 805306512 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -54,6 +54,12 @@
 
 // bio_st->num
 #define BIO_ST_NUM 0x38
+
+// bio_st->method
+#define BIO_ST_METHOD 0x8
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
 
 #include "openssl.h"
 #include "openssl_masterkey_3.0.h"

--- a/kern/openssl_3_1_0_kern.c
+++ b/kern/openssl_3_1_0_kern.c
@@ -1,8 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_3_0_0_KERN_H
 #define ECAPTURE_OPENSSL_3_0_0_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 3.1.5 30 Jan 2024 */
-/* OPENSSL_VERSION_NUMBER: 806355024 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.1.7 3 Sep 2024 */
+/* OPENSSL_VERSION_NUMBER: 806355056 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -54,6 +54,12 @@
 
 // bio_st->num
 #define BIO_ST_NUM 0x38
+
+// bio_st->method
+#define BIO_ST_METHOD 0x8
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
 
 #include "openssl.h"
 #include "openssl_masterkey_3.0.h"

--- a/kern/openssl_3_2_0_kern.c
+++ b/kern/openssl_3_2_0_kern.c
@@ -1,5 +1,5 @@
-#ifndef ECAPTURE_OPENSSL_3_2_2_KERN_H
-#define ECAPTURE_OPENSSL_3_2_2_KERN_H
+#ifndef ECAPTURE_OPENSSL_3_2_0_KERN_H
+#define ECAPTURE_OPENSSL_3_2_0_KERN_H
 
 /* OPENSSL_VERSION_TEXT: OpenSSL 3.2.2 4 Jun 2024 */
 /* OPENSSL_VERSION_NUMBER: 807403552 */
@@ -57,6 +57,12 @@
 
 // bio_st->num
 #define BIO_ST_NUM 0x38
+
+// bio_st->method
+#define BIO_ST_METHOD 0x8
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
 
 // quic_conn_st->tls
 #define QUIC_CONN_ST_TLS 0x40

--- a/kern/openssl_3_2_3_kern.c
+++ b/kern/openssl_3_2_3_kern.c
@@ -58,6 +58,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x38
 
+// bio_st->method
+#define BIO_ST_METHOD 0x8
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 // quic_conn_st->tls
 #define QUIC_CONN_ST_TLS 0x40
 

--- a/kern/openssl_3_3_0_kern.c
+++ b/kern/openssl_3_3_0_kern.c
@@ -74,6 +74,6 @@
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
 #include "openssl.h"
-#include "openssl_masterkey_3.3.h"
+#include "openssl_masterkey_3.2.h"
 
 #endif

--- a/kern/openssl_3_3_0_kern.c
+++ b/kern/openssl_3_3_0_kern.c
@@ -1,8 +1,8 @@
-#ifndef ECAPTURE_OPENSSL_3_2_2_KERN_H
-#define ECAPTURE_OPENSSL_3_2_2_KERN_H
+#ifndef ECAPTURE_OPENSSL_3_2_0_KERN_H
+#define ECAPTURE_OPENSSL_3_2_0_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 3.2.2 4 Jun 2024 */
-/* OPENSSL_VERSION_NUMBER: 807403552 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.3.2 3 Sep 2024 */
+/* OPENSSL_VERSION_NUMBER: 808452128 */
 
 // ssl_st->type
 #define SSL_ST_TYPE 0x0
@@ -32,10 +32,10 @@
 #define SSL_CONNECTION_ST_S3_CLIENT_RANDOM 0x140
 
 // ssl_session_st->cipher
-#define SSL_SESSION_ST_CIPHER 0x300
+#define SSL_SESSION_ST_CIPHER 0x2f8
 
 // ssl_session_st->cipher_id
-#define SSL_SESSION_ST_CIPHER_ID 0x308
+#define SSL_SESSION_ST_CIPHER_ID 0x300
 
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
@@ -58,6 +58,12 @@
 // bio_st->num
 #define BIO_ST_NUM 0x38
 
+// bio_st->method
+#define BIO_ST_METHOD 0x8
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
 // quic_conn_st->tls
 #define QUIC_CONN_ST_TLS 0x40
 
@@ -69,6 +75,6 @@
 
 
 #include "openssl.h"
-#include "openssl_masterkey_3.2.h"
+#include "openssl_masterkey_3.3.h"
 
 #endif

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -80,7 +80,7 @@ type SSLDataEvent struct {
 	Fd        uint32            `json:"fd"`
 	Version   int32             `json:"version"`
 	Addr      string
-	IsSetFd   uint32
+	BioType   uint32
 }
 
 func (se *SSLDataEvent) Decode(payload []byte) (err error) {
@@ -110,6 +110,9 @@ func (se *SSLDataEvent) Decode(payload []byte) (err error) {
 		return
 	}
 	if err = binary.Read(buf, binary.LittleEndian, &se.Version); err != nil {
+		return
+	}
+	if err = binary.Read(buf, binary.LittleEndian, &se.BioType); err != nil {
 		return
 	}
 

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -80,6 +80,7 @@ type SSLDataEvent struct {
 	Fd        uint32            `json:"fd"`
 	Version   int32             `json:"version"`
 	Addr      string
+	IsSetFd   uint32
 }
 
 func (se *SSLDataEvent) Decode(payload []byte) (err error) {

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -648,7 +648,7 @@ func (m *MOpenSSLProbe) Dispatcher(eventStruct event.IEventStruct) {
 }
 
 func (m *MOpenSSLProbe) dumpSslData(eventStruct *event.SSLDataEvent) {
-	if eventStruct.Fd <= 0 {
+	if eventStruct.IsSetFd > 0 && eventStruct.Fd <= 0 {
 		m.logger.Error().Uint32("pid", eventStruct.Pid).Uint32("fd", eventStruct.Fd).Str("address", eventStruct.Addr).Msg("SSLDataEvent's fd is 0")
 		//return
 	}

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -648,7 +648,8 @@ func (m *MOpenSSLProbe) Dispatcher(eventStruct event.IEventStruct) {
 }
 
 func (m *MOpenSSLProbe) dumpSslData(eventStruct *event.SSLDataEvent) {
-	if eventStruct.Fd <= 0 {
+	// BIO_TYPE_SOURCE_SINK|BIO_TYPE_DESCRIPTOR = 0x0400|0x0100 = 1280
+	if eventStruct.Fd <= 0 && eventStruct.BioType > 1280 {
 		m.logger.Error().Uint32("pid", eventStruct.Pid).Uint32("fd", eventStruct.Fd).Str("address", eventStruct.Addr).Msg("SSLDataEvent's fd is 0")
 		//return
 	}

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -42,6 +42,7 @@ const (
 	ConnNotFound = "[ADDR_NOT_FOUND]"
 	DefaultAddr  = "0.0.0.0"
 	// OpenSSL the classes of BIOs
+	// https://github.com/openssl/openssl/blob/openssl-3.0.0/include/openssl/bio.h.in
 	BIO_TYPE_DESCRIPTOR  = 0x0100
 	BIO_TYPE_SOURCE_SINK = 0x0400
 )

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -648,12 +648,12 @@ func (m *MOpenSSLProbe) Dispatcher(eventStruct event.IEventStruct) {
 }
 
 func (m *MOpenSSLProbe) dumpSslData(eventStruct *event.SSLDataEvent) {
-	if eventStruct.IsSetFd > 0 && eventStruct.Fd <= 0 {
+	if eventStruct.Fd <= 0 {
 		m.logger.Error().Uint32("pid", eventStruct.Pid).Uint32("fd", eventStruct.Fd).Str("address", eventStruct.Addr).Msg("SSLDataEvent's fd is 0")
 		//return
 	}
 	addr := m.GetConn(eventStruct.Pid, eventStruct.Fd)
-	m.logger.Debug().Uint32("pid", eventStruct.Pid).Uint32("fd", eventStruct.Fd).Str("address", addr).Msg("SSLDataEvent")
+	m.logger.Debug().Uint32("pid", eventStruct.Pid).Uint32("bio_type", eventStruct.BioType).Uint32("fd", eventStruct.Fd).Str("address", addr).Msg("SSLDataEvent")
 	if addr == ConnNotFound {
 		eventStruct.Addr = DefaultAddr
 	} else {

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -41,6 +41,9 @@ import (
 const (
 	ConnNotFound = "[ADDR_NOT_FOUND]"
 	DefaultAddr  = "0.0.0.0"
+	// OpenSSL the classes of BIOs
+	BIO_TYPE_DESCRIPTOR  = 0x0100
+	BIO_TYPE_SOURCE_SINK = 0x0400
 )
 
 type Tls13MasterSecret struct {
@@ -649,7 +652,7 @@ func (m *MOpenSSLProbe) Dispatcher(eventStruct event.IEventStruct) {
 
 func (m *MOpenSSLProbe) dumpSslData(eventStruct *event.SSLDataEvent) {
 	// BIO_TYPE_SOURCE_SINK|BIO_TYPE_DESCRIPTOR = 0x0400|0x0100 = 1280
-	if eventStruct.Fd <= 0 && eventStruct.BioType > 1280 {
+	if eventStruct.Fd <= 0 && eventStruct.BioType > BIO_TYPE_SOURCE_SINK|BIO_TYPE_DESCRIPTOR {
 		m.logger.Error().Uint32("pid", eventStruct.Pid).Uint32("fd", eventStruct.Fd).Str("address", eventStruct.Addr).Msg("SSLDataEvent's fd is 0")
 		//return
 	}

--- a/utils/boringssl-offset.c
+++ b/utils/boringssl-offset.c
@@ -30,6 +30,8 @@
     X(ssl_session_st, secret)                \
     X(ssl_session_st, cipher)                \
     X(bio_st, num)                           \
+    X(bio_st, method)                        \
+    X(bio_method_st, type)                   \
     X(ssl_cipher_st, id)                     \
     X(bssl::SSL3_STATE, hs)                  \
     X(bssl::SSL3_STATE, client_random)       \

--- a/utils/openssl_1_0_2_offset.c
+++ b/utils/openssl_1_0_2_offset.c
@@ -16,7 +16,9 @@
     X(ssl_session_st, cipher)       \
     X(ssl_session_st, cipher_id)    \
     X(ssl_cipher_st, id)            \
-    X(bio_st, num)
+    X(bio_st, num)                  \
+    X(bio_st, method)               \
+    X(bio_method_st, type)
 
 void toUpper(char *s) {
     int i = 0;

--- a/utils/openssl_1_1_0_offset.c
+++ b/utils/openssl_1_1_0_offset.c
@@ -11,13 +11,15 @@
     X(ssl_st, s3)                   \
     X(ssl_st, rbio)                 \
     X(ssl_st, wbio)                 \
-    X(ssl_st, server)                    \
+    X(ssl_st, server)               \
     X(ssl_session_st, master_key)   \
     X(ssl3_state_st, client_random) \
     X(ssl_session_st, cipher)       \
     X(ssl_session_st, cipher_id)    \
     X(ssl_cipher_st, id)            \
-    X(bio_st, num)
+    X(bio_st, num)                  \
+    X(bio_st, method)               \
+    X(bio_method_st, type)
 
 void toUpper(char *s) {
     int i = 0;

--- a/utils/openssl_1_1_1_offset.c
+++ b/utils/openssl_1_1_1_offset.c
@@ -32,7 +32,9 @@
     X(ssl_st, client_app_traffic_secret) \
     X(ssl_st, server_app_traffic_secret) \
     X(ssl_st, exporter_master_secret)    \
-    X(bio_st, num)
+    X(bio_st, num)                       \
+    X(bio_st, method)                    \
+    X(bio_method_st, type)
 
 void toUpper(char *s) {
     int i = 0;

--- a/utils/openssl_3_0_offset.c
+++ b/utils/openssl_3_0_offset.c
@@ -22,7 +22,9 @@
     X(ssl_st, client_app_traffic_secret) \
     X(ssl_st, server_app_traffic_secret) \
     X(ssl_st, exporter_master_secret)    \
-    X(bio_st, num)
+    X(bio_st, num)                       \
+    X(bio_st, method)                    \
+    X(bio_method_st, type)
 
 void toUpper(char *s) {
     int i = 0;

--- a/utils/openssl_3_2_0_offset.c
+++ b/utils/openssl_3_2_0_offset.c
@@ -24,6 +24,8 @@
     X(ssl_connection_st, server_app_traffic_secret) \
     X(ssl_connection_st, exporter_master_secret)    \
     X(bio_st, num)                                  \
+    X(bio_st, method)                               \
+    X(bio_method_st, type)                          \
     X(quic_conn_st, tls)
 
 void toUpper(char *s) {


### PR DESCRIPTION
Fixes: #596 

this error happend because application use BIO instead of set socket fd into the SSL layers.

the default fd value in SSLDataEvent struct is 0, When application use SSL_set_fd, the error will not happend, we can get corret fd value.

When application use SSL_set_bio, the fd value in SSLDataEvent struct will keep default value.

App Example:

```
# curl v7.74.0 lib/vtls/openssl.c
static CURLcode ossl_connect_step1(struct connectdata *conn, int sockindex) {
......
    if(!SSL_set_fd(backend->handle, (int)sockfd)) {
    /* pass the raw socket into the SSL layers */
    failf(data, "SSL: SSL_set_fd failed: %s",
          ossl_strerror(ERR_get_error(), error_buffer, sizeof(error_buffer)));
    return CURLE_SSL_CONNECT_ERROR;
  }

  connssl->connecting_state = ssl_connect_2;

  return CURLE_OK;
}

# curl v7.88.1 lib/vtls/openssl.c
static CURLcode ossl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data) {
......
  backend->bio_method = bio_cf_method_create();
  if(!backend->bio_method)
    return CURLE_OUT_OF_MEMORY;
  bio = BIO_new(backend->bio_method);
  if(!bio)
    return CURLE_OUT_OF_MEMORY;

  BIO_set_data(bio, cf);
#ifdef HAVE_SSL_SET0_WBIO
  /* with OpenSSL v1.1.1 we get an alternative to SSL_set_bio() that works
   * without backward compat quirks. Every call takes one reference, so we
   * up it and pass. SSL* then owns it and will free.
   * We check on the function in configure, since libressl and friends
   * each have their own versions to add support for this. */
  BIO_up_ref(bio);
  SSL_set0_rbio(backend->handle, bio);
  SSL_set0_wbio(backend->handle, bio);
#else
  SSL_set_bio(backend->handle, bio, bio);
#endif
  connssl->connecting_state = ssl_connect_2;

  return CURLE_OK;
}
```