### PR TITLE
fix: incorrect CAP_BPF check method

### DIFF
--- a/cli/cmd/env_detection.go
+++ b/cli/cmd/env_detection.go
@@ -52,7 +52,9 @@ func detectBpfCap() error {
 		return fmt.Errorf("failed to get the capabilities of the current process: %v", err)
 	}
 
-	haveBpfCap := data[0].Permitted&unix.CAP_BPF != 0
+	capBpfMask := uint32(1 << (unix.CAP_BPF - 32))
+	capSysAdminMask := uint32(1 << unix.CAP_SYS_ADMIN)
+	haveBpfCap := (data[1].Permitted&capBpfMask != 0) || (data[0].Permitted&capSysAdminMask != 0)
 	if !haveBpfCap {
 		return fmt.Errorf("the current user does not have CAP_BPF to load bpf programs. Please run as root or use sudo or add the --privileged=true flag for Docker.")
 	}


### PR DESCRIPTION
According to the linux man pages: https://man7.org/linux/man-pages/man2/capset.2.html:

> Note that the CAP_* values are bit indexes and need to be bit-shifted before ORing into the bit fields.

And added a check for CAP_SYS_ADMIN permissions.

CLOSE #714 