### PR TITLE
builder: fix init script fails to run on ubuntu 24.04 system #667

### DIFF
--- a/builder/init_env.sh
+++ b/builder/init_env.sh
@@ -2,6 +2,10 @@
 
 # /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/gojue/ecapture/master/builder/init_env.sh)"
 
+echo "Welcome to eCapture project development environment initialization script."
+echo "Home page: https://ecapture.cc"
+echo "Github: https://github.com/gojue/ecapture"
+
 # 环境检测
 release_num=$(lsb_release -r --short)
 if [ $? -ne 0 ]; then
@@ -11,13 +15,10 @@ fi
 
 CLANG_NUM=-12
 # shellcheck disable=SC2209
-MAKE_ECAPTURE=make
 if [ ${release_num} == "20.04" ]; then
   CLANG_NUM=-9
-  MAKE_ECAPTURE="make nocore"
   elif [ ${release_num} == "20.10" ]; then
   CLANG_NUM=-10
-  MAKE_ECAPTURE="make nocore"
   elif [ ${release_num} == "21.04" ]; then
   CLANG_NUM=-11
   elif [ ${release_num} == "21.10" ]; then
@@ -43,14 +44,18 @@ UNAME_M=`uname -m`
 ARCH="amd64"
 CROSS_ARCH_PATH="arm64"
 CROSS_COMPILE=aarch64-linux-gnu-
+CROSS_COMPILE_DEB=gcc-aarch64-linux-gnu
 if [[ ${UNAME_M} =~ "x86_64" ]];then
   ARCH="amd64"
   CROSS_ARCH_PATH="arm64"
   CROSS_COMPILE=aarch64-linux-gnu-
+  CROSS_COMPILE_DEB=gcc-aarch64-linux-gnu
   elif [[ ${UNAME_M} =~ "aarch64" ]]; then
     ARCH="arm64"
     CROSS_ARCH_PATH="x86"
     CROSS_COMPILE=x86_64-linux-gnu-
+    CROSS_COMPILE_DEB=gcc-x86-64-linux-gnu
+    # 在ubuntu 24.04 上， 跨平台的GCC编译器的包名为“gcc-x86-64-linux-gnu”，不是以前的“x86_64-linux-gnu-gcc”
   else
     echo "unsupported arch ${UNAME_M}";
 fi
@@ -59,30 +64,30 @@ GOBIN_ZIP="go1.21.0.linux-${ARCH}.tar.gz"
 echo "GOBIN_ZIP:${GOBIN_ZIP}"
 
 
-cd ~
+cd ~ || exit
 
 uname -a
 sudo apt-get update
 # 环境安装
-sudo apt-get install --yes build-essential pkgconf libelf-dev llvm${CLANG_NUM} clang${CLANG_NUM} linux-tools-common linux-tools-generic gcc-aarch64-linux-gnu libssl-dev flex bison linux-source
+sudo apt-get install --yes build-essential pkgconf libelf-dev llvm${CLANG_NUM} clang${CLANG_NUM} linux-tools-common linux-tools-generic ${CROSS_COMPILE_DEB} libssl-dev flex bison bc linux-source
 for tool in "clang" "llc" "llvm-strip"
 do
   sudo rm -f /usr/bin/$tool
   sudo ln -s /usr/bin/$tool${CLANG_NUM} /usr/bin/$tool
 done
 
-cd /usr/src
+cd /usr/src || exit
 source_file=$(find . -maxdepth 1 -name "*linux-source*.tar.bz2")
 source_dir=$(echo "$source_file" | sed 's/\.tar\.bz2//g')
 sudo tar -xf $source_file
-cd $source_dir
+cd $source_dir || exit
 test -f .config || yes "" | sudo make oldconfig
 yes "" | sudo make ARCH=${CROSS_ARCH_PATH} CROSS_COMPILE=${CROSS_COMPILE} prepare V=0 > /dev/null
 yes "" | sudo make prepare V=0 > /dev/null
 ls -al $source_dir
 
 clang --version
-cd ~
+cd ~ || exit
 # 安装golang，设置goproxy
 wget https://golang.google.cn/dl/${GOBIN_ZIP}
 sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf ${GOBIN_ZIP}
@@ -92,4 +97,8 @@ export GOPROXY=https://goproxy.cn
 # clone 源码
 git clone https://github.com/gojue/ecapture.git
 cd ./ecapture || exit
-${MAKE_ECAPTURE}
+
+echo "The development environment for the eCapture project has been successfully installed,"
+echo "and you can start compiling the project now."
+echo "see the README.md for more information."
+echo "Enjoy it!"


### PR DESCRIPTION
Remove the make compilation command from the installation of the development environment.