### PR TITLE
fixed the issue of missing cross-compilation environment.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Compilers
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
+          sudo apt-get install --yes \
             build-essential \
             pkgconf \
             libelf-dev \


### PR DESCRIPTION
Github Action `release.yml` run failed in `Release arm64 (CROSS COMPILATION)` phase
```shell
cd lib/libpcap && \
	CC=aarch64-linux-gnu-gcc AR=aarch64-linux-gnu-ar CFLAGS="-O2 -g -gdwarf-4 -static -Wno-unused-result" ./configure --disable-rdma --disable-shared --disable-usb \
		--disable-netmap --disable-bluetooth --disable-dbus --without-libnl \
		--without-dpdk --without-dag --without-septel --without-snf \
		--without-gcc --with-pcap=linux \
		--without-turbocap --host=aarch64-unknown-linux-gnu && \
CC=aarch64-linux-gnu-gcc AR=aarch64-linux-gnu-ar make
checking build system type... x86_64-pc-linux-gnu
checking host system type... aarch64-unknown-linux-gnu
checking target system type... aarch64-unknown-linux-gnu
checking for aarch64-unknown-linux-gnu-gcc... aarch64-linux-gnu-gcc
checking whether the C compiler works... no
configure: error: in `/home/runner/work/ecapture/ecapture/lib/libpcap':
configure: error: C compiler cannot create executables
See `config.log' for more details
make[1]: *** [Makefile:201: lib/libpcap.a] Error 77
cp: cannot stat './bin/ecapture': No such file or directory
```