### PR TITLE
fix #697, When building in nocore mode, use only non-core bytecode les by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,7 @@ build_noncore: \
 	$(TARGET_LIBPCAP) \
 	assets_noncore
 	$(call allow-override,VERSION_FLAG,$(HOST_ARCH))
+	$(call allow-override,BYTECODE_FILES,noncore)
 	$(call gobuild, $(ANDROID))
 
 # Format the code

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -46,6 +46,7 @@ var (
 	// GitVersion default value, eg: linux_arm64:v0.8.10-20241116-fcddaeb:5.15.0-125-generic
 	GitVersion = "os_arch:v0.0.0-20221111-develop:default_kernel"
 	//ReleaseDate = "2022-03-16"
+	ByteCodeFiles = "all" // Indicates the type of bytecode files built by the project, i.e., the file types under the assets/* folder. Default is "all", meaning both types are included.
 )
 
 const (
@@ -153,6 +154,15 @@ func setModConfig(globalConf config.BaseConfig, modConf config.IConfig) {
 	modConf.SetBTF(globalConf.BtfMode)
 	modConf.SetPerCpuMapSize(globalConf.PerCpuMapSize)
 	modConf.SetAddrType(loggerTypeStdout)
+
+	switch ByteCodeFiles {
+	case "core":
+		modConf.SetByteCodeFileMode(config.ByteCodeFileCore)
+	case "noncore":
+		modConf.SetByteCodeFileMode(config.ByteCodeFileNonCore)
+	default:
+		modConf.SetByteCodeFileMode(config.ByteCodeFileAll)
+	}
 }
 
 // initLogger init logger

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -36,7 +36,7 @@ func upgradeCheck(ctx context.Context) (string, string, error) {
 	if byteToString(uname.Machine[:]) == "aarch64" {
 		arch = "arm64"
 	}
-	rex := regexp.MustCompile(`([^:]+):v?(\d+\.\d+\.\d+)[^:]+:[^:]+`)
+	rex := regexp.MustCompile(`([^:]*):v?(\d+\.\d+\.\d+)[^:]*:[^:]*`)
 	verMatch := rex.FindStringSubmatch(GitVersion)
 	if len(verMatch) <= 2 {
 		return "", "", fmt.Errorf("error matching version: %s, verMatch:%v", GitVersion, verMatch)

--- a/functions.mk
+++ b/functions.mk
@@ -49,7 +49,7 @@ define gobuild
 	CGO_CFLAGS='-O2 -g -gdwarf-4 -I$(CURDIR)/lib/libpcap/' \
 	CGO_LDFLAGS='-O2 -g -L$(CURDIR)/lib/libpcap/ -lpcap -static' \
 	GOOS=linux GOARCH=$(GOARCH) CC=$(CMD_CC_PREFIX)$(CMD_CC) \
-	$(CMD_GO) build -tags '$(TARGET_TAG),netgo' -ldflags "-w -s -X 'github.com/gojue/ecapture/cli/cmd.GitVersion=$(TARGET_TAG)_$(GOARCH):$(VERSION_NUM):$(VERSION_FLAG)' -linkmode=external -extldflags -static " -o $(OUT_BIN)
+	$(CMD_GO) build -tags '$(TARGET_TAG),netgo' -ldflags "-w -s -X 'github.com/gojue/ecapture/cli/cmd.GitVersion=$(TARGET_TAG)_$(GOARCH):$(VERSION_NUM):$(VERSION_FLAG)' -X 'github.com/gojue/ecapture/cli/cmd.ByteCodeFiles=$(BYTECODE_FILES)' -linkmode=external -extldflags -static " -o $(OUT_BIN)
 	$(CMD_FILE) $(OUT_BIN)
 endef
 

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -46,12 +46,13 @@ func TestCheckLatest(t *testing.T) {
 	//var ver = "linux_arm64:v0.8.8:5.15.0-125-generic"
 	var ver = "androidgki:v0.8.8:5.15.0-125-generic"
 	ver = "linux_arm64:v0.8.10-20241116-fcddaeb:5.15.0-125-generic"
+	ver = "linux_arm64:v0.9.1:6.5.0-1025-azure"
 	var arch = "amd64"
 	if byteToString(uname.Machine[:]) == "aarch64" {
 		arch = "arm64"
 	}
 
-	rex := regexp.MustCompile(`([^:]+):v?(\d+\.\d+\.\d+)[^:]+:[^:]+`)
+	rex := regexp.MustCompile(`([^:]*):v?(\d+\.\d+\.\d+)[^:]*:[^:]*`)
 
 	verMatch := rex.FindStringSubmatch(ver)
 	if len(verMatch) <= 2 {

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -16,58 +16,93 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/gojue/ecapture/pkg/util/kernel"
 	"os"
+
+	"github.com/gojue/ecapture/pkg/util/kernel"
 )
 
+// IConfig defines the interface for configuration management
 type IConfig interface {
-	Check() error //检测配置合法性
+	// Check validates the configuration settings
+	Check() error
+	// GetPid returns the process ID to monitor
 	GetPid() uint64
+	// GetUid returns the user ID to monitor
 	GetUid() uint64
+	// GetHex returns whether to display output in hexadecimal format
 	GetHex() bool
+	// GetBTF returns the BTF (BPF Type Format) mode
 	GetBTF() uint8
+	// GetDebug returns whether debug mode is enabled
 	GetDebug() bool
+	// GetByteCodeFileMode returns the bytecode file mode
+	GetByteCodeFileMode() uint8
+	// SetPid sets the process ID to monitor
 	SetPid(uint64)
+	// SetUid sets the user ID to monitor
 	SetUid(uint64)
+	// SetHex sets whether to display output in hexadecimal format
 	SetHex(bool)
+	// SetBTF sets the BTF (BPF Type Format) mode
 	SetBTF(uint8)
+	// SetByteCodeFileMode sets the bytecode file mode
+	SetByteCodeFileMode(uint8)
+	// SetDebug enables or disables debug mode
 	SetDebug(bool)
+	// SetAddrType sets the logger output type
 	SetAddrType(uint8)
+	// SetEventCollectorAddr sets the address for the event collector
 	SetEventCollectorAddr(string)
+	// GetEventCollectorAddr returns the event collector address
 	GetEventCollectorAddr() string
+	// GetPerCpuMapSize returns the eBPF map size per CPU
 	GetPerCpuMapSize() int
+	// SetPerCpuMapSize sets the eBPF map size per CPU
 	SetPerCpuMapSize(int)
-	EnableGlobalVar() bool //
+	// EnableGlobalVar checks if global variables are supported based on kernel version
+	EnableGlobalVar() bool
+	// Bytes serializes the configuration to JSON bytes
 	Bytes() []byte
 }
 
+// TLS capture mode constants defining different output formats
 const (
-	TlsCaptureModelText   = "text"
-	TlsCaptureModelPcap   = "pcap"
-	TlsCaptureModelPcapng = "pcapng"
-	TlsCaptureModelKey    = "key"
-	TlsCaptureModelKeylog = "keylog"
+	TlsCaptureModelText   = "text"   // Plain text output
+	TlsCaptureModelPcap   = "pcap"   // PCAP format output
+	TlsCaptureModelPcapng = "pcapng" // PCAPNG format output
+	TlsCaptureModelKey    = "key"    // Key only output
+	TlsCaptureModelKeylog = "keylog" // Key log format output
 )
 
+// BTF mode constants for BPF Type Format handling
 const (
-	BTFModeAutoDetect = 0
-	BTFModeCore       = 1
-	BTFModeNonCore    = 2
+	BTFModeAutoDetect = 0 // Automatically detect BTF availability
+	BTFModeCore       = 1 // Use kernel BTF
+	BTFModeNonCore    = 2 // Use non-kernel BTF
 )
 
+// ByteCodeFileMode defines the mode for bytecode file selection
+const (
+	ByteCodeFileAll     = 0 // Use all bytecode files
+	ByteCodeFileCore    = 1 // Use kernel bytecode file
+	ByteCodeFileNonCore = 2 // Use non-kernel bytecode file
+)
+
+// BaseConfig implements the IConfig interface and holds the basic configuration settings
 type BaseConfig struct {
-	Pid    uint64 `json:"pid"`
-	Uid    uint64 `json:"uid"`
-	Listen string `json:"listen"` // listen address, default: 127.0.0.1:28256
+	Pid    uint64 `json:"pid"`    // Process ID to monitor
+	Uid    uint64 `json:"uid"`    // User ID to monitor
+	Listen string `json:"listen"` // Listen address for the server (default: 127.0.0.1:28256)
 
-	// mapSizeKB
-	PerCpuMapSize      int    `json:"per_cpu_map_size"` // ebpf map size for per Cpu.   see https://github.com/gojue/ecapture/issues/433 .
-	IsHex              bool   `json:"is_hex"`
-	Debug              bool   `json:"debug"`
-	BtfMode            uint8  `json:"btf_mode"`
-	LoggerAddr         string `json:"logger_addr"`          // logger address
-	LoggerType         uint8  `json:"logger_type"`          // 0:stdout, 1:file, 2:tcp
-	EventCollectorAddr string `json:"event_collector_addr"` // the server address that receives the captured event
+	// eBPF map configuration
+	PerCpuMapSize      int    `json:"per_cpu_map_size"`     // Size of eBPF map per CPU core
+	IsHex              bool   `json:"is_hex"`               // Whether to display output in hexadecimal
+	Debug              bool   `json:"debug"`                // Enable debug mode
+	BtfMode            uint8  `json:"btf_mode"`             // BTF mode selection
+	ByteCodeFileMode   uint8  `json:"byte_code_file_mode"`  // assets/* include bytecode file type
+	LoggerAddr         string `json:"logger_addr"`          // Address for logger output
+	LoggerType         uint8  `json:"logger_type"`          // Logger type (0:stdout, 1:file, 2:tcp)
+	EventCollectorAddr string `json:"event_collector_addr"` // Address of the event collector server
 }
 
 func (c *BaseConfig) GetPid() uint64 {
@@ -120,6 +155,14 @@ func (c *BaseConfig) SetBTF(BtfMode uint8) {
 
 func (c *BaseConfig) GetBTF() uint8 {
 	return c.BtfMode
+}
+
+func (c *BaseConfig) SetByteCodeFileMode(mode uint8) {
+	c.ByteCodeFileMode = mode
+}
+
+func (c *BaseConfig) GetByteCodeFileMode() uint8 {
+	return c.ByteCodeFileMode
 }
 
 func (c *BaseConfig) GetPerCpuMapSize() int {

--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -84,6 +84,9 @@ type Module struct {
 	// module的类型，uprobe,kprobe等
 	mType string
 
+	// bytecodeTypes
+	byteCodetype int
+
 	conf config.IConfig
 
 	processor       *event_processor.EventProcessor
@@ -166,13 +169,22 @@ func (m *Module) autoDetectBTF() {
 }
 func (m *Module) geteBPFName(filename string) string {
 	var newFilename = filename
-	// CO-RE detect first
-	if m.isCoreUsed {
+
+	switch m.conf.GetByteCodeFileMode() {
+	case config.ByteCodeFileCore:
 		newFilename = strings.Replace(newFilename, ".o", "_core.o", 1)
-	} else {
+	case config.ByteCodeFileNonCore:
 		newFilename = strings.Replace(newFilename, ".o", "_noncore.o", 1)
+	default:
+		// CO-RE detect first
+		if m.isCoreUsed {
+			newFilename = strings.Replace(newFilename, ".o", "_core.o", 1)
+		} else {
+			newFilename = strings.Replace(newFilename, ".o", "_noncore.o", 1)
+		}
 	}
-	//
+
+	// kernel version perfix
 	if m.isKernelLess5_2 {
 		newFilename = strings.Replace(newFilename, ".o", KernelLess52Prefix, 1)
 	}

--- a/variables.mk
+++ b/variables.mk
@@ -34,6 +34,7 @@ CMD_DPKG-DEB ?= dpkg-deb
 CMD_ECHO ?= echo
 
 KERNEL_LESS_5_2_PREFIX ?= _less52.o
+BYTECODE_FILES ?= all
 STYLE    ?= "{BasedOnStyle: Google, IndentWidth: 4, TabWidth: 4, UseTab: Never, ColumnLimit: 120}"
 IGNORE_LESS52 ?=
 AUTOGENCMD ?=


### PR DESCRIPTION
When compiling eBPF bytecode as non-core, only *_noncore.o files exist in the assets directory. In this case, we can ignore the BTFMode specified in command-line arguments and directly select *_noncore.o files.