### PR TITLE
fix: use other hooks to probe 5-tuple

### DIFF
--- a/user/module/probe_openssl_text.go
+++ b/user/module/probe_openssl_text.go
@@ -78,10 +78,10 @@ func (m *MOpenSSLProbe) setupManagersText() error {
 				UID:              "kprobe_sys_connect",
 			},
 			{
-				Section:          "kprobe/__sys_connect_file",
-				EbpfFuncName:     "probe_connect_file",
-				AttachToFuncName: "__sys_connect_file",
-				UID:              "kprobe_sys_connect_file",
+				Section:          "kprobe/inet_stream_connect",
+				EbpfFuncName:     "probe_inet_stream_connect",
+				AttachToFuncName: "inet_stream_connect",
+				UID:              "kprobe_sys_inet_stream_connect",
 			},
 			{
 				Section:          "kretprobe/sys_connect",
@@ -96,10 +96,10 @@ func (m *MOpenSSLProbe) setupManagersText() error {
 				UID:              "kprobe_sys_accept4",
 			},
 			{
-				Section:          "kretprobe/do_accept",
-				EbpfFuncName:     "retprobe_do_accept",
-				AttachToFuncName: "do_accept",
-				UID:              "kretprobe_do_accept",
+				Section:          "kprobe/inet_accept",
+				EbpfFuncName:     "probe_inet_accept",
+				AttachToFuncName: "inet_accept",
+				UID:              "kprobe_inet_accept",
 			},
 			{
 				Section:          "kretprobe/__sys_accept4",


### PR DESCRIPTION
Fixes #693 

`__sys_connect_file` and `do_accept` are not found on v5.4 kernel.

Then, use `inet_stream_connect` and `inet_accept` instead, as they are found on v4.19 and v5.4 kernels.

I've test it on v5.4, v5.15 and v6.8 kernels.

@cfc4n can you help to test noncore on v4.19 and v5.4 kernels?