### PR TITLE
workflows: update linux source tgz file version.

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,13 +50,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes build-essential pkgconf libelf-dev llvm clang linux-tools-common linux-tools-generic flex bison gcc-aarch64-linux-gnu libssl-dev linux-source
-          for tool in "clang" "llc" "llvm-strip"
           cd /usr/src
-          sudo tar -xf linux-source.tar.bz2
-          cd /usr/src/linux-source
+          source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+          source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')  
+          sudo tar -xf $source_file
+          cd $source_dir
           test -f .config || sudo make oldconfig
           sudo make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare V=0
-          ls -al /usr/src/linux-source
+          ls -al /usr/src/$source_dir
         shell: bash
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,19 +49,14 @@ jobs:
       - name: Install Compilers
         run: |
           sudo apt-get update
-          kernel_ver=`uname -r | cut -d'-' -f 1`
-          sudo apt-get install --yes build-essential pkgconf libelf-dev llvm-12 clang-12 linux-tools-common linux-tools-generic flex bison gcc-aarch64-linux-gnu libssl-dev linux-source-${kernel_ver}
+          sudo apt-get install --yes build-essential pkgconf libelf-dev llvm clang linux-tools-common linux-tools-generic flex bison gcc-aarch64-linux-gnu libssl-dev linux-source
           for tool in "clang" "llc" "llvm-strip"
-          do
-            sudo rm -f /usr/bin/$tool
-            sudo ln -s /usr/bin/$tool-12 /usr/bin/$tool
-          done
           cd /usr/src
-          sudo tar -xf linux-source-${kernel_ver}.tar.bz2
-          cd /usr/src/linux-source-${kernel_ver}
+          sudo tar -xf linux-source.tar.bz2
+          cd /usr/src/linux-source
           test -f .config || sudo make oldconfig
           sudo make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare V=0
-          ls -al /usr/src/linux-source-${kernel_ver}
+          ls -al /usr/src/linux-source
         shell: bash
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/go-c-cpp.yml
+++ b/.github/workflows/go-c-cpp.yml
@@ -66,11 +66,13 @@ jobs:
             sudo ln -s /usr/bin/$tool-14 /usr/bin/$tool
           done
           cd /usr/src
-          sudo tar -xf linux-source.tar.bz2
-          cd /usr/src/linux-source
+          source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+          source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')  
+          sudo tar -xf $source_file
+          cd $source_dir
           test -f .config || sudo make oldconfig
           sudo make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare V=0
-          ls -al /usr/src/linux-source
+          ls -al /usr/src/$source_dir
         shell: bash
       - uses: actions/checkout@v4
         with:
@@ -174,12 +176,14 @@ jobs:
             rm -rf /usr/local/go
             tar -C /usr/local -xzf go1.21.0.linux-arm64.tar.gz
             cd /usr/src
-            tar -xf linux-source.tar.bz2
-            cd /usr/src/linux-source
+            source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+            source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')
+            tar -xf $source_file
+            cd $source_dir
             test -f .config || make oldconfig > /dev/null
             make ARCH=x86 CROSS_COMPILE=x86_64-linux-gnu- prepare V=0 > /dev/null
             make prepare V=0 > /dev/null
-            ls -al /usr/src/linux-source
+            ls -al /usr/src/$source_dir
           # Produce a binary artifact and place it in the mounted volume
           run: |
             uname -a
@@ -197,17 +201,20 @@ jobs:
             cat /proc/1/cgroup
             echo "cat /proc/1/sched:"
             cat /proc/1/sched
+            cd /usr/src
+            source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+            source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')
             git config --global --add safe.directory /source_code
             cd /source_code
             echo "-------------------start: Build CO-RE Linux (include non-CO-RE)-------------------"
-            KERN_HEADERS=/usr/src/linux-source make env
+            KERN_HEADERS=/usr/src/$source_dir make env
             make clean
