### PR TITLE
fix: check CAP_BPF by capget syscall

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -133,6 +133,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&globalConf.LoggerAddr, "logaddr", "l", "", "send logs to this server. -l /tmp/ecapture.log or -l tcp://127.0.0.1:8080")
 	rootCmd.PersistentFlags().StringVar(&globalConf.EventCollectorAddr, "eventaddr", "", "the server address that receives the captured event. --eventaddr tcp://127.0.0.1:8090, default: same as logaddr")
 	rootCmd.PersistentFlags().StringVar(&globalConf.Listen, "listen", eCaptureListenAddr, "listen on this address for http server, default: 127.0.0.1:28256")
+
+	rootCmd.SilenceUsage = true
 }
 
 // eventCollector


### PR DESCRIPTION
Fixes #706 

It's more simple to check CAP_BPF by capget syscall than creating a bpf prog, as creating bpf prog requires removing rlimit memlock.