### PR TITLE
refactor: remove loopback device checks from pcap probe files

### DIFF
--- a/.github/workflows/go-c-cpp.yml
+++ b/.github/workflows/go-c-cpp.yml
@@ -1,5 +1,4 @@
 name: GO/C/C++ CI
-
 on:
   push:
     branches: [ master ]
@@ -7,48 +6,6 @@ on:
     branches: [ master ]
 
 jobs:
-  build-on-ubuntu2004:
-    runs-on: ubuntu-20.04
-    name: build on ubuntu-20.04 x86_64
-    steps:
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.22.10'
-      - name: Install Compilers
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes build-essential pkgconf libelf-dev llvm-10 clang-10 linux-tools-common linux-tools-generic gcc gcc-aarch64-linux-gnu libssl-dev
-          for tool in "clang" "llc" "llvm-strip"
-          do
-            sudo rm -f /usr/bin/$tool
-            sudo ln -s /usr/bin/$tool-10 /usr/bin/$tool
-          done
-        shell: bash
-      - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
-          fetch-depth: 0
-      - name: Build
-        run: |
-          make clean
-          make env
-          DEBUG=1 make nocore -j4
-          cd ./lib/libpcap/ && sudo make install
-          cd $GITHUB_WORKSPACE
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
-        with:
-          args: --disable-all -E errcheck -E staticcheck
-          skip-cache: true
-          problem-matchers: true
-      - name: Build NOCORE
-        run: |
-          make clean
-          make env
-          make nocore
-      - name: Test
-        run: go test -v -race ./...
-
   build-on-ubuntu2204:
     runs-on: ubuntu-22.04
     name: build on ubuntu-22.04 x86_64

--- a/user/module/probe_gnutls_pcap.go
+++ b/user/module/probe_gnutls_pcap.go
@@ -36,12 +36,6 @@ func (m *MGnutlsProbe) setupManagersPcap() error {
 		return fmt.Errorf("InterfaceByName: %s , failed: %v", m.ifName, err)
 	}
 
-	// loopback devices are special, some tc probes should be skipped
-	isNetIfaceLo := interf.Flags&net.FlagLoopback == net.FlagLoopback
-	skipLoopback := true // TODO: detect loopback devices via aquasecrity/tracee/pkg/ebpf/probes/probe.go line 322
-	if isNetIfaceLo && skipLoopback {
-		return fmt.Errorf("%s\t%s is a loopback interface, skip it", m.Name(), m.ifName)
-	}
 	m.ifIdex = interf.Index
 
 	pcapFilter := m.conf.(*config.GnutlsConfig).PcapFilter
@@ -67,15 +61,6 @@ func (m *MGnutlsProbe) setupManagersPcap() error {
 
 	m.bpfManager = &manager.Manager{
 		Probes: []*manager.Probe{
-			// customize deleteed TC filter
-			// tc filter del dev eth0 ingress
-			// tc filter del dev eth0 egress
-			// loopback devices are special, some tc probes should be skipped
-			// TODO: detect loopback devices via aquasecrity/tracee/pkg/ebpf/probes/probe.go line 322
-			// isNetIfaceLo := netIface.Flags&net.FlagLoopback == net.FlagLoopback
-			//	if isNetIfaceLo && p.skipLoopback {
-			//		return nil
-			//	}
 			{
 				Section:          "classifier/egress",
 				EbpfFuncName:     tcFuncNameEgress,

--- a/user/module/probe_gotls_pcap.go
+++ b/user/module/probe_gotls_pcap.go
@@ -43,12 +43,6 @@ func (g *GoTLSProbe) setupManagersPcap() error {
 		return err
 	}
 
-	// loopback devices are special, some tc probes should be skipped
-	isNetIfaceLo := interf.Flags&net.FlagLoopback == net.FlagLoopback
-	skipLoopback := true // TODO: detect loopback devices via aquasecrity/tracee/pkg/ebpf/probes/probe.go line 322
-	if isNetIfaceLo && skipLoopback {
-		return fmt.Errorf("%s\t%s is a loopback interface, skip it", g.Name(), g.ifName)
-	}
 	g.ifIdex = interf.Index
 
 	pcapFilter := g.conf.(*config.GoTLSConfig).PcapFilter

--- a/user/module/probe_openssl_pcap.go
+++ b/user/module/probe_openssl_pcap.go
@@ -46,12 +46,6 @@ func (m *MOpenSSLProbe) setupManagersPcap() error {
 		return fmt.Errorf("InterfaceByName: %s , failed: %v", m.ifName, err)
 	}
 
-	// loopback devices are special, some tc probes should be skipped
-	isNetIfaceLo := interf.Flags&net.FlagLoopback == net.FlagLoopback
-	skipLoopback := true // TODO: detect loopback devices via aquasecrity/tracee/pkg/ebpf/probes/probe.go line 322
-	if isNetIfaceLo && skipLoopback {
-		return fmt.Errorf("%s\t%s is a loopback interface, skip it", m.Name(), m.ifName)
-	}
 	m.ifIdex = interf.Index
 
 	sslVersion = m.conf.(*config.OpensslConfig).SslVersion
@@ -97,15 +91,6 @@ func (m *MOpenSSLProbe) setupManagersPcap() error {
 
 	m.bpfManager = &manager.Manager{
 		Probes: []*manager.Probe{
-			// customize deleteed TC filter
-			// tc filter del dev eth0 ingress
-			// tc filter del dev eth0 egress
-			// loopback devices are special, some tc probes should be skipped
-			// TODO: detect loopback devices via aquasecrity/tracee/pkg/ebpf/probes/probe.go line 322
-			// isNetIfaceLo := netIface.Flags&net.FlagLoopback == net.FlagLoopback
-			//	if isNetIfaceLo && p.skipLoopback {
-			//		return nil
-			//	}
 			{
 				Section:          "classifier/egress",
 				EbpfFuncName:     tcFuncNameEgress,


### PR DESCRIPTION
This pull request includes changes to the `setupManagersPcap` functions across multiple probe implementations to remove special handling for loopback devices. The most important changes include the removal of checks and comments related to loopback interfaces and the deletion of customized TC filter comments.

Removal of loopback device handling:

* [`user/module/probe_gnutls_pcap.go`](diffhunk://#diff-4fec8f06255579ed0d3c0f516162bb51bc0a34075500b6fec03eb56388894736L39-L44): Removed loopback device checks and related comments from `setupManagersPcap` function. [[1]](diffhunk://#diff-4fec8f06255579ed0d3c0f516162bb51bc0a34075500b6fec03eb56388894736L39-L44) [[2]](diffhunk://#diff-4fec8f06255579ed0d3c0f516162bb51bc0a34075500b6fec03eb56388894736L70-L78)
* [`user/module/probe_gotls_pcap.go`](diffhunk://#diff-d3101e43978db3f982e6370019b347b0f4863d1871d4b8c86bf9b3eed84ec6c3L46-L51): Removed loopback device checks and related comments from `setupManagersPcap` function.
* [`user/module/probe_openssl_pcap.go`](diffhunk://#diff-b553bad9a74ab279dd00b3a5b64930c3b9f142ebd13f36b1333eaa7770eb2f2cL49-L54): Removed loopback device checks and related comments from `setupManagersPcap` function. [[1]](diffhunk://#diff-b553bad9a74ab279dd00b3a5b64930c3b9f142ebd13f36b1333eaa7770eb2f2cL49-L54) [[2]](diffhunk://#diff-b553bad9a74ab279dd00b3a5b64930c3b9f142ebd13f36b1333eaa7770eb2f2cL100-L108)