### PR TITLE
feat: support openssl version 3.5.0 #783

### DIFF
--- a/kern/openssl_3_5_0_kern.c
+++ b/kern/openssl_3_5_0_kern.c
@@ -1,0 +1,80 @@
+#ifndef ECAPTURE_OPENSSL_3_5_0_KERN_H
+#define ECAPTURE_OPENSSL_3_5_0_KERN_H
+
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.5.0 8 Apr 2025 */
+/* OPENSSL_VERSION_NUMBER: 810549248 */
+
+// ssl_st->type
+#define SSL_ST_TYPE 0x0
+
+// ssl_connection_st->version
+#define SSL_CONNECTION_ST_VERSION 0x48
+
+// ssl_connection_st->session
+#define SSL_CONNECTION_ST_SESSION 0x900
+
+// ssl_connection_st->s3
+#define SSL_CONNECTION_ST_S3 0x160
+
+// ssl_connection_st->rbio
+#define SSL_CONNECTION_ST_RBIO 0x50
+
+// ssl_connection_st->wbio
+#define SSL_CONNECTION_ST_WBIO 0x58
+
+// ssl_connection_st->server
+#define SSL_CONNECTION_ST_SERVER 0x78
+
+// ssl_session_st->master_key
+#define SSL_SESSION_ST_MASTER_KEY 0x50
+
+// ssl_connection_st->s3.client_random
+#define SSL_CONNECTION_ST_S3_CLIENT_RANDOM 0x188
+
+// ssl_session_st->cipher
+#define SSL_SESSION_ST_CIPHER 0x2f8
+
+// ssl_session_st->cipher_id
+#define SSL_SESSION_ST_CIPHER_ID 0x300
+
+// ssl_cipher_st->id
+#define SSL_CIPHER_ST_ID 0x18
+
+// ssl_connection_st->handshake_secret
+#define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x5bc
+
+// ssl_connection_st->handshake_traffic_hash
+#define SSL_CONNECTION_ST_HANDSHAKE_TRAFFIC_HASH 0x73c
+
+// ssl_connection_st->client_app_traffic_secret
+#define SSL_CONNECTION_ST_CLIENT_APP_TRAFFIC_SECRET 0x77c
+
+// ssl_connection_st->server_app_traffic_secret
+#define SSL_CONNECTION_ST_SERVER_APP_TRAFFIC_SECRET 0x7bc
+
+// ssl_connection_st->exporter_master_secret
+#define SSL_CONNECTION_ST_EXPORTER_MASTER_SECRET 0x7fc
+
+// bio_st->num
+#define BIO_ST_NUM 0x38
+
+// bio_st->method
+#define BIO_ST_METHOD 0x8
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
+// quic_conn_st->tls
+#define QUIC_CONN_ST_TLS 0x78
+
+#define SSL_ST_VERSION SSL_CONNECTION_ST_VERSION
+
+#define SSL_ST_WBIO SSL_CONNECTION_ST_WBIO
+
+#define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
+
+
+#include "openssl.h"
+#include "openssl_masterkey_3.2.h"
+
+#endif

