### PR TITLE
fix: clean up SSLDataEvent string methods and improve logging  #776

### DIFF
--- a/pkg/event_processor/base_event.go
+++ b/pkg/event_processor/base_event.go
@@ -70,7 +70,7 @@ func (t tlsVersion) String() string {
 	case Dtls12Version:
 		return "DTLS1_2_VERSION"
 	}
-	return fmt.Sprintf("TLS_VERSION_UNKNOW_%d", t.version)
+	return fmt.Sprintf("TLS_VERSION_UNKNOWN_%d", t.version)
 }
 
 type BaseEvent struct {
@@ -140,7 +140,7 @@ func (be *BaseEvent) StringHex() string {
 	case ProbeRet:
 		connInfo = fmt.Sprintf("Send %d bytes", be.DataLen)
 	default:
-		prefix = fmt.Sprintf("UNKNOW_%d", be.DataType)
+		prefix = fmt.Sprintf("UNKNOWN_%d", be.DataType)
 	}
 
 	b := dumpByteSlice(be.Data[:be.DataLen], prefix)
@@ -159,7 +159,7 @@ func (be *BaseEvent) String() string {
 	case ProbeRet:
 		connInfo = fmt.Sprintf("Send %d bytes", be.DataLen)
 	default:
-		connInfo = fmt.Sprintf("UNKNOW_%d", be.DataType)
+		connInfo = fmt.Sprintf("UNKNOWN_%d", be.DataType)
 	}
 	v := tlsVersion{version: be.Version}
 	s := fmt.Sprintf("PID:%d, Comm:%s, TID:%d, Version:%s, %s, Payload:\n%s", be.Pid, bytes.TrimSpace(be.Comm[:]), be.Tid, v.String(), connInfo, string(be.Data[:be.DataLen]))

--- a/user/event/event_gnutls.go
+++ b/user/event/event_gnutls.go
@@ -67,13 +67,13 @@ func (ge *GnutlsDataEvent) StringHex() string {
 	var perfix, packetType string
 	switch AttachType(ge.DataType) {
 	case ProbeEntry:
-		packetType = fmt.Sprintf("%sRecived%s", COLORGREEN, COLORRESET)
+		packetType = fmt.Sprintf("%sReceived%s", COLORGREEN, COLORRESET)
 		perfix = COLORGREEN
 	case ProbeRet:
 		packetType = fmt.Sprintf("%sSend%s", COLORPURPLE, COLORRESET)
 		perfix = fmt.Sprintf("%s\t", COLORPURPLE)
 	default:
-		perfix = fmt.Sprintf("UNKNOW_%d", ge.DataType)
+		perfix = fmt.Sprintf("UNKNOWN_%d", ge.DataType)
 	}
 
 	b := dumpByteSlice(ge.Data[:ge.DataLen], perfix)
@@ -86,13 +86,13 @@ func (ge *GnutlsDataEvent) String() string {
 	var perfix, packetType string
 	switch AttachType(ge.DataType) {
 	case ProbeEntry:
-		packetType = fmt.Sprintf("%sRecived%s", COLORGREEN, COLORRESET)
+		packetType = fmt.Sprintf("%sReceived%s", COLORGREEN, COLORRESET)
 		perfix = COLORGREEN
 	case ProbeRet:
 		packetType = fmt.Sprintf("%sSend%s", COLORPURPLE, COLORRESET)
 		perfix = COLORPURPLE
 	default:
-		packetType = fmt.Sprintf("%sUNKNOW_%d%s", COLORRED, ge.DataType, COLORRESET)
+		packetType = fmt.Sprintf("%sUNKNOWN_%d%s", COLORRED, ge.DataType, COLORRESET)
 	}
 	s := fmt.Sprintf(" PID:%d, Comm:%s, TID:%d, TYPE:%s, DataLen:%d bytes, Payload:\n%s%s%s", ge.Pid, ge.Comm, ge.Tid, packetType, ge.DataLen, perfix, string(ge.Data[:ge.DataLen]), COLORRESET)
 	return s

--- a/user/event/event_nspr.go
+++ b/user/event/event_nspr.go
@@ -66,13 +66,13 @@ func (ne *NsprDataEvent) StringHex() string {
 	var perfix, packetType string
 	switch AttachType(ne.DataType) {
 	case ProbeEntry:
-		packetType = fmt.Sprintf("%sRecived%s", COLORGREEN, COLORRESET)
+		packetType = fmt.Sprintf("%sReceived%s", COLORGREEN, COLORRESET)
 		perfix = COLORGREEN
 	case ProbeRet:
 		packetType = fmt.Sprintf("%sSend%s", COLORPURPLE, COLORRESET)
 		perfix = fmt.Sprintf("%s\t", COLORPURPLE)
 	default:
-		perfix = fmt.Sprintf("UNKNOW_%d", ne.DataType)
+		perfix = fmt.Sprintf("UNKNOWN_%d", ne.DataType)
 	}
 
 	var b *bytes.Buffer
@@ -96,13 +96,13 @@ func (ne *NsprDataEvent) String() string {
 	var perfix, packetType string
 	switch AttachType(ne.DataType) {
 	case ProbeEntry:
-		packetType = fmt.Sprintf("%sRecived%s", COLORGREEN, COLORRESET)
+		packetType = fmt.Sprintf("%sReceived%s", COLORGREEN, COLORRESET)
 		perfix = COLORGREEN
 	case ProbeRet:
 		packetType = fmt.Sprintf("%sSend%s", COLORPURPLE, COLORRESET)
 		perfix = COLORPURPLE
 	default:
-		packetType = fmt.Sprintf("%sUNKNOW_%d%s", COLORRED, ne.DataType, COLORRESET)
+		packetType = fmt.Sprintf("%sUNKNOWN_%d%s", COLORRED, ne.DataType, COLORRESET)
 	}
 
 	var b *bytes.Buffer

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -67,7 +67,7 @@ func (t TlsVersion) String() string {
 	case Dtls12Version:
 		return "DTLS1_2_VERSION"
 	}
-	return fmt.Sprintf("TLS_VERSION_UNKNOW_%d", t.Version)
+	return fmt.Sprintf("TLS_VERSION_UNKNOWN_%d", t.Version)
 }
 
 type SSLDataEvent struct {
@@ -179,11 +179,11 @@ func (se *SSLDataEvent) BaseInfo() string {
 	var connInfo string
 	switch AttachType(se.DataType) {
 	case ProbeEntry:
-		connInfo = fmt.Sprintf("%sRecived %d%s bytes from %s%s%s", COLORGREEN, se.DataLen, COLORRESET, COLORYELLOW, addr, COLORRESET)
+		connInfo = fmt.Sprintf("%sReceived %d%s bytes from %s%s%s", COLORGREEN, se.DataLen, COLORRESET, COLORYELLOW, addr, COLORRESET)
 	case ProbeRet:
 		connInfo = fmt.Sprintf("%sSend %d%s bytes to %s%s%s", COLORPURPLE, se.DataLen, COLORRESET, COLORYELLOW, addr, COLORRESET)
 	default:
-		connInfo = fmt.Sprintf("%sUNKNOW_%d%s", COLORRED, se.DataType, COLORRESET)
+		connInfo = fmt.Sprintf("%sUNKNOWN_%d%s", COLORRED, se.DataType, COLORRESET)
 	}
 	v := TlsVersion{Version: se.Version}
 	s := fmt.Sprintf("PID:%d, Comm:%s, TID:%d, Version:%s, %s", se.Pid, commStr(se.Comm[:]), se.Tid, v.String(), connInfo)

--- a/user/module/imodule.go
+++ b/user/module/imodule.go
@@ -254,10 +254,10 @@ func (m *Module) run() {
 			//err := m.child.Close()
 			//if err != nil {
 			//}
-			m.logger.Info().Msg("Module closed,message recived from Context")
+			m.logger.Info().Msg("Module closed,message Received from Context")
 			return
 		case err := <-m.errChan:
-			m.logger.Warn().AnErr("Module closed,message recived from errChan", err).Send()
+			m.logger.Warn().AnErr("Module closed,message Received from errChan", err).Send()
 			return
 		}
 	}

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -764,12 +764,8 @@ func (m *MOpenSSLProbe) dumpSslData(eventStruct *event.SSLDataEvent) {
 	} else {
 		eventStruct.Tuple = tuple
 	}
-	// m.processor.PcapFile(eventStruct)
-	//if m.conf.GetHex() {
-	//	m.logger.Println(eventStruct.StringHex())
-	//} else {
-	//	m.logger.Println(eventStruct.String())
-	//}
+
+	m.logger.Info().Msg(eventStruct.BaseInfo())
 	m.processor.Write(eventStruct)
 }
 


### PR DESCRIPTION
This pull request refactors and simplifies the `SSLDataEvent` handling in the `user/event/event_openssl.go` and `user/module/probe_openssl.go` files. The changes focus on improving code readability, modularizing functionality, and removing unused or commented-out code.

### Refactoring and modularization:

* Extracted common information formatting logic into a new method `BaseInfo` in the `SSLDataEvent` struct, reducing duplication across `StringHex` and `String` methods. (`[user/event/event_openssl.goL145-R189](diffhunk://#diff-480dff63c9fb64faab905b5e03148ce0c39eaf4ddfbf6fcda10d3d565642f83aL145-R189)`)

### Code cleanup:

* Removed commented-out and unused code in the `StringHex`, `String`, and `dumpSslData` methods, as well as outdated comments in the `connDataEvent` struct. (`[[1]](diffhunk://#diff-480dff63c9fb64faab905b5e03148ce0c39eaf4ddfbf6fcda10d3d565642f83aL145-R189)`, `[[2]](diffhunk://#diff-480dff63c9fb64faab905b5e03148ce0c39eaf4ddfbf6fcda10d3d565642f83aL199-L214)`, `[[3]](diffhunk://#diff-779504b2ae7d5c72fdd91b76febcf4f3a108e7bd02638501401a518f773cb195L767-R768)`)

### Logging improvements:

* Updated the `dumpSslData` method in `MOpenSSLProbe` to log only the `BaseInfo` of `SSLDataEvent` instead of the full payload, streamlining log output. (`[user/module/probe_openssl.goL767-R768](diffhunk://#diff-779504b2ae7d5c72fdd91b76febcf4f3a108e7bd02638501401a518f773cb195L767-R768)`)