-            KERN_HEADERS=/usr/src/linux-source make
+            KERN_HEADERS=/usr/src/$source_dir make
             bin/ecapture -v
             echo "-------------------start: Build non-CO-RE (Cross-Compilation) Linux -------------------"
             make clean
-            KERN_HEADERS=/usr/src/linux-source CROSS_ARCH=amd64 make env
-            KERN_HEADERS=/usr/src/linux-source CROSS_ARCH=amd64 make nocore -j8
+            KERN_HEADERS=/usr/src/$source_dir CROSS_ARCH=amd64 make env
+            KERN_HEADERS=/usr/src/$source_dir CROSS_ARCH=amd64 make nocore -j8
             file bin/ecapture
       - name: Show the artifact
         # Items placed in /artifacts in the container will be in

--- a/.github/workflows/go-c-cpp.yml
+++ b/.github/workflows/go-c-cpp.yml
@@ -59,19 +59,18 @@ jobs:
       - name: Install Compilers
         run: |
           sudo apt-get update
-          kernel_ver=`uname -r | cut -d'-' -f 1`
-          sudo apt-get install --yes build-essential pkgconf libelf-dev llvm-14 clang-14 flex bison linux-tools-common linux-tools-generic gcc gcc-aarch64-linux-gnu libssl-dev linux-source-${kernel_ver}
+          sudo apt-get install --yes build-essential pkgconf libelf-dev llvm-14 clang-14 flex bison linux-tools-common linux-tools-generic gcc gcc-aarch64-linux-gnu libssl-dev linux-source
           for tool in "clang" "llc" "llvm-strip"
           do
             sudo rm -f /usr/bin/$tool
             sudo ln -s /usr/bin/$tool-14 /usr/bin/$tool
           done
           cd /usr/src
-          sudo tar -xf linux-source-${kernel_ver}.tar.bz2
-          cd /usr/src/linux-source-${kernel_ver}
+          sudo tar -xf linux-source.tar.bz2
+          cd /usr/src/linux-source
           test -f .config || sudo make oldconfig
           sudo make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare V=0
-          ls -al /usr/src/linux-source-${kernel_ver}
+          ls -al /usr/src/linux-source
         shell: bash
       - uses: actions/checkout@v4
         with:
@@ -170,18 +169,17 @@ jobs:
           install: |
             uname -a
             apt-get update
-            kernel_ver=`uname -r | cut -d'-' -f 1`
-            apt-get install --yes wget git build-essential pkgconf libelf-dev llvm-12 clang-12 linux-tools-generic linux-tools-common flex bison file gcc-x86-64-linux-gnu libssl-dev bc linux-source-${kernel_ver}
+            apt-get install --yes wget git build-essential pkgconf libelf-dev llvm-12 clang-12 linux-tools-generic linux-tools-common flex bison file gcc-x86-64-linux-gnu libssl-dev bc linux-source
             wget https://go.dev/dl/go1.21.0.linux-arm64.tar.gz
             rm -rf /usr/local/go
             tar -C /usr/local -xzf go1.21.0.linux-arm64.tar.gz
             cd /usr/src
-            tar -xf linux-source-${kernel_ver}.tar.bz2
-            cd /usr/src/linux-source-${kernel_ver}
+            tar -xf linux-source.tar.bz2
+            cd /usr/src/linux-source
             test -f .config || make oldconfig > /dev/null
             make ARCH=x86 CROSS_COMPILE=x86_64-linux-gnu- prepare V=0 > /dev/null
             make prepare V=0 > /dev/null
-            ls -al /usr/src/linux-source-${kernel_ver}
+            ls -al /usr/src/linux-source
           # Produce a binary artifact and place it in the mounted volume
           run: |
             uname -a
@@ -201,16 +199,15 @@ jobs:
             cat /proc/1/sched
             git config --global --add safe.directory /source_code
             cd /source_code
-            kernel_ver=`uname -r | cut -d'-' -f 1`
             echo "-------------------start: Build CO-RE Linux (include non-CO-RE)-------------------"
