### PR TITLE
improve: handle COMPRESSION_ERROR to reduce the error log displayed

### DIFF
--- a/pkg/event_processor/http2_request.go
+++ b/pkg/event_processor/http2_request.go
@@ -54,7 +54,6 @@ func (h2r *HTTP2Request) Init() {
 	h2r.reader = bytes.NewBuffer(nil)
 	h2r.bufReader = bufio.NewReader(h2r.reader)
 	h2r.framer = http2.NewFramer(nil, h2r.bufReader)
-	h2r.framer.ReadMetaHeaders = hpack.NewDecoder(0, nil)
 }
 
 func (h2r *HTTP2Request) Write(b []byte) (int, error) {
@@ -94,6 +93,7 @@ func (h2r *HTTP2Request) Display() []byte {
 	encodingMap := make(map[uint32]string)
 	dataBufMap := make(map[uint32]*bytes.Buffer)
 	frameBuf := bytes.NewBufferString("")
+	hdec := hpack.NewDecoder(4096, nil)
 	for {
 		f, err := h2r.framer.ReadFrame()
 		if err != nil {
@@ -103,14 +103,22 @@ func (h2r *HTTP2Request) Display() []byte {
 			break
 		}
 		switch f := f.(type) {
-		case *http2.MetaHeadersFrame:
+		case *http2.HeadersFrame:
 			streamID := f.StreamID
 			frameBuf.WriteString(fmt.Sprintf("\nFrame Type\t=>\tHEADERS\nFrame StreamID\t=>\t%d\n", streamID))
-			for _, header := range f.Fields {
-				frameBuf.WriteString(fmt.Sprintf("%s\n", header.String()))
-				if header.Name == "content-encoding" {
-					encodingMap[streamID] = header.Value
+			if f.HeadersEnded() {
+				fields, err := hdec.DecodeFull(f.HeaderBlockFragment())
+				for _, header := range fields {
+					frameBuf.WriteString(fmt.Sprintf("%s\n", header.String()))
+					if header.Name == "content-encoding" {
+						encodingMap[streamID] = header.Value
+					}
 				}
+				if err != nil {
+					frameBuf.WriteString("Incorrect HPACK context, Please use PCAP mode to get correct header fields ...\n")
+				}
+			} else {
+				frameBuf.WriteString("Not Supported HEADERS Frame with CONTINUATION frames\n")
 			}
 		case *http2.DataFrame:
 			streamID := f.StreamID
@@ -121,7 +129,7 @@ func (h2r *HTTP2Request) Display() []byte {
 				h2r.packerType = PacketTypeGzip
 				frameBuf.WriteString("Partial entity body with gzip encoding ... \n")
 				if dataBufMap[streamID] == nil {
-					dataBufMap[streamID] = bytes.NewBuffer(nil) 
+					dataBufMap[streamID] = bytes.NewBuffer(nil)
 				}
 				_, err := dataBufMap[streamID].Write(payload)
 				if err != nil {


### PR DESCRIPTION
the reason why always has COMPRESSION_ERROR happened: the hpack context lost.

two example:

1. single tcp connection, multi stream on. Before this pr, the hpack DynamicTable is set to 0, so the next headers frame could not be decoded.

run: 
```
nghttp  https://localhost:4444/1234d -m 3
```

output:
``` bash
2025/02/28 11:52:33 [http2 request] Dump HTTP2 Frame error: connection error: COMPRESSION_ERROR
2025-02-28T11:52:33+08:00 ??? UUID:210635_210635_nghttp_5_1_[::1]:54222-[::1]:4444, Name:HTTP2Request, Type:2, Length:618

Frame Type	=>	SETTINGS
Frame StreamID	=>	0

Frame Type	=>	SETTINGS
Frame StreamID	=>	0

Frame Type	=>	PRIORITY
Frame StreamID	=>	3

Frame Type	=>	PRIORITY
Frame StreamID	=>	5

Frame Type	=>	PRIORITY
Frame StreamID	=>	7

Frame Type	=>	PRIORITY
Frame StreamID	=>	9

Frame Type	=>	PRIORITY
Frame StreamID	=>	11

Frame Type	=>	HEADERS
Frame StreamID	=>	13
header field ":method" = "GET"
header field ":path" = "/1234d"
header field ":scheme" = "https"
header field ":authority" = "localhost:4444"
header field "accept" = "*/*"
header field "accept-encoding" = "gzip, deflate"
header field "user-agent" = "nghttp2/1.52.0"

```

this could be fixed in this pr, those frame use same hpack decoder.

2. single tcp connection, single stream on, and than start a new stream in same tcp connection. first incoming event will work fine, but the new stream will get COMPRESSION_ERROR, because they use different event worker and never use same hpack decoder.

```
2025-02-28T12:00:15+08:00 ??? UUID:155734_155734_nginx_4_1_10.0.2.2:60482-10.0.2.5:4444, Name:HTTP2Response, Type:4, Length:992

Frame Type	=>	SETTINGS
Frame StreamID	=>	0

Frame Type	=>	WINDOW_UPDATE
Frame StreamID	=>	0

Frame Type	=>	SETTINGS
Frame StreamID	=>	0

Frame Type	=>	HEADERS
Frame StreamID	=>	1
header field ":status" = "404"
header field "server" = "openresty/1.25.3.2"
header field "date" = "Fri, 28 Feb 2025 04:00:14 GMT"
header field "content-type" = "text/html"
header field "content-length" = "561"

Frame Type	=>	DATA
Frame StreamID	=>	1
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>openresty/1.25.3.2</center>
</body>
</html>
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->


2025-02-28T12:00:15+08:00 ??? UUID:155734_155734_nginx_4_0_10.0.2.2:60482-10.0.2.5:4444, Name:HTTP2Request, Type:2, Length:1172

Frame Type	=>	SETTINGS
Frame StreamID	=>	0

Frame Type	=>	WINDOW_UPDATE
Frame StreamID	=>	0

Frame Type	=>	HEADERS
Frame StreamID	=>	1
header field ":method" = "GET"
header field ":authority" = "localhost:4444"
header field ":scheme" = "https"
header field ":path" = "/123"
header field "sec-ch-ua" = "\"Not(A:Brand\";v=\"99\", \"Google Chrome\";v=\"133\", \"Chromium\";v=\"133\""
header field "sec-ch-ua-mobile" = "?0"
header field "sec-ch-ua-platform" = "\"Windows\""
header field "upgrade-insecure-requests" = "1"
header field "user-agent" = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36"
header field "accept" = "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
header field "sec-fetch-site" = "none"
header field "sec-fetch-mode" = "navigate"
header field "sec-fetch-user" = "?1"
header field "sec-fetch-dest" = "document"
header field "accept-encoding" = "gzip, deflate, br, zstd"
header field "accept-language" = "zh-CN,zh;q=0.9"
header field "priority" = "u=0, i"

Frame Type	=>	SETTINGS
Frame StreamID	=>	0

2025-02-28T12:00:16+08:00 ??? UUID:155734_155734_nginx_5_1_10.0.2.2:60483-10.0.2.5:4444, Name:HTTP2Response, Type:4, Length:93

Frame Type	=>	SETTINGS
Frame StreamID	=>	0

Frame Type	=>	WINDOW_UPDATE
Frame StreamID	=>	0

2025/02/28 12:00:24 [http2 response] Dump HTTP2 Frame error: connection error: COMPRESSION_ERROR
2025-02-28T12:00:24+08:00 ??? UUID:155734_155734_nginx_4_1_10.0.2.2:60482-10.0.2.5:4444, Name:HTTP2Response, Type:4, Length:855

Frame Type	=>	HEADERS
Frame StreamID	=>	3
header field ":status" = "404"
header field "server" = "openresty/1.25.3.2"
header field "date" = "Fri, 28 Feb 2025 04:00:23 GMT"
header field "content-type" = "text/html"
header field "content-length" = "561"

Frame Type	=>	DATA
Frame StreamID	=>	3
<html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>openresty/1.25.3.2</center>
</body>
</html>
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
```

this problem is quite hard to fix now.