### PR TITLE
feat: Enrich addr info with remote addr info

### DIFF
--- a/kern/common.h
+++ b/kern/common.h
@@ -39,7 +39,6 @@
 
 #define AF_INET 2
 #define AF_INET6 10
-#define SA_DATA_LEN 14
 #define BASH_ERRNO_DEFAULT 128
 
 #define BASH_EVENT_TYPE_READLINE 0

--- a/kern/openssl.h
+++ b/kern/openssl.h
@@ -43,9 +43,12 @@ struct connect_event_t {
     u32 pid;
     u32 tid;
     u32 fd;
-    char sa_data[SA_DATA_LEN];
+    u16 sport;
+    u16 dport;
+    __be32 saddr;
+    __be32 daddr;
     char comm[TASK_COMM_LEN];
-};
+} __attribute__((packed)); // NOTE: do not leave padding hole in this struct.
 
 struct active_ssl_buf {
     /*
@@ -57,6 +60,11 @@ struct active_ssl_buf {
     u32 fd;
     u32 bio_type;
     const char* buf;
+};
+
+struct tcp_fd_info {
+    u64 file;
+    int fd;
 };
 
 /***********************************************************
@@ -112,6 +120,14 @@ struct {
     __type(value, u64);
     __uint(max_entries, 10240);
 } ssl_st_fd SEC(".maps");
+
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, u64);
+    __type(value, struct tcp_fd_info);
+    __uint(max_entries, 10240);
+} tcp_fd_infos SEC(".maps");
 
 
 /***********************************************************
@@ -436,14 +452,67 @@ int probe_ret_SSL_read(struct pt_regs* ctx) {
     return 0;
 }
 
+
+static __inline struct tcp_fd_info *find_fd_info(struct pt_regs *regs) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+
+    return bpf_map_lookup_elem(&tcp_fd_infos, &pid_tgid);
+}
+
+static __inline struct tcp_fd_info *lookup_and_delete_fd_info(struct pt_regs *regs) {
+    struct tcp_fd_info *fd_info;
+    u64 pid_tgid;
+
+    pid_tgid = bpf_get_current_pid_tgid();
+    fd_info = bpf_map_lookup_elem(&tcp_fd_infos, &pid_tgid);
+    if (fd_info) {
+        bpf_map_delete_elem(&tcp_fd_infos, &pid_tgid);
+    }
+    return fd_info;
+}
+
+static __inline struct sock *tcp_sock_from_file(u64 ptr) {
+    struct socket *socket;
+    struct file *file;
+    struct sock *sk;
+
+    file = (struct file *)ptr;
+    bpf_probe_read_kernel(&socket, sizeof(socket), &file->private_data);
+    bpf_probe_read_kernel(&sk, sizeof(sk), &socket->sk);
+    return sk;
+}
+
 // libc : int __connect (int fd, __CONST_SOCKADDR_ARG addr, socklen_t len)
 // kernel : int __sys_connect(int fd, struct sockaddr __user *uservaddr, int addrlen)
 SEC("kprobe/sys_connect")
 int probe_connect(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    struct tcp_fd_info fd_info = {};
+
+    fd_info.fd = PT_REGS_PARM1(ctx);
+    bpf_map_update_elem(&tcp_fd_infos, &pid_tgid, &fd_info, BPF_ANY);
+    return 0;
+}
+
+SEC("kprobe/__sys_connect_file")
+int probe_connect_file(struct pt_regs* ctx) {
+    struct tcp_fd_info *fd_info;
+
+    fd_info = find_fd_info(ctx);
+    if (fd_info) {
+        fd_info->file = (u64)(void *) PT_REGS_PARM1(ctx);
+    }
+    return 0;
+}
+
+static __inline int kretprobe_connect(struct pt_regs *ctx, int fd, struct sock *sk, const bool active) {
     u64 current_pid_tgid = bpf_get_current_pid_tgid();
     u32 pid = current_pid_tgid >> 32;
     u64 current_uid_gid = bpf_get_current_uid_gid();
     u32 uid = current_uid_gid;
+    u16 address_family = 0;
+    u64 addrs;
+    u32 ports;
 
 #ifndef KERNEL_LESS_5_2
     // if target_ppid is 0 then we target all pids
@@ -455,16 +524,15 @@ int probe_connect(struct pt_regs* ctx) {
     }
 #endif
 
-    u32 fd = (u32)PT_REGS_PARM1(ctx);
-    struct sockaddr* saddr = (struct sockaddr*)PT_REGS_PARM2(ctx);
-    if (!saddr) {
+    bpf_probe_read_kernel(&address_family, sizeof(address_family), &sk->__sk_common.skc_family);
+    if (address_family != AF_INET) {
         return 0;
     }
-    sa_family_t address_family = 0;
-    bpf_probe_read_user(&address_family, sizeof(address_family),
-                        &saddr->sa_family);
 
-    if (address_family != AF_INET) {
+    // if the connection hasn't been established yet, the ports or addrs are 0.
+    bpf_probe_read_kernel(&addrs, sizeof(addrs), &sk->__sk_common.skc_addrpair);
+    bpf_probe_read_kernel(&ports, sizeof(ports), &sk->__sk_common.skc_portpair);
+    if (ports == 0 || addrs == 0) {
         return 0;
     }
 
@@ -476,7 +544,17 @@ int probe_connect(struct pt_regs* ctx) {
     conn.pid = pid;
     conn.tid = current_pid_tgid;
     conn.fd = fd;
-    bpf_probe_read_user(&conn.sa_data, SA_DATA_LEN, &saddr->sa_data);
+    if (active) {
+        conn.dport = bpf_ntohs((u16)ports);
+        conn.sport = ports >> 16;
+        conn.daddr = (__be32)addrs;
+        conn.saddr = (__be32)(addrs >> 32);
+    } else {
+        conn.sport = bpf_ntohs((u16)ports);
+        conn.dport = ports >> 16;
+        conn.saddr = (__be32)addrs;
+        conn.daddr = (__be32)(addrs >> 32);
+    }
     bpf_get_current_comm(&conn.comm, sizeof(conn.comm));
 
     bpf_perf_event_output(ctx, &connect_events, BPF_F_CURRENT_CPU, &conn,
@@ -484,6 +562,63 @@ int probe_connect(struct pt_regs* ctx) {
     return 0;
 }
 
+SEC("kretprobe/sys_connect")
+int retprobe_connect(struct pt_regs* ctx) {
+    struct tcp_fd_info *fd_info;
+    struct sock *sk;
+
+    fd_info = lookup_and_delete_fd_info(ctx);
+    if (fd_info) {
+        sk = tcp_sock_from_file(fd_info->file);
+        if (sk) {
+            return kretprobe_connect(ctx, fd_info->fd, sk, true);
+        }
+    }
+    return 0;
+}
+
+#ifndef IS_ERR_VALUE
+#define MAX_ERRNO	4095
+#define IS_ERR_VALUE(x) ((unsigned long)(void *)(x) >= (unsigned long)-MAX_ERRNO)
+#endif
+
+SEC("kretprobe/do_accept")
+int retprobe_do_accept(struct pt_regs* ctx) {
+    struct tcp_fd_info *fd_info;
+    struct file *file;
+
+    file = (struct file *)PT_REGS_RC(ctx);
+    if (IS_ERR_VALUE(file)) {
+        return 0;
+    }
+
+    fd_info = find_fd_info(ctx);
+    if (fd_info) {
+        fd_info->file = (u64)file;
+    }
+    return 0;
+}
+
+SEC("kretprobe/__sys_accept4")
+int retprobe_accept4(struct pt_regs* ctx) {
+    struct tcp_fd_info *fd_info;
+    struct sock *sk;
+    int fd;
+
+    fd = PT_REGS_RC(ctx);
+    if (fd < 0) {
+        return 0;
+    }
+
+    fd_info = lookup_and_delete_fd_info(ctx);
+    if (fd_info) {
+        sk = tcp_sock_from_file(fd_info->file);
+        if (sk) {
+            return kretprobe_connect(ctx, fd, sk, false);
+        }
+    }
+    return 0;
+}
 
 
 // int SSL_set_fd(SSL *s, int fd)

--- a/pkg/event_processor/base_event.go
+++ b/pkg/event_processor/base_event.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+
 	"github.com/gojue/ecapture/user/event"
 )
 
@@ -34,8 +35,6 @@ const ChunkSize = 16
 const ChunkSizeHalf = ChunkSize / 2
 
 const MaxDataSize = 1024 * 4
-
-//const SaDataLen = 14
 
 const (
 	Ssl2Version   = 0x0002

--- a/user/module/probe_openssl_text.go
+++ b/user/module/probe_openssl_text.go
@@ -2,15 +2,16 @@ package module
 
 import (
 	"errors"
+	"math"
+	"os"
+	"path"
+	"strings"
+
 	"github.com/cilium/ebpf"
 	manager "github.com/gojue/ebpfmanager"
 	"github.com/gojue/ecapture/user/config"
 	"github.com/gojue/ecapture/user/event"
 	"golang.org/x/sys/unix"
-	"math"
-	"os"
-	"path"
-	"strings"
 )
 
 func (m *MOpenSSLProbe) setupManagersText() error {
@@ -77,10 +78,34 @@ func (m *MOpenSSLProbe) setupManagersText() error {
 				UID:              "kprobe_sys_connect",
 			},
 			{
+				Section:          "kprobe/__sys_connect_file",
+				EbpfFuncName:     "probe_connect_file",
+				AttachToFuncName: "__sys_connect_file",
+				UID:              "kprobe_sys_connect_file",
+			},
+			{
+				Section:          "kretprobe/sys_connect",
+				EbpfFuncName:     "retprobe_connect",
+				AttachToFuncName: "__sys_connect",
+				UID:              "kretprobe_sys_connect",
+			},
+			{
 				Section:          "kprobe/sys_connect",
 				EbpfFuncName:     "probe_connect",
 				AttachToFuncName: "__sys_accept4",
 				UID:              "kprobe_sys_accept4",
+			},
+			{
+				Section:          "kretprobe/do_accept",
+				EbpfFuncName:     "retprobe_do_accept",
+				AttachToFuncName: "do_accept",
+				UID:              "kretprobe_do_accept",
+			},
+			{
+				Section:          "kretprobe/__sys_accept4",
+				EbpfFuncName:     "retprobe_accept4",
+				AttachToFuncName: "__sys_accept4",
+				UID:              "kretprobe_sys_accept4",
 			},
 
 			// --------------------------------------------------


### PR DESCRIPTION
It is able to get full 5-tuple info when hooking `connect` and `accept` syscalls with format `saddr:sport-daddr-dport` always.

```bash
$ sudo ./bin/ecapture tls -d
...
2024-12-08T16:44:24Z DBG AddConn success fd=5 pid=113767 tuple=192.168.241.133:37736-172.217.194.113:443
2024-12-10T05:08:04Z DBG AddConn success fd=4 pid=121587 tuple=192.168.241.1:54587-192.168.241.133:8080
...
```

See #682 to get more context.


See [eBPF Talk: 在 bpf 里将 fd 和 sock 关联起来](https://mp.weixin.qq.com/s/sMmudLmn714AmA166TyB_w) for design ideas and technical implementation.