-            KERN_HEADERS=/usr/src/linux-source-${kernel_ver} make env
+            KERN_HEADERS=/usr/src/linux-source make env
             make clean
-            KERN_HEADERS=/usr/src/linux-source-${kernel_ver} make
+            KERN_HEADERS=/usr/src/linux-source make
             bin/ecapture -v
             echo "-------------------start: Build non-CO-RE (Cross-Compilation) Linux -------------------"
             make clean
-            KERN_HEADERS=/usr/src/linux-source-${kernel_ver} CROSS_ARCH=amd64 make env
-            KERN_HEADERS=/usr/src/linux-source-${kernel_ver} CROSS_ARCH=amd64 make nocore -j8
+            KERN_HEADERS=/usr/src/linux-source CROSS_ARCH=amd64 make env
+            KERN_HEADERS=/usr/src/linux-source CROSS_ARCH=amd64 make nocore -j8
             file bin/ecapture
       - name: Show the artifact
         # Items placed in /artifacts in the container will be in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,19 +16,18 @@ jobs:
       - name: Install Compilers
         run: |
           sudo apt-get update
-          kernel_ver=`uname -r | cut -d'-' -f 1`
-          sudo apt-get install --yes build-essential pkgconf libelf-dev llvm-14 clang-14 linux-tools-common linux-tools-generic gcc gcc-aarch64-linux-gnu linux-source-${kernel_ver}
+          sudo apt-get install --yes build-essential pkgconf libelf-dev llvm-14 clang-14 linux-tools-common linux-tools-generic gcc gcc-aarch64-linux-gnu linux-source
           for tool in "clang" "llc" "llvm-strip"
           do
             sudo rm -f /usr/bin/$tool
             sudo ln -s /usr/bin/$tool-14 /usr/bin/$tool
           done
           cd /usr/src
-          sudo tar -xf linux-source-${kernel_ver}.tar.bz2
-          cd /usr/src/linux-source-${kernel_ver}
+          sudo tar -xf linux-source.tar.bz2
+          cd /usr/src/linux-source
           test -f .config || sudo make oldconfig
           sudo make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare V=0
-          ls -al /usr/src/linux-source-${kernel_ver}
+          ls -al /usr/src/linux-source
         shell: bash
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,11 +23,13 @@ jobs:
             sudo ln -s /usr/bin/$tool-14 /usr/bin/$tool
           done
           cd /usr/src
-          sudo tar -xf linux-source.tar.bz2
-          cd /usr/src/linux-source
+          source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+          source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')  
+          sudo tar -xf $source_file
+          cd $source_dir
           test -f .config || sudo make oldconfig
           sudo make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- prepare V=0
-          ls -al /usr/src/linux-source
+          ls -al /usr/src/$source_dir
         shell: bash
       - uses: actions/checkout@v4
         with:

--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -85,11 +85,12 @@ To cross-compile the eCapture tool, you need to install the kernel header files 
 install the `linux-source` package.
 
 ```shell
-kernel_ver=`uname -r | cut -d'-' -f 1`
-sudo apt-get install -y linux-source-$kernel_ver
+sudo apt-get install -y linux-source
 cd /usr/src
-sudo tar -xf linux-source-${kernel_ver}.tar.bz2
-cd /usr/src/linux-source-${kernel_ver}
+source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')  
+sudo tar -xf $source_file
+cd $source_dir
 test -f .config || yes "" | sudo make oldconfig
 ```
 

--- a/COMPILATION_CN.md
+++ b/COMPILATION_CN.md
@@ -102,8 +102,10 @@ bin/ecapture
 kernel_ver=`uname -r | cut -d'-' -f 1`
 sudo apt-get install -y linux-source-$kernel_ver
 cd /usr/src