--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -54,6 +54,8 @@ const (
 	MaxSupportedOpenSSL33Version  = 3 // openssl 3.3.3
 	SupportedOpenSSL34Version0    = 0 // openssl 3.4.0
 	MaxSupportedOpenSSL34Version  = 1 // openssl 3.4.1
+	SupportedOpenSSL35Version0    = 0 // openssl 3.5.0
+	MaxSupportedOpenSSL35Version  = 0 // openssl 3.5.1
 )
 
 var (
@@ -158,6 +160,11 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 	// openssl 3.4.1
 	for ch := 1; ch <= MaxSupportedOpenSSL34Version; ch++ {
 		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.4.%d", ch)] = "openssl_3_4_1_kern.o"
+	}
+
+	// openssl 3.5.0
+	for ch := 0; ch <= SupportedOpenSSL35Version0; ch++ {
+		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.5.%d", ch)] = "openssl_3_5_0_kern.o"
 	}
 
 	// openssl 1.1.0a - 1.1.0l

--- a/utils/openssl_3_5_0_offset.c
+++ b/utils/openssl_3_5_0_offset.c
@@ -1,0 +1,62 @@
+// clang -I include/ -I . offset.c -o offset
+#include <crypto/bio/bio_local.h>
+#include <openssl/crypto.h>
+#include <ssl/quic/quic_local.h>
+#include <ssl/ssl_local.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#define SSL_STRUCT_OFFSETS                          \
+    X(ssl_st, type)                                 \
+    X(ssl_connection_st, version)                   \
+    X(ssl_connection_st, session)                   \
+    X(ssl_connection_st, s3)                        \
+    X(ssl_connection_st, rbio)                      \
+    X(ssl_connection_st, wbio)                      \
+    X(ssl_connection_st, server)                    \
+    X(ssl_session_st, master_key)                   \
+    X(ssl_connection_st, s3.client_random)          \
+    X(ssl_session_st, cipher)                       \
+    X(ssl_session_st, cipher_id)                    \
+    X(ssl_cipher_st, id)                            \
+    X(ssl_connection_st, handshake_secret)          \
+    X(ssl_connection_st, handshake_traffic_hash)    \
+    X(ssl_connection_st, client_app_traffic_secret) \
+    X(ssl_connection_st, server_app_traffic_secret) \
+    X(ssl_connection_st, exporter_master_secret)    \
+    X(bio_st, num)                                  \
+    X(bio_st, method)                               \
+    X(bio_method_st, type)                          \
+    X(quic_conn_st, tls)
+
+void toUpper(char *s) {
+    int i = 0;
+    while (s[i] != '\0') {
+        if (s[i] == '.') {
+            putchar('_');
+        } else {
+            putchar(toupper(s[i]));
+        }
+        i++;
+    }
+}
+
+void format(char *struct_name, char *field_name, size_t offset) {
+    printf("// %s->%s\n", struct_name, field_name);
+    printf("#define ");
+    toUpper(struct_name);
+    printf("_");
+    toUpper(field_name);
+    printf(" 0x%lx\n\n", offset);
+}
+
+int main() {
+    printf("/* OPENSSL_VERSION_TEXT: %s */\n", OPENSSL_VERSION_TEXT);
+    printf("/* OPENSSL_VERSION_NUMBER: %ld */\n\n", OPENSSL_VERSION_NUMBER);
+#define X(struct_name, field_name) format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
+    SSL_STRUCT_OFFSETS
+#undef X
+
+    return 0;
+}

--- a/utils/openssl_offset_3.5.sh
+++ b/utils/openssl_offset_3.5.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -e
+
+PROJECT_ROOT_DIR=$(pwd)
+OPENSSL_DIR="${PROJECT_ROOT_DIR}/deps/openssl"
+OUTPUT_DIR="${PROJECT_ROOT_DIR}/kern"
+
+if [[ ! -f "go.mod" ]]; then
+  echo "Run the script from the project root directory"
+  exit 1
+fi
+
+echo "check file exists: ${OPENSSL_DIR}/.git"
+# skip cloning if the header file of the max supported version is already generated
+if [[ ! -f "${OPENSSL_DIR}/.git" ]]; then
+  echo "check directory exists: ${OPENSSL_DIR}"
+  # skip cloning if the openssl directory already exists
+  if [[ ! -d "${OPENSSL_DIR}" ]]; then
+    echo "git clone openssl to ${OPENSSL_DIR}"
+    git clone https://github.com/openssl/openssl.git ${OPENSSL_DIR}
+  fi
+fi
+
+function run() {
+  git fetch --tags
+  cp -f ${PROJECT_ROOT_DIR}/utils/openssl_3_5_0_offset.c ${OPENSSL_DIR}/offset.c
+  declare -A sslVerMap=()
+  sslVerMap["0"]="0"
+
+  # shellcheck disable=SC2068
+  for ver in ${!sslVerMap[@]}; do
+    tag="openssl-3.5.${ver}"
+    val=${sslVerMap[$ver]}
+    header_file="${OUTPUT_DIR}/openssl_3_5_${val}_kern.c"
+    header_define="OPENSSL_3_5_$(echo ${val} | tr "[:lower:]" "[:upper:]")_KERN_H"
+
+    if [[ -f ${header_file} ]]; then
+      echo "Skip ${header_file}"
+      continue
+    fi
+    echo "git checkout ${tag}"
+    git checkout ${tag}
+    echo "Generating ${header_file}"
+
+
+    # ./Configure and make openssl/opensslconf.h
+    ./Configure
+    make clean
+    make build_generated
+
+
+    clang -I /usr/include -I include/ -I . offset.c -o offset
+
+    echo -e "#ifndef ECAPTURE_${header_define}" >${header_file}
+    echo -e "#define ECAPTURE_${header_define}\n" >>${header_file}
+    ./offset >>${header_file}
+    echo -e "#define SSL_ST_VERSION SSL_CONNECTION_ST_VERSION\n" >>${header_file}
+    echo -e "#define SSL_ST_WBIO SSL_CONNECTION_ST_WBIO\n" >>${header_file}
+    echo -e "#define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO\n" >>${header_file}
+    echo -e "\n#include \"openssl.h\"" >>${header_file}
+    echo -e "#include \"openssl_masterkey_3.2.h\"" >>${header_file}
+    echo -e "\n#endif" >>${header_file}
+
+    # clean up
+    make clean
+
+  done
+
+  rm offset.c
+}
+
+# TODO Check if the directory for OpenSSL exists
+pushd ${OPENSSL_DIR}
+(run)
+[[ "$?" != 0 ]] && popd
+popd

--- a/variables.mk
+++ b/variables.mk
@@ -207,6 +207,7 @@ TARGETS += kern/openssl_3_3_2
 TARGETS += kern/openssl_3_3_3
 TARGETS += kern/openssl_3_4_0
 TARGETS += kern/openssl_3_4_1
+TARGETS += kern/openssl_3_5_0
 TARGETS += kern/gotls
 
 ifeq ($(ANDROID),0)


### PR DESCRIPTION
This pull request introduces support for OpenSSL version 3.5.0 by adding new kernel offsets, updating user-space probe logic, and creating utilities for generating offsets dynamically. The changes ensure compatibility with the new OpenSSL version and streamline the process for handling future updates.

### OpenSSL 3.5.0 Support

* **Kernel Offset Definitions**: Added detailed offset definitions for OpenSSL 3.5.0 structures in `kern/openssl_3_5_0_kern.c`, including fields like `ssl_connection_st->version`, `ssl_session_st->master_key`, and `bio_st->num`. These offsets are crucial for interacting with OpenSSL internals.
* **User-Space Probe Updates**: Extended the `MOpenSSLProbe` logic in `user/module/probe_openssl_lib.go` to include OpenSSL 3.5.0 in the supported versions map and initialization logic. [[1]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222R57-R58) [[2]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222R165-R169)

### Utilities for Dynamic Offset Generation

* **Offset Generator**: Added `utils/openssl_3_5_0_offset.c`, a utility for dynamically generating offset definitions using OpenSSL headers and structure layouts. This simplifies maintaining offsets for future OpenSSL versions.
* **Automation Script**: Introduced `utils/openssl_offset_3.5.sh`, a script to automate cloning the OpenSSL repository, checking out the correct version, and generating offset files.

### Build System Updates

* **Makefile Target**: Added `kern/openssl_3_5_0` to the build targets in `variables.mk` to ensure the new kernel offsets are included in the build process.