### PR TITLE
fix: avoid writing empty decryption secrets block in savePcapng method

### DIFF
--- a/user/module/probe_pcap.go
+++ b/user/module/probe_pcap.go
@@ -149,11 +149,12 @@ func (t *MTCProbe) writePid(tcEvent *event.TcSkbEvent) ([]byte, error) {
 
 // save pcapng file ,merge master key into pcapng file TODO
 func (t *MTCProbe) savePcapng() (i int, err error) {
-	err = t.pcapWriter.WriteDecryptionSecretsBlock(pcapgo.DSB_SECRETS_TYPE_TLS, t.masterKeyBuffer.Bytes())
-	if err != nil {
-		return
+	if t.masterKeyBuffer.Len() > 0 {
+		err = t.pcapWriter.WriteDecryptionSecretsBlock(pcapgo.DSB_SECRETS_TYPE_TLS, t.masterKeyBuffer.Bytes())
+		if err != nil {
+			return
+		}
 	}
-
 	// reset master key buffer, fix issue #542
 	t.masterKeyBuffer.Reset()
 	t.tcPacketLocker.Lock()


### PR DESCRIPTION
fix #784

Key change:

* [`user/module/probe_pcap.go`](diffhunk://#diff-843cfd1b21b56be558d838830b906f9c699dd712b18d1b8f439a70a7466a894dR152-R157): Added a conditional check to ensure the `masterKeyBuffer` is not empty before attempting to write the decryption secrets block, resolving issue #542.