-sudo tar -xf linux-source-${kernel_ver}.tar.bz2
-cd /usr/src/linux-source-${kernel_ver}
+source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')  
+sudo tar -xf $source_file
+cd $source_dir
 test -f .config || yes "" | sudo make oldconfig
 ```
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -200,8 +200,10 @@ bin/ecapture --help
 kernel_ver=`uname -r | cut -d'-' -f 1`
 sudo apt-get install -y linux-source-$kernel_ver
 cd /usr/src
-sudo tar -xf linux-source-${kernel_ver}.tar.bz2
-cd /usr/src/linux-source-${kernel_ver}
+source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')  
+sudo tar -xf $source_file
+cd $source_dir
 test -f .config || yes "" | sudo make oldconfig
 ```
 

--- a/builder/init_env.sh
+++ b/builder/init_env.sh
@@ -9,27 +9,28 @@ if [ $? -ne 0 ]; then
   exit
 fi
 
-CLANG_NUM=12
+CLANG_NUM=-12
 # shellcheck disable=SC2209
 MAKE_ECAPTURE=make
 if [ ${release_num} == "20.04" ]; then
-  CLANG_NUM=9
+  CLANG_NUM=-9
   MAKE_ECAPTURE="make nocore"
   elif [ ${release_num} == "20.10" ]; then
-  CLANG_NUM=10
+  CLANG_NUM=-10
   MAKE_ECAPTURE="make nocore"
   elif [ ${release_num} == "21.04" ]; then
-  CLANG_NUM=11
+  CLANG_NUM=-11
   elif [ ${release_num} == "21.10" ]; then
-  CLANG_NUM=12
+  CLANG_NUM=-12
   elif [ ${release_num} == "22.04" ]; then
-  CLANG_NUM=12
+  CLANG_NUM=-12
   elif [ ${release_num} == "22.10" ]; then
-  CLANG_NUM=12
+  CLANG_NUM=-12
   elif [ ${release_num} == "23.04" ];then
-  CLANG_NUM=15
+  CLANG_NUM=-15
   else
-    echo "unsupported release version ${release_num}" && exit
+    echo "used default CLANG Version"
+    CLANG_NUM=
 fi
 
 echo "CLANG_NUM=${CLANG_NUM}"
@@ -52,22 +53,21 @@ cd ~
 
 uname -a
 sudo apt-get update
-kernel_ver=`uname -r | cut -d'-' -f 1`
 # 环境安装
-sudo apt-get install --yes build-essential pkgconf libelf-dev llvm-${CLANG_NUM} clang-${CLANG_NUM} linux-tools-common linux-tools-generic gcc-aarch64-linux-gnu libssl-dev flex bison linux-source-${kernel_ver}
+sudo apt-get install --yes build-essential pkgconf libelf-dev llvm${CLANG_NUM} clang${CLANG_NUM} linux-tools-common linux-tools-generic gcc-aarch64-linux-gnu libssl-dev flex bison linux-source
 for tool in "clang" "llc" "llvm-strip"
 do
   sudo rm -f /usr/bin/$tool
-  sudo ln -s /usr/bin/$tool-${CLANG_NUM} /usr/bin/$tool
+  sudo ln -s /usr/bin/$tool${CLANG_NUM} /usr/bin/$tool
 done
 
 cd /usr/src
-sudo tar -xf linux-source-${kernel_ver}.tar.bz2
-cd /usr/src/linux-source-${kernel_ver}
+sudo tar -xf linux-source.tar.bz2
+cd /usr/src/linux-source
 test -f .config || yes "" | sudo make oldconfig
 yes "" | sudo make ARCH=${ARCH} CROSS_COMPILE=aarch64-linux-gnu- prepare V=0 > /dev/null
 yes "" | sudo make prepare V=0 > /dev/null
-ls -al /usr/src/linux-source-${kernel_ver}
+ls -al /usr/src/linux-source
 
 clang --version
 cd ~

