### PR TITLE
Fix: #740,  the bug of incomplete SSL data for excessively long lengths.

### DIFF
--- a/kern/common.h
+++ b/kern/common.h
@@ -27,7 +27,16 @@
 
 #define TASK_COMM_LEN 16
 #define PATH_MAX_LEN 256
-#define MAX_DATA_SIZE_OPENSSL 1024 * 4
+
+/* 
+ * RFC 5246 : https://datatracker.ietf.org/doc/html/rfc5246#section-6.2
+ * length
+ *    The length (in bytes) of the following TLSPlaintext.fragment.  The length MUST NOT exceed 2^14.
+ * 
+ * OpenSSL : SSL3_RT_MAX_PLAIN_LENGTH (16384). These functions will only accept a value in the range 512 - SSL3_RT_MAX_PLAIN_LENGTH.
+ * https://docs.openssl.org/1.1.1/man3/SSL_CTX_set_split_send_fragment/#description
+*/
+#define MAX_DATA_SIZE_OPENSSL 1024 * 16
 #define MAX_DATA_SIZE_MYSQL 256
 #define MAX_DATA_SIZE_POSTGRES 256
 #define MAX_DATA_SIZE_BASH 256

--- a/pkg/event_processor/base_event.go
+++ b/pkg/event_processor/base_event.go
@@ -34,7 +34,7 @@ const (
 const ChunkSize = 16
 const ChunkSizeHalf = ChunkSize / 2
 
-const MaxDataSize = 1024 * 4
+const MaxDataSize = 1024 * 16
 
 const (
 	Ssl2Version   = 0x0002

--- a/pkg/event_processor/processor_test.go
+++ b/pkg/event_processor/processor_test.go
@@ -25,7 +25,7 @@ type SSLDataEventTmp struct {
 	Comm      [16]byte   `json:"Comm"`
 	Fd        uint32     `json:"Fd"`
 	Version   int32      `json:"Version"`
-	Data      [4096]byte `json:"Data"`
+	Data      [16384]byte `json:"Data"`
 }
 
 func TestEventProcessor_Serve(t *testing.T) {

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -31,7 +31,7 @@ const (
 	ProbeRet
 )
 
-const MaxDataSize = 1024 * 4
+const MaxDataSize = 1024 * 16	// fix: https://github.com/gojue/ecapture/issues/740
 
 const (
 	Ssl2Version   = 0x0002


### PR DESCRIPTION
Fix: #740
 Increase the memory size for storing SSL data in eBPF to 16K according to the OpenSSL RFC 5246 standard.