### PR TITLE
builder: docerk build error: header not found (fix: #649)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ env:
 	@echo "LAST_GIT_TAG             $(LAST_GIT_TAG)"
 	@echo "BPF_NOCORE_TAG           $(BPF_NOCORE_TAG)"
 	@echo "KERN_RELEASE             $(KERN_RELEASE)"
+	@echo "LINUX_SOURCE_PATH        $(LINUX_SOURCE_PATH)"
 	@echo "KERN_BUILD_PATH          $(KERN_BUILD_PATH)"
 	@echo "KERN_SRC_PATH            $(KERN_SRC_PATH)"
 	@echo "TARGET_ARCH              $(TARGET_ARCH)"

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,14 @@ help:
 
 .PHONY: prepare
 prepare:
-	$(CMD_CD) $(LINUX_SOURCE_PATH)
-	$(KERNEL_HEADER_GEN) || exit 1
+	if [ -d "/lib/modules/$(KERN_RELEASE)/build" ]; then \
+		$(CMD_CD) /lib/modules/$(KERN_RELEASE)/build && $(KERNEL_HEADER_GEN) || { echo "Kernel header generation failed"; exit 1; } \
+	fi
+	if [ -d "$(LINUX_SOURCE_PATH)" ]; then \
+		$(CMD_CD) $(LINUX_SOURCE_PATH) && $(KERNEL_HEADER_GEN) || { echo "Kernel header generation failed"; exit 1; } \
+	elif [ -n "$(CROSS_ARCH)" ]; then \
+		$(CMD_ECHO) "linux source not found with path: $(LINUX_SOURCE_PATH)" || exit 1; \
+    fi
 
 .PHONY: clean assets build ebpf
 
@@ -144,10 +150,11 @@ ebpf_noncore: prepare $(KERN_OBJECTS_NOCORE)
 .PHONY: $(KERN_OBJECTS_NOCORE)
 $(KERN_OBJECTS_NOCORE): %.nocore: %.c \
 	| .checkver_$(CMD_CLANG) \
-	.checkver_$(CMD_GO)
+	.checkver_$(CMD_GO) \
+	prepare
 	$(CMD_CLANG) \
 			$(EXTRA_CFLAGS_NOCORE) \
-    		$(BPFHEADER) \
+			$(BPFHEADER) \
 			-I $(KERN_SRC_PATH)/arch/$(LINUX_ARCH)/include \
 			-I $(KERN_BUILD_PATH)/arch/$(LINUX_ARCH)/include/generated \
 			-I $(KERN_SRC_PATH)/include \
@@ -155,11 +162,11 @@ $(KERN_OBJECTS_NOCORE): %.nocore: %.c \
 			-I $(KERN_BUILD_PATH)/arch/$(LINUX_ARCH)/include/generated/uapi \
 			-I $(KERN_SRC_PATH)/include/uapi \
 			-I $(KERN_BUILD_PATH)/include/generated/uapi \
-    		-c $< \
-    		-o - |$(CMD_LLC) \
-    		-march=bpf \
-    		-filetype=obj \
-    		-o $(subst kern/,user/bytecode/,$(subst .c,_noncore.o,$<))
+			-c $< \
+			-o - |$(CMD_LLC) \
+			-march=bpf \
+			-filetype=obj \
+			-o $(subst kern/,user/bytecode/,$(subst .c,_noncore.o,$<))
 	$(CMD_CLANG) \
 			$(EXTRA_CFLAGS_NOCORE) \
 			$(BPFHEADER) \
@@ -195,7 +202,7 @@ assets_noncore: \
 $(TARGET_LIBPCAP):
 	test -f ./lib/libpcap/configure || git submodule update --init
 	cd lib/libpcap && \
-		CC=$(CMD_CC_PREFIX)$(CMD_CC) AR=$(CMD_AR_PREFIX)$(CMD_AR) CFLAGS="-O2 -g -gdwarf-4 -static" ./configure --disable-rdma --disable-shared --disable-usb \
+		CC=$(CMD_CC_PREFIX)$(CMD_CC) AR=$(CMD_AR_PREFIX)$(CMD_AR) CFLAGS="-O2 -g -gdwarf-4 -static -Wno-unused-result" ./configure --disable-rdma --disable-shared --disable-usb \
 			--disable-netmap --disable-bluetooth --disable-dbus --without-libnl \
 			--without-dpdk --without-dag --without-septel --without-snf \
 			--without-gcc --with-pcap=linux \

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,6 @@ help:
 
 .PHONY: prepare
 prepare:
-	if [ -d "/lib/modules/$(KERN_RELEASE)/build" ]; then \
-		$(CMD_CD) /lib/modules/$(KERN_RELEASE)/build && $(KERNEL_HEADER_GEN) || { echo "Kernel header generation failed"; exit 1; } \
-	fi
 	if [ -d "$(LINUX_SOURCE_PATH)" ]; then \
 		$(CMD_CD) $(LINUX_SOURCE_PATH) && $(KERNEL_HEADER_GEN) || { echo "Kernel header generation failed"; exit 1; } \
 	elif [ -n "$(CROSS_ARCH)" ]; then \

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04 as ecapture_builder
 
 # Install Compilers
 RUN apt-get update &&\
-  apt-get install --yes build-essential pkgconf libelf-dev llvm-14 clang-14 linux-tools-common linux-tools-$(uname -r) make gcc flex bison file wget &&\
+  apt-get install --yes git build-essential pkgconf libelf-dev llvm-14 clang-14 linux-tools-common linux-headers-$(uname -r) make gcc flex bison file wget linux-source &&\
   # the for-shell built-in instruction does not count as a command 
   # and the shell used to execute the script is sh by default and not bash.
   rm -f /usr/bin/clang && ln -s /usr/bin/clang-14 /usr/bin/clang &&\
@@ -29,7 +29,7 @@ ARG VERSION
 
 RUN cd /build/ecapture &&\
   make clean &&\
-  make -j $(nproc) all SNAPSHOT_VERSION=${VERSION}_docker
+  make all SNAPSHOT_VERSION=${VERSION}_docker
 
 # ecapture release image
 FROM alpine:latest as ecapture

--- a/builder/init_env.sh
+++ b/builder/init_env.sh
@@ -28,6 +28,10 @@ if [ ${release_num} == "20.04" ]; then
   CLANG_NUM=-12
   elif [ ${release_num} == "23.04" ];then
   CLANG_NUM=-15
+  elif [ ${release_num} == "23.10" ];then
+    CLANG_NUM=-15
+  elif [ ${release_num} == "24.04" ];then
+  CLANG_NUM=-18
   else
     echo "used default CLANG Version"
     CLANG_NUM=
@@ -37,10 +41,16 @@ echo "CLANG_NUM=${CLANG_NUM}"
 
 UNAME_M=`uname -m`
 ARCH="amd64"
+CROSS_ARCH_PATH="arm64"
+CROSS_COMPILE=aarch64-linux-gnu-
 if [[ ${UNAME_M} =~ "x86_64" ]];then
   ARCH="amd64"
+  CROSS_ARCH_PATH="arm64"
+  CROSS_COMPILE=aarch64-linux-gnu-
   elif [[ ${UNAME_M} =~ "aarch64" ]]; then
     ARCH="arm64"
+    CROSS_ARCH_PATH="x86"
+    CROSS_COMPILE=x86_64-linux-gnu-
   else
     echo "unsupported arch ${UNAME_M}";
 fi
@@ -62,12 +72,14 @@ do
 done
 
 cd /usr/src
-sudo tar -xf linux-source.tar.bz2
-cd /usr/src/linux-source
+source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
+source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')
+sudo tar -xf $source_file
+cd $source_dir
 test -f .config || yes "" | sudo make oldconfig
-yes "" | sudo make ARCH=${ARCH} CROSS_COMPILE=aarch64-linux-gnu- prepare V=0 > /dev/null
+yes "" | sudo make ARCH=${CROSS_ARCH_PATH} CROSS_COMPILE=${CROSS_COMPILE} prepare V=0 > /dev/null
 yes "" | sudo make prepare V=0 > /dev/null
-ls -al /usr/src/linux-source
+ls -al $source_dir
 
 clang --version
 cd ~

--- a/variables.mk
+++ b/variables.mk
@@ -170,7 +170,7 @@ endif
 # include vpath
 #
 ifdef CROSS_ARCH
-	KERNEL_HEADER_GEN = test -e arch/$(LINUX_ARCH)/kernel/asm-offsets.s || yes "" | $(SUDO) make ARCH=$(LINUX_ARCH) CROSS_COMPILE=$(CMD_CC_PREFIX) prepare V=0
+	KERNEL_HEADER_GEN = yes "" | $(SUDO) make ARCH=$(LINUX_ARCH) CROSS_COMPILE=$(CMD_CC_PREFIX) prepare V=0
 	ifdef KERN_HEADERS
 		LINUX_SOURCE_PATH = $(KERN_HEADERS)
 	else

--- a/variables.mk
+++ b/variables.mk
@@ -105,9 +105,8 @@ BUILD_DATE := $(shell date +%Y-%m-%d)
 HOST_ARCH := $(shell uname -m)
 UNAME_R := $(shell uname -r)
 HOST_VERSION_SHORT := $(shell uname -r | cut -d'-' -f 1)
-
-# linux-source-5.15.0.tar.bz2
-LINUX_SOURCE_PATH ?= /usr/src/linux-source-$(HOST_VERSION_SHORT)
+LINUX_SOURCE_FILE := $(shell find /usr/src -maxdepth 1 -name "*linux-source*.tar.bz2")
+LINUX_SOURCE_PATH := $(shell echo $(LINUX_SOURCE_FILE) | $(CMD_SED) 's/\.tar\.bz2//g')
 
 ifdef CROSS_ARCH
 	ifeq ($(HOST_ARCH),aarch64)


### PR DESCRIPTION
via [github action (docker build)](https://github.com/gojue/ecapture/actions/runs/11208092161/job/31151556985#step:7:3409)


```shell
clang \
#18 8.403 		-emit-llvm -O2 -S -D__TARGET_ARCH_x86 -xc -g -isystem -D__BPF_TRACING__ -D__KERNEL__ -DNOCORE -nostdinc -DKBUILD_MODNAME=\"eCapture\" -target x86_64  -Wall -Wno-unused-variable -Wnounused-but-set-variable -Wno-frame-address -Wno-unused-value -Wno-unknown-warning-option -Wno-pragma-once-outside-header -Wno-pointer-sign -Wno-gnu-variable-sized-type-not-at-end -Wno-deprecated-declarations -Wno-compare-distinct-pointer-types -Wno-address-of-packed-member -fno-stack-protector -fno-jump-tables -fno-unwind-tables -fno-asynchronous-unwind-tables \
#18 8.403 		-I ./kern -I ./kern/bpf/x86 \
#18 8.403 		-I /lib/modules/6.8.0-1014-azure/build/arch/x86/include \
#18 8.403 		-I /lib/modules/6.8.0-1014-azure/build/arch/x86/include/generated \
#18 8.403 		-I /lib/modules/6.8.0-1014-azure/build/include \
#18 8.403 		-I /lib/modules/6.8.0-1014-azure/build/arch/x86/include/uapi \
#18 8.403 		-I /lib/modules/6.8.0-1014-azure/build/arch/x86/include/generated/uapi \
#18 8.403 		-I /lib/modules/6.8.0-1014-azure/build/include/uapi \
#18 8.403 		-I /lib/modules/6.8.0-1014-azure/build/include/generated/uapi \
#18 8.403 		-DKERNEL_LESS_5_2 \
#18 8.403 		-c kern/boringssl_a_14_kern.c \
#18 8.403 		-o - |llc \
#18 8.403 		-march=bpf \
#18 8.403 		-filetype=obj \
#18 8.403 		-o user/bytecode/boringssl_a_14_kern_noncore_less52.o
#18 8.431 In file included from kern/boringssl_a_14_kern.c:71:
#18 8.433 In file included from ./kern/boringssl_masterkey.h:15:
#18 8.433 ./kern/ecapture.h:28:10: fatal error: 'linux/kconfig.h' file not found
#18 8.436 #include <linux/kconfig.h>
#18 8.437          ^~~~~~~~~~~~~~~~~
#18 8.450 1 error generated.
#18 8.502 yes
#18 8.502 In file included from kern/boringssl_a_14_kern.c:71:
#18 8.502 In file included from ./kern/boringssl_masterkey.h:15:
#18 8.502 ./kern/ecapture.h:28:10: fatal error: 'linux/kconfig.h' file not found
#18 8.502 #include <linux/kconfig.h>
#18 8.502          ^~~~~~~~~~~~~~~~~
#18 8.514 checking for capable lex... 1 error generated.
```