--- a/variables.mk
+++ b/variables.mk
@@ -108,7 +108,13 @@ HOST_VERSION_SHORT := $(shell uname -r | cut -d'-' -f 1)
 
 # linux-source-5.15.0.tar.bz2
 LINUX_SOURCE_PATH ?= /usr/src/linux-source-$(HOST_VERSION_SHORT)
-LINUX_SOURCE_TAR ?= /usr/src/linux-source-$(HOST_VERSION_SHORT).tar.bz2
+ifdef KERN_HEADERS
+	LINUX_SOURCE_PATH = $(KERN_HEADERS)
+else
+	KERN_HEADERS = $(LINUX_SOURCE_PATH)
+endif
+
+LINUX_SOURCE_TAR ?= $(LINUX_SOURCE_PATH).tar.bz2
 
 ifdef CROSS_ARCH
 	ifeq ($(HOST_ARCH),aarch64)
@@ -172,7 +178,6 @@ endif
 #
 ifdef CROSS_ARCH
 	KERNEL_HEADER_GEN = test -e arch/$(LINUX_ARCH)/kernel/asm-offsets.s || yes "" | $(SUDO) make ARCH=$(LINUX_ARCH) CROSS_COMPILE=$(CMD_CC_PREFIX) prepare V=0
-	KERN_HEADERS = $(LINUX_SOURCE_PATH)
 endif
 KERN_RELEASE ?= $(UNAME_R)
 KERN_BUILD_PATH ?= $(if $(KERN_HEADERS),$(KERN_HEADERS),/lib/modules/$(KERN_RELEASE)/build)


### PR DESCRIPTION
error output:
```shell
Reading state information...
E: Unable to locate package linux-source-6.8.0
E: Couldn't find any package by glob 'linux-source-6.8.0' E: Couldn't find any package by regex 'linux-source-6.8.0' Error: Process completed with exit code 100.
```

Github Action run failed via : https://github.com/gojue/ecapture/actions/runs/11101523778/job/30839371311?pr=642#step:3:48


The [Ubuntu 22.04 image](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) used by Github Action has a system kernel version of `6.8.0-1014-azure`, but there is no package for `linux-source-6.8.0` in the deb repository. The deb package downloaded from `apt install linux-source` corresponds to a kernel version of `5.15`, which is quite frustrating.

---- 


Github Action 使用的[UBUNTU 22.04镜像](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md)，系统内核版本为`6.8.0-1014-azure`，但是deb源中却没有`linux-source-6.8.0`的包，`apt install linux-source`下载的deb包，对应的内核版本确是`5.15`，这很让人头疼。



### CI log
```shell
uname -r
cd /usr/src
ls -al
source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')  
echo $source_file
echo $source_dir
```

```shell
...
Setting up gcc-aarch64-linux-gnu (4:11.2.0-1ubuntu1) ...
Processing triggers for man-db (2.10.2-1) ...
Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
NEEDRESTART-VER: 3.5
NEEDRESTART-KCUR: 6.8.0-1014-azure
NEEDRESTART-KEXP: 6.8.0-1014-azure
NEEDRESTART-KSTA: 1
6.8.0-1014-azure
total 24
drwxr-xr-x  6 root root 4096 Sep 30 14:27 .
drwxr-xr-x 15 root root 4096 Sep 30 14:27 ..
drwxr-xr-x 26 root root 4096 Sep 13 02:22 linux-azure-6.8-headers-6.8.0-1014
drwxr-xr-x  7 root root 4096 Sep 13 02:22 linux-headers-6.8.0-1014-azure
drwxr-xr-x  4 root root 4096 Sep 30 14:27 linux-source-5.15.0
lrwxrwxrwx  1 root root   47 Aug 29 12:23 linux-source-5.15.0.tar.bz2 -> linux-source-5.15.0/linux-source-5.15.0.tar.bz2
drwxr-xr-x  4 root root 4096 Sep 22 22:12 python3.10
./linux-source-5.15.0.tar.bz2
...

```