### PR TITLE
feat: define early_secret in SSL structures for enhanced security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@
 bin/*
 /.check*
 /deps/*
+/assets/probe.go

--- a/builder/rpmBuild.spec
+++ b/builder/rpmBuild.spec
@@ -1,6 +1,6 @@
 Name:       ecapture
-Version:    v0.0.1
-Release:    2023%{?dist}
+Version:    v1.1.0
+Release:    2025%{?dist}
 Summary:    Capture SSL/TLS plaintext content without CA certificates using eBPF
 License:    Apache-2.0
 URL:        https://ecapture.cc
@@ -11,16 +11,24 @@ Source0:    %{name}-%{version}.tar.gz
 
 
 %description
-SSL/TLS plaintext capture,
-supports OpenSSL, LibreSSL, BoringSSL, GnuTLS, and NSPR (NSS) libraries.
+eCapture is a powerful network traffic capture and decryption tool based on eBPF technology, focusing on TLS/SSL protocol transparency and analysis. This tool supports multiple protocols and architectures, providing efficient and flexible capture and decryption capabilities.
 
-GoTLS plaintext support for the Go TLS library, which refers to encrypted
+Key features include:
+- Multi-Protocol Support: Compatible with TLS, gnutls, nss, openssl, and other encryption protocols across different versions of SSL/TLS implementations
+- Smart Packet Capture: Efficient network data capture and protocol parsing based on eBPF technology, supporting IPv4/IPv6 dual-stack and 4-tuple filtering
+- Master Key Capture: Supports TLS 1.0/1.1/1.2 and 1.3 protocol master key capture, integrates with Wireshark for decryption to view encrypted traffic in plain text
+- Modular Architecture: Easy extension and flexible configuration of different protocol modules
+- Cross-Platform Support: Compatible with Linux, Android, and other platforms, supporting ARM64 and x86 architectures
 
-communication in HTTPS/TLS programs written in the Go language.
+Technical advantages:
+- Automatic detection of SSL/TLS library versions, intelligent identification of CO-RE and non-CO-RE modes
+- Support for custom filters, log files, decryption modes, and multiple output formats
+- High-efficiency data processing based on eBPF, supporting large-scale concurrent captures and long-term packet capturing
+- Wireshark plugin support for easy data analysis and visualization
 
-Bash audit captures bash commands for Host Security Audit.
-Zsh audit captures zsh commands for Host Security Audit.
-MySQL query SQL audit supports MySQL 5.6/5.7/8.0 and MariaDB.
+Application scenarios: Network debugging, security analysis, protocol research, monitoring and auditing.
+
+For more information, visit: https://ecapture.cc or https://github.com/gojue/ecapture
 
 %prep
 %setup -c
@@ -42,14 +50,14 @@ echo "Please ensure that /usr/local/bin is in your \$PATH, or use /usr/local/bin
 /usr/local/bin/ecapture
 
 %changelog
-* Sat Dec 30 2023 CFC4N <cfc4ncs@gmail.com> - 0.7.0-1
-- Split `nss/gnutls/openssl` into three separate submodules. Corresponding to the `./ecapture nss`, `./ecapture gnutls`, `ecapture tls` commands.
-- Support `keylog` mode, equivalent to the functionality of the `SSLKEYLOGFILE` environment variable. Captures SSL/TLS communication keys directly without the need for changes in the target process.
-- Refactor the mode parameters supported by the `openssl`(aka tls) module using the `-m`parameter, with values `text`, `pcap`,`keylog`.
-  - `pcap` mode: Set with `-m pcap` or `-m pcapng` parameters. When using this mode, it is necessary to specify `--pcapfile` and `-i` parameters. The default value for the `--pcapfile` parameter is `ecapture_openssl.pcapng`.
-  - `keylog` mode: Set with `-m keylog` or `-m key` parameters. When using this mode, it is necessary to specify `--keylogfile`, defaulting to `ecapture_masterkey.log`.
-  - `text` mode: Default mode when `-m` parameter is unspecified. Outputs all plaintext packets in text form. (As of v0.7.0, no longer captures communication keys, please use `keylog` mode instead.)
-- Refactor the mode parameters supported by the `gotls` module, similar to the `openssl` module, without further details.
-- Optimize the memory size of eBPF Map, specify with the `--mapsize` parameter, defaulting to 5120 KB.
-- Remove the `-w` parameter, use `--pcapfile` parameter instead.
-- Change `log-addr` parameter to `logaddr`, with unchanged functionality.
+* Tue Mar 25 2025 CFC4N <cfc4ncs@gmail.com> - 1.0.0
+- Initial stable release
+- Added support for multiple encryption protocols including TLS, gnutls, nss, and openssl
+- Implemented smart packet capture based on eBPF technology
+- Added support for TLS 1.2 and 1.3 protocol master key capture
+- Completed modular architecture design for easy extension
+- Added cross-platform support for Linux, Android, and other platforms
+- Ensured compatibility with ARM64 and x86 architectures
+- Added Wireshark plugin support
+- Implemented automatic detection of SSL/TLS library versions
+- Added support for custom filters, log files, and multiple output formats

--- a/kern/common.h
+++ b/kern/common.h
@@ -28,14 +28,14 @@
 #define TASK_COMM_LEN 16
 #define PATH_MAX_LEN 256
 
-/* 
+/*
  * RFC 5246 : https://datatracker.ietf.org/doc/html/rfc5246#section-6.2
  * length
  *    The length (in bytes) of the following TLSPlaintext.fragment.  The length MUST NOT exceed 2^14.
- * 
+ *
  * OpenSSL : SSL3_RT_MAX_PLAIN_LENGTH (16384). These functions will only accept a value in the range 512 - SSL3_RT_MAX_PLAIN_LENGTH.
  * https://docs.openssl.org/1.1.1/man3/SSL_CTX_set_split_send_fragment/#description
-*/
+ */
 #define MAX_DATA_SIZE_OPENSSL 1024 * 16
 #define MAX_DATA_SIZE_MYSQL 256
 #define MAX_DATA_SIZE_POSTGRES 256

--- a/kern/gotls_kern.c
+++ b/kern/gotls_kern.c
@@ -245,8 +245,8 @@ static __always_inline int gotls_mastersecret(struct pt_regs *ctx, bool is_regis
     }
 
     debug_bpf_printk("gotls_mastersecret read mastersecret label:%s\n", mastersecret_gotls.label);
-    ret = bpf_probe_read_user_str(&mastersecret_gotls.client_random, sizeof(mastersecret_gotls.client_random),
-                                  (void *)cr_ptr);
+    ret = bpf_probe_read_user_str(
+        &mastersecret_gotls.client_random, sizeof(mastersecret_gotls.client_random), (void *)cr_ptr);
     if (ret < 0) {
         debug_bpf_printk(
             "gotls_mastersecret read mastersecret client_random failed, "
@@ -264,8 +264,8 @@ static __always_inline int gotls_mastersecret(struct pt_regs *ctx, bool is_regis
         return 0;
     }
 
-    bpf_perf_event_output(ctx, &mastersecret_go_events, BPF_F_CURRENT_CPU, &mastersecret_gotls,
-                          sizeof(struct mastersecret_gotls_t));
+    bpf_perf_event_output(
+        ctx, &mastersecret_go_events, BPF_F_CURRENT_CPU, &mastersecret_gotls, sizeof(struct mastersecret_gotls_t));
     return 0;
 }
 

--- a/kern/openssl_1_0_2a_kern.c
+++ b/kern/openssl_1_0_2a_kern.c
@@ -47,6 +47,7 @@
 #define BIO_METHOD_ST_TYPE 0x0
 
 // openssl 1.0.2 does not support TLS 1.3, set 0 default
+#define SSL_ST_EARLY_SECRET 0
 #define SSL_ST_HANDSHAKE_SECRET 0
 #define SSL_ST_HANDSHAKE_TRAFFIC_HASH 0
 #define SSL_ST_CLIENT_APP_TRAFFIC_SECRET 0

--- a/kern/openssl_1_1_0a_kern.c
+++ b/kern/openssl_1_1_0a_kern.c
@@ -47,6 +47,7 @@
 #define BIO_METHOD_ST_TYPE 0x0
 
 // openssl 1.1.0 does not support TLS 1.3, set 0 default
+#define SSL_ST_EARLY_SECRET 0
 #define SSL_ST_HANDSHAKE_SECRET 0
 #define SSL_ST_HANDSHAKE_TRAFFIC_HASH 0
 #define SSL_ST_CLIENT_APP_TRAFFIC_SECRET 0

--- a/kern/openssl_1_1_1a_kern.c
+++ b/kern/openssl_1_1_1a_kern.c
@@ -37,6 +37,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_st->early_secret
+#define SSL_ST_EARLY_SECRET 0x134
+
 // ssl_st->handshake_secret
 #define SSL_ST_HANDSHAKE_SECRET 0x174
 

--- a/kern/openssl_1_1_1b_kern.c
+++ b/kern/openssl_1_1_1b_kern.c
@@ -37,6 +37,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_st->early_secret
+#define SSL_ST_EARLY_SECRET 0x134
+
 // ssl_st->handshake_secret
 #define SSL_ST_HANDSHAKE_SECRET 0x174
 

--- a/kern/openssl_1_1_1d_kern.c
+++ b/kern/openssl_1_1_1d_kern.c
@@ -37,6 +37,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_st->early_secret
+#define SSL_ST_EARLY_SECRET 0x13c
+
 // ssl_st->handshake_secret
 #define SSL_ST_HANDSHAKE_SECRET 0x17c
 

--- a/kern/openssl_1_1_1j_kern.c
+++ b/kern/openssl_1_1_1j_kern.c
@@ -37,6 +37,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_st->early_secret
+#define SSL_ST_EARLY_SECRET 0x13c
+
 // ssl_st->handshake_secret
 #define SSL_ST_HANDSHAKE_SECRET 0x17c
 

--- a/kern/openssl_3_0_0_kern.c
+++ b/kern/openssl_3_0_0_kern.c
@@ -37,6 +37,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_st->early_secret
+#define SSL_ST_EARLY_SECRET 0x544
+
 // ssl_st->handshake_secret
 #define SSL_ST_HANDSHAKE_SECRET 0x584
 

--- a/kern/openssl_3_1_0_kern.c
+++ b/kern/openssl_3_1_0_kern.c
@@ -1,8 +1,8 @@
 #ifndef ECAPTURE_OPENSSL_3_0_0_KERN_H
 #define ECAPTURE_OPENSSL_3_0_0_KERN_H
 
-/* OPENSSL_VERSION_TEXT: OpenSSL 3.1.7 3 Sep 2024 */
-/* OPENSSL_VERSION_NUMBER: 806355056 */
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.1.8 11 Feb 2025 */
+/* OPENSSL_VERSION_NUMBER: 806355072 */
 
 // ssl_st->version
 #define SSL_ST_VERSION 0x0
@@ -36,6 +36,9 @@
 
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
+
+// ssl_st->early_secret
+#define SSL_ST_EARLY_SECRET 0x544
 
 // ssl_st->handshake_secret
 #define SSL_ST_HANDSHAKE_SECRET 0x584

--- a/kern/openssl_3_2_0_kern.c
+++ b/kern/openssl_3_2_0_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x4fc
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x53c
 
@@ -72,6 +75,7 @@
 #define SSL_ST_WBIO SSL_CONNECTION_ST_WBIO
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
+
 
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"

--- a/kern/openssl_3_2_0_kern.c
+++ b/kern/openssl_3_2_0_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_3_2_3_kern.c
+++ b/kern/openssl_3_2_3_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x4fc
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x53c
 
@@ -72,6 +75,7 @@
 #define SSL_ST_WBIO SSL_CONNECTION_ST_WBIO
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
+
 
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"

--- a/kern/openssl_3_2_3_kern.c
+++ b/kern/openssl_3_2_3_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_3_2_4_kern.c
+++ b/kern/openssl_3_2_4_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_3_2_4_kern.c
+++ b/kern/openssl_3_2_4_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x504
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x544
 

--- a/kern/openssl_3_3_0_kern.c
+++ b/kern/openssl_3_3_0_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x4fc
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x53c
 

--- a/kern/openssl_3_3_0_kern.c
+++ b/kern/openssl_3_3_0_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_3_3_2_kern.c
+++ b/kern/openssl_3_3_2_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x4fc
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x53c
 

--- a/kern/openssl_3_3_2_kern.c
+++ b/kern/openssl_3_3_2_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_3_3_3_kern.c
+++ b/kern/openssl_3_3_3_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_3_3_3_kern.c
+++ b/kern/openssl_3_3_3_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x504
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x544
 

--- a/kern/openssl_3_4_0_kern.c
+++ b/kern/openssl_3_4_0_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x4fc
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x53c
 

--- a/kern/openssl_3_4_0_kern.c
+++ b/kern/openssl_3_4_0_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_3_4_1_kern.c
+++ b/kern/openssl_3_4_1_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_3_4_1_kern.c
+++ b/kern/openssl_3_4_1_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x504
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x544
 

--- a/kern/openssl_3_5_0_kern.c
+++ b/kern/openssl_3_5_0_kern.c
@@ -40,6 +40,9 @@
 // ssl_cipher_st->id
 #define SSL_CIPHER_ST_ID 0x18
 
+// ssl_connection_st->early_secret
+#define SSL_CONNECTION_ST_EARLY_SECRET 0x57c
+
 // ssl_connection_st->handshake_secret
 #define SSL_CONNECTION_ST_HANDSHAKE_SECRET 0x5bc
 

--- a/kern/openssl_3_5_0_kern.c
+++ b/kern/openssl_3_5_0_kern.c
@@ -76,7 +76,6 @@
 
 #define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO
 
-
 #include "openssl.h"
 #include "openssl_masterkey_3.2.h"
 

--- a/kern/openssl_masterkey.h
+++ b/kern/openssl_masterkey.h
@@ -30,6 +30,7 @@ struct mastersecret_t {
 
     // TLS 1.3
     u32 cipher_id;
+    u8 early_secret[EVP_MAX_MD_SIZE];
     u8 handshake_secret[EVP_MAX_MD_SIZE];
     u8 handshake_traffic_hash[EVP_MAX_MD_SIZE];
     u8 client_app_traffic_secret[EVP_MAX_MD_SIZE];

--- a/kern/openssl_masterkey.h
+++ b/kern/openssl_masterkey.h
@@ -128,14 +128,14 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
 
     // Get ssl3_state_st->client_random pointer
     u64 *s3_st_client_random_ptr = (u64 *)(address + SSL3_STATE_ST_CLIENT_RANDOM);
-    ret = bpf_probe_read_user(&mastersecret->client_random, sizeof(mastersecret->client_random),
-                              (void *)s3_st_client_random_ptr);
+    ret = bpf_probe_read_user(
+        &mastersecret->client_random, sizeof(mastersecret->client_random), (void *)s3_st_client_random_ptr);
     if (ret) {
         debug_bpf_printk("bpf_probe_read ssl3_state_st struct failed, ret :%d\n", ret);
         return 0;
     }
     debug_bpf_printk("client_random: %x %x %x\n", mastersecret->client_random[0], mastersecret->client_random[1],
-                     mastersecret->client_random[2]);
+        mastersecret->client_random[2]);
 
     // Get ssl_session_st pointer
     u64 *ssl_session_st_ptr;
@@ -161,10 +161,10 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         }
 
         debug_bpf_printk("master_key: %x %x %x\n", mastersecret->master_key[0], mastersecret->master_key[1],
-                         mastersecret->master_key[2]);
+            mastersecret->master_key[2]);
 
-        bpf_perf_event_output(ctx, &mastersecret_events, BPF_F_CURRENT_CPU, mastersecret,
-                              sizeof(struct mastersecret_t));
+        bpf_perf_event_output(
+            ctx, &mastersecret_events, BPF_F_CURRENT_CPU, mastersecret, sizeof(struct mastersecret_t));
         return 0;
     }
 
@@ -204,17 +204,24 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
 
     //////////////////// TLS 1.3 master secret ////////////////////////
 
+    void *es_ptr_tls13 = (void *)(ssl_st_ptr + SSL_ST_EARLY_SECRET);
+    ret = bpf_probe_read_user(&mastersecret->early_secret, sizeof(mastersecret->early_secret), (void *)es_ptr_tls13);
+    if (ret) {
+        debug_bpf_printk("bpf_probe_read SSL_ST_EARLY_SECRET failed, ret :%d\n", ret);
+        // If the read fails, it may be because TLS 1.3 early data is not enabled, so this error can be ignored
+    }
+
     void *hs_ptr_tls13 = (void *)(ssl_st_ptr + SSL_ST_HANDSHAKE_SECRET);
-    ret = bpf_probe_read_user(&mastersecret->handshake_secret, sizeof(mastersecret->handshake_secret),
-                              (void *)hs_ptr_tls13);
+    ret = bpf_probe_read_user(
+        &mastersecret->handshake_secret, sizeof(mastersecret->handshake_secret), (void *)hs_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_ST_HANDSHAKE_SECRET failed, ret :%d\n", ret);
         return 0;
     }
 
     void *hth_ptr_tls13 = (void *)(ssl_st_ptr + SSL_ST_HANDSHAKE_TRAFFIC_HASH);
-    ret = bpf_probe_read_user(&mastersecret->handshake_traffic_hash, sizeof(mastersecret->handshake_traffic_hash),
-                              (void *)hth_ptr_tls13);
+    ret = bpf_probe_read_user(
+        &mastersecret->handshake_traffic_hash, sizeof(mastersecret->handshake_traffic_hash), (void *)hth_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_ST_HANDSHAKE_TRAFFIC_HASH failed, ret :%d\n", ret);
         return 0;
@@ -222,7 +229,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
 
     void *cats_ptr_tls13 = (void *)(ssl_st_ptr + SSL_ST_CLIENT_APP_TRAFFIC_SECRET);
     ret = bpf_probe_read_user(&mastersecret->client_app_traffic_secret, sizeof(mastersecret->client_app_traffic_secret),
-                              (void *)cats_ptr_tls13);
+        (void *)cats_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_ST_CLIENT_APP_TRAFFIC_SECRET failed, ret :%d\n", ret);
         return 0;
@@ -230,21 +237,21 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
 
     void *sats_ptr_tls13 = (void *)(ssl_st_ptr + SSL_ST_SERVER_APP_TRAFFIC_SECRET);
     ret = bpf_probe_read_user(&mastersecret->server_app_traffic_secret, sizeof(mastersecret->server_app_traffic_secret),
-                              (void *)sats_ptr_tls13);
+        (void *)sats_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_ST_SERVER_APP_TRAFFIC_SECRET failed, ret :%d\n", ret);
         return 0;
     }
 
     void *ems_ptr_tls13 = (void *)(ssl_st_ptr + SSL_ST_EXPORTER_MASTER_SECRET);
-    ret = bpf_probe_read_user(&mastersecret->exporter_master_secret, sizeof(mastersecret->exporter_master_secret),
-                              (void *)ems_ptr_tls13);
+    ret = bpf_probe_read_user(
+        &mastersecret->exporter_master_secret, sizeof(mastersecret->exporter_master_secret), (void *)ems_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_ST_EXPORTER_MASTER_SECRET failed, ret :%d\n", ret);
         return 0;
     }
     debug_bpf_printk("*****master_secret*****: %x %x %x\n", mastersecret->master_key[0], mastersecret->master_key[1],
-                     mastersecret->master_key[2]);
+        mastersecret->master_key[2]);
     bpf_perf_event_output(ctx, &mastersecret_events, BPF_F_CURRENT_CPU, mastersecret, sizeof(struct mastersecret_t));
     return 0;
 }

--- a/kern/openssl_masterkey_3.2.h
+++ b/kern/openssl_masterkey_3.2.h
@@ -30,6 +30,7 @@ struct mastersecret_t {
 
     // TLS 1.3
     u32 cipher_id;
+    u8 early_secret[EVP_MAX_MD_SIZE];
     u8 handshake_secret[EVP_MAX_MD_SIZE];
     u8 handshake_traffic_hash[EVP_MAX_MD_SIZE];
     u8 client_app_traffic_secret[EVP_MAX_MD_SIZE];
@@ -137,8 +138,8 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         return 0;
     }
     debug_bpf_printk("client_random: %x %x %x\n", client_random[0], client_random[1], client_random[2]);
-    ret = bpf_probe_read_kernel(&mastersecret->client_random, sizeof(mastersecret->client_random),
-                                (void *)&client_random);
+    ret = bpf_probe_read_kernel(
+        &mastersecret->client_random, sizeof(mastersecret->client_random), (void *)&client_random);
     if (ret) {
         debug_bpf_printk("bpf_probe_read_kernel ssl3_stat.client_random failed, ret :%d\n", ret);
         return 0;
@@ -168,10 +169,10 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
         }
 
         debug_bpf_printk("master_key: %x %x %x\n", mastersecret->master_key[0], mastersecret->master_key[1],
-                         mastersecret->master_key[2]);
+            mastersecret->master_key[2]);
 
-        bpf_perf_event_output(ctx, &mastersecret_events, BPF_F_CURRENT_CPU, mastersecret,
-                              sizeof(struct mastersecret_t));
+        bpf_perf_event_output(
+            ctx, &mastersecret_events, BPF_F_CURRENT_CPU, mastersecret, sizeof(struct mastersecret_t));
         return 0;
     }
 
@@ -211,17 +212,24 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
 
     //////////////////// TLS 1.3 master secret ////////////////////////
 
+    void *es_ptr_tls13 = (void *)(ssl_st_ptr + SSL_CONNECTION_ST_EARLY_SECRET);
+    ret = bpf_probe_read_user(&mastersecret->early_secret, sizeof(mastersecret->early_secret), (void *)es_ptr_tls13);
+    if (ret) {
+        debug_bpf_printk("bpf_probe_read SSL_ST_EARLY_SECRET failed, ret :%d\n", ret);
+        // If the read fails, it may be because TLS 1.3 early data is not enabled, so this error can be ignored
+    }
+
     void *hs_ptr_tls13 = (void *)(ssl_st_ptr + SSL_CONNECTION_ST_HANDSHAKE_SECRET);
-    ret = bpf_probe_read_user(&mastersecret->handshake_secret, sizeof(mastersecret->handshake_secret),
-                              (void *)hs_ptr_tls13);
+    ret = bpf_probe_read_user(
+        &mastersecret->handshake_secret, sizeof(mastersecret->handshake_secret), (void *)hs_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_CONNECTION_ST_HANDSHAKE_SECRET failed, ret :%d\n", ret);
         return 0;
     }
 
     void *hth_ptr_tls13 = (void *)(ssl_st_ptr + SSL_CONNECTION_ST_HANDSHAKE_TRAFFIC_HASH);
-    ret = bpf_probe_read_user(&mastersecret->handshake_traffic_hash, sizeof(mastersecret->handshake_traffic_hash),
-                              (void *)hth_ptr_tls13);
+    ret = bpf_probe_read_user(
+        &mastersecret->handshake_traffic_hash, sizeof(mastersecret->handshake_traffic_hash), (void *)hth_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_CONNECTION_ST_HANDSHAKE_TRAFFIC_HASH failed, ret :%d\n", ret);
         return 0;
@@ -229,7 +237,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
 
     void *cats_ptr_tls13 = (void *)(ssl_st_ptr + SSL_CONNECTION_ST_CLIENT_APP_TRAFFIC_SECRET);
     ret = bpf_probe_read_user(&mastersecret->client_app_traffic_secret, sizeof(mastersecret->client_app_traffic_secret),
-                              (void *)cats_ptr_tls13);
+        (void *)cats_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_CONNECTION_ST_CLIENT_APP_TRAFFIC_SECRET failed, ret :%d\n", ret);
         return 0;
@@ -237,21 +245,21 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
 
     void *sats_ptr_tls13 = (void *)(ssl_st_ptr + SSL_CONNECTION_ST_SERVER_APP_TRAFFIC_SECRET);
     ret = bpf_probe_read_user(&mastersecret->server_app_traffic_secret, sizeof(mastersecret->server_app_traffic_secret),
-                              (void *)sats_ptr_tls13);
+        (void *)sats_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_CONNECTION_ST_SERVER_APP_TRAFFIC_SECRET failed, ret :%d\n", ret);
         return 0;
     }
 
     void *ems_ptr_tls13 = (void *)(ssl_st_ptr + SSL_CONNECTION_ST_EXPORTER_MASTER_SECRET);
-    ret = bpf_probe_read_user(&mastersecret->exporter_master_secret, sizeof(mastersecret->exporter_master_secret),
-                              (void *)ems_ptr_tls13);
+    ret = bpf_probe_read_user(
+        &mastersecret->exporter_master_secret, sizeof(mastersecret->exporter_master_secret), (void *)ems_ptr_tls13);
     if (ret) {
         debug_bpf_printk("bpf_probe_read SSL_CONNECTION_ST_EXPORTER_MASTER_SECRET failed, ret :%d\n", ret);
         return 0;
     }
     debug_bpf_printk("*****master_secret*****: %x %x %x\n", mastersecret->master_key[0], mastersecret->master_key[1],
-                     mastersecret->master_key[2]);
+        mastersecret->master_key[2]);
     bpf_perf_event_output(ctx, &mastersecret_events, BPF_F_CURRENT_CPU, mastersecret, sizeof(struct mastersecret_t));
     return 0;
 }

--- a/kern/zsh_kern.c
+++ b/kern/zsh_kern.c
@@ -37,8 +37,8 @@ int uretprobe_zsh_zleentry(struct pt_regs *ctx) {
     event.pid = pid;
     event.uid = uid;
     event.type = ZSH_EVENT_TYPE_READLINE;
-    bpf_get_current_comm(&event.comm, sizeof(event.comm));   
-    bpf_probe_read_user(&event.line, sizeof(event.line),(void *)PT_REGS_RC(ctx));
+    bpf_get_current_comm(&event.comm, sizeof(event.comm));
+    bpf_probe_read_user(&event.line, sizeof(event.line), (void *)PT_REGS_RC(ctx));
     bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, &event, sizeof(struct event));
     return 0;
 }

--- a/pkg/util/hkdf/hkdf.go
+++ b/pkg/util/hkdf/hkdf.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	ResumptionBinderLabel         = "res binder"
-	ClientEarlySecretLabel = "c e traffic"
+	ClientEarlySecretLabel        = "c e traffic"
 	ClientHandshakeTrafficLabel   = "c hs traffic"
 	ServerHandshakeTrafficLabel   = "s hs traffic"
 	ClientApplicationTrafficLabel = "c ap traffic"

--- a/pkg/util/hkdf/hkdf.go
+++ b/pkg/util/hkdf/hkdf.go
@@ -36,6 +36,7 @@ import (
 
 const (
 	ResumptionBinderLabel         = "res binder"
+	ClientEarlySecretLabel = "c e traffic"
 	ClientHandshakeTrafficLabel   = "c hs traffic"
 	ServerHandshakeTrafficLabel   = "s hs traffic"
 	ClientApplicationTrafficLabel = "c ap traffic"

--- a/user/event/event_masterkey.go
+++ b/user/event/event_masterkey.go
@@ -42,6 +42,7 @@ type MasterSecretEvent struct {
 
 	// TLS 1.3
 	CipherId               uint32             `json:"cipherId"`               // Cipher ID
+	EarlyTrafficSecret     [EvpMaxMdSize]byte `json:"earlyTrafficSecret"`     // CLIENT_EARLY_TRAFFIC_SECRET
 	HandshakeSecret        [EvpMaxMdSize]byte `json:"handshakeSecret"`        // Handshake Secret
 	HandshakeTrafficHash   [EvpMaxMdSize]byte `json:"handshakeTrafficHash"`   // Handshake Traffic Hash
 	ClientAppTrafficSecret [EvpMaxMdSize]byte `json:"clientAppTrafficSecret"` // Client App Traffic Secret
@@ -62,6 +63,9 @@ func (mse *MasterSecretEvent) Decode(payload []byte) (err error) {
 		return
 	}
 	if err = binary.Read(buf, binary.LittleEndian, &mse.CipherId); err != nil {
+		return
+	}
+	if err = binary.Read(buf, binary.LittleEndian, &mse.EarlyTrafficSecret); err != nil {
 		return
 	}
 	if err = binary.Read(buf, binary.LittleEndian, &mse.HandshakeSecret); err != nil {

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -534,6 +534,12 @@ func (m *MOpenSSLProbe) saveMasterSecret(secretEvent *event.MasterSecretEvent) {
 		}
 		m.masterKeys[k] = true
 
+		if !m.mk12NullSecrets(length, secretEvent.EarlyTrafficSecret[:]) {
+			b.WriteString(fmt.Sprintf("%s %02x %02x\n",
+				hkdf.KeyLogLabelClientEarlyTafficSecret, secretEvent.ClientRandom, secretEvent.EarlyTrafficSecret[:length]))
+			return
+		}
+
 		b.WriteString(fmt.Sprintf("%s %02x %02x\n",
 			hkdf.KeyLogLabelServerHandshake, secretEvent.ClientRandom, serverHandshakeSecret))
 
@@ -639,14 +645,14 @@ func (m *MOpenSSLProbe) saveMasterSecretBSSL(secretEvent *event.MasterSecretBSSL
 }
 
 func (m *MOpenSSLProbe) bSSLEvent12NullSecrets(e *event.MasterSecretBSSLEvent) bool {
-	return m.mk12NullSecrets(int(e.HashLen), e.Secret)
+	return m.mk12NullSecrets(int(e.HashLen), e.Secret[:])
 }
 
 func (m *MOpenSSLProbe) oSSLEvent12NullSecrets(hashLen int, e *event.MasterSecretEvent) bool {
-	return m.mk12NullSecrets(hashLen, e.MasterKey)
+	return m.mk12NullSecrets(hashLen, e.MasterKey[:])
 }
 
-func (m *MOpenSSLProbe) mk12NullSecrets(hashLen int, secret [48]byte) bool {
+func (m *MOpenSSLProbe) mk12NullSecrets(hashLen int, secret []byte) bool {
 	isNull := true
 	for i := 0; i < hashLen; i++ {
 		if hashLen > len(secret) {

--- a/utils/gnutls_offset.c
+++ b/utils/gnutls_offset.c
@@ -2,25 +2,25 @@
 // configure
 // clang -I gnulib/lib/ -I lib/ -I . gnutls_offset.c -o offset
 
-#include <stddef.h>
-#include <stdio.h>
 #include <config.h>
 #include <lib/gnutls_int.h>
+#include <stddef.h>
+#include <stdio.h>
 
-#define SSL_STRUCT_OFFSETS                                      \
-    X(gnutls_session_int, security_parameters)                  \
-    X(gnutls_session_int, security_parameters.prf)              \
-    X(mac_entry_st, id)                                         \
-    X(gnutls_session_int, security_parameters.client_random)    \
-    X(gnutls_session_int, security_parameters.master_secret)    \
-    X(gnutls_session_int, key.proto.tls13.hs_ckey)              \
-    X(gnutls_session_int, key.proto.tls13.hs_skey)              \
-    X(gnutls_session_int, key.proto.tls13.ap_ckey)              \
-    X(gnutls_session_int, key.proto.tls13.ap_skey)              \
+#define SSL_STRUCT_OFFSETS                                   \
+    X(gnutls_session_int, security_parameters)               \
+    X(gnutls_session_int, security_parameters.prf)           \
+    X(mac_entry_st, id)                                      \
+    X(gnutls_session_int, security_parameters.client_random) \
+    X(gnutls_session_int, security_parameters.master_secret) \
+    X(gnutls_session_int, key.proto.tls13.hs_ckey)           \
+    X(gnutls_session_int, key.proto.tls13.hs_skey)           \
+    X(gnutls_session_int, key.proto.tls13.ap_ckey)           \
+    X(gnutls_session_int, key.proto.tls13.ap_skey)           \
     X(gnutls_session_int, key.proto.tls13.ap_expkey)
 
-#define SSL_ANY_STRUCT_OFFSETS                                  \
-    Y(security_parameters_st, pversion)                         \
+#define SSL_ANY_STRUCT_OFFSETS          \
+    Y(security_parameters_st, pversion) \
     Y(version_entry_st, id)
 
 void toUpper(char *s) {
@@ -44,9 +44,7 @@ void format(char *struct_name, char *field_name, size_t offset) {
     printf(" 0x%lx\n\n", offset);
 }
 
-
 int main() {
-
 #define X(struct_name, field_name) format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
     SSL_STRUCT_OFFSETS
 #undef X

--- a/utils/openssl_1_1_1_offset.c
+++ b/utils/openssl_1_1_1_offset.c
@@ -27,6 +27,7 @@
     X(ssl_session_st, cipher)            \
     X(ssl_session_st, cipher_id)         \
     X(ssl_cipher_st, id)                 \
+    X(ssl_st, early_secret)              \
     X(ssl_st, handshake_secret)          \
     X(ssl_st, handshake_traffic_hash)    \
     X(ssl_st, client_app_traffic_secret) \

--- a/utils/openssl_3_0_offset.c
+++ b/utils/openssl_3_0_offset.c
@@ -17,6 +17,7 @@
     X(ssl_session_st, cipher)            \
     X(ssl_session_st, cipher_id)         \
     X(ssl_cipher_st, id)                 \
+    X(ssl_st, early_secret)              \
     X(ssl_st, handshake_secret)          \
     X(ssl_st, handshake_traffic_hash)    \
     X(ssl_st, client_app_traffic_secret) \

--- a/utils/openssl_3_2_0_offset.c
+++ b/utils/openssl_3_2_0_offset.c
@@ -1,10 +1,10 @@
 // clang -I include/ -I . offset.c -o offset
 #include <crypto/bio/bio_local.h>
+#include <ctype.h>
 #include <openssl/crypto.h>
 #include <ssl/ssl_local.h>
 #include <stddef.h>
 #include <stdio.h>
-#include <ctype.h>
 
 #define SSL_STRUCT_OFFSETS                          \
     X(ssl_st, type)                                 \

--- a/utils/openssl_3_2_0_offset.c
+++ b/utils/openssl_3_2_0_offset.c
@@ -19,6 +19,7 @@
     X(ssl_session_st, cipher)                       \
     X(ssl_session_st, cipher_id)                    \
     X(ssl_cipher_st, id)                            \
+    X(ssl_connection_st, early_secret)              \
     X(ssl_connection_st, handshake_secret)          \
     X(ssl_connection_st, handshake_traffic_hash)    \
     X(ssl_connection_st, client_app_traffic_secret) \

--- a/utils/openssl_3_5_0_offset.c
+++ b/utils/openssl_3_5_0_offset.c
@@ -1,11 +1,11 @@
 // clang -I include/ -I . offset.c -o offset
 #include <crypto/bio/bio_local.h>
+#include <ctype.h>
 #include <openssl/crypto.h>
 #include <ssl/quic/quic_local.h>
 #include <ssl/ssl_local.h>
 #include <stddef.h>
 #include <stdio.h>
-#include <ctype.h>
 
 #define SSL_STRUCT_OFFSETS                          \
     X(ssl_st, type)                                 \

--- a/utils/openssl_3_5_0_offset.c
+++ b/utils/openssl_3_5_0_offset.c
@@ -20,6 +20,7 @@
     X(ssl_session_st, cipher)                       \
     X(ssl_session_st, cipher_id)                    \
     X(ssl_cipher_st, id)                            \
+    X(ssl_connection_st, early_secret)              \
     X(ssl_connection_st, handshake_secret)          \
     X(ssl_connection_st, handshake_traffic_hash)    \
     X(ssl_connection_st, client_app_traffic_secret) \

--- a/utils/openssl_offset_1.0.2.sh
+++ b/utils/openssl_offset_1.0.2.sh
@@ -76,6 +76,7 @@ function run() {
     echo -e "#define ECAPTURE_${header_define}\n" >>${header_file}
     ./offset >>${header_file}
     echo -e "// openssl 1.0.2 does not support TLS 1.3, set 0 default" >>${header_file}
+    echo -e "#define SSL_ST_EARLY_SECRET 0" >>${header_file}
     echo -e "#define SSL_ST_HANDSHAKE_SECRET 0" >>${header_file}
     echo -e "#define SSL_ST_HANDSHAKE_TRAFFIC_HASH 0" >>${header_file}
     echo -e "#define SSL_ST_CLIENT_APP_TRAFFIC_SECRET 0" >>${header_file}

--- a/utils/openssl_offset_1.1.0.sh
+++ b/utils/openssl_offset_1.1.0.sh
@@ -66,6 +66,7 @@ function run() {
     echo -e "#define ECAPTURE_${header_define}\n" >>${header_file}
     ./offset >>${header_file}
     echo -e "// openssl 1.1.0 does not support TLS 1.3, set 0 default" >>${header_file}
+    echo -e "#define SSL_ST_EARLY_SECRET 0" >>${header_file}
     echo -e "#define SSL_ST_HANDSHAKE_SECRET 0" >>${header_file}
     echo -e "#define SSL_ST_HANDSHAKE_TRAFFIC_HASH 0" >>${header_file}
     echo -e "#define SSL_ST_CLIENT_APP_TRAFFIC_SECRET 0" >>${header_file}

--- a/utils/openssl_offset_1.1.1.sh
+++ b/utils/openssl_offset_1.1.1.sh
@@ -90,7 +90,7 @@ function run() {
     ./offset >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey.h\"" >>${header_file}
-    echo -e "\n#endif" >>${header_file}
+    echo -e "#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_3.0.sh
+++ b/utils/openssl_offset_3.0.sh
@@ -75,7 +75,7 @@ function run() {
     ./offset >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey_3.0.h\"" >>${header_file}
-    echo -e "\n#endif" >>${header_file}
+    echo -e "#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_3.1.sh
+++ b/utils/openssl_offset_3.1.sh
@@ -69,7 +69,7 @@ function run() {
     ./offset >>${header_file}
     echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey_3.0.h\"" >>${header_file}
-    echo -e "\n#endif" >>${header_file}
+    echo -e "#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_3.2.sh
+++ b/utils/openssl_offset_3.2.sh
@@ -61,9 +61,9 @@ function run() {
     echo -e "#define SSL_ST_VERSION SSL_CONNECTION_ST_VERSION\n" >>${header_file}
     echo -e "#define SSL_ST_WBIO SSL_CONNECTION_ST_WBIO\n" >>${header_file}
     echo -e "#define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO\n" >>${header_file}
-    echo -e "\n#include \"openssl.h\"" >>${header_file}
+    echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey_3.2.h\"" >>${header_file}
-    echo -e "\n#endif" >>${header_file}
+    echo -e "#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_3.3.sh
+++ b/utils/openssl_offset_3.3.sh
@@ -61,9 +61,9 @@ function run() {
     echo -e "#define SSL_ST_VERSION SSL_CONNECTION_ST_VERSION\n" >>${header_file}
     echo -e "#define SSL_ST_WBIO SSL_CONNECTION_ST_WBIO\n" >>${header_file}
     echo -e "#define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO\n" >>${header_file}
-    echo -e "\n#include \"openssl.h\"" >>${header_file}
+    echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey_3.2.h\"" >>${header_file}
-    echo -e "\n#endif" >>${header_file}
+    echo -e "#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_3.4.sh
+++ b/utils/openssl_offset_3.4.sh
@@ -60,9 +60,9 @@ function run() {
     echo -e "#define SSL_ST_VERSION SSL_CONNECTION_ST_VERSION\n" >>${header_file}
     echo -e "#define SSL_ST_WBIO SSL_CONNECTION_ST_WBIO\n" >>${header_file}
     echo -e "#define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO\n" >>${header_file}
-    echo -e "\n#include \"openssl.h\"" >>${header_file}
+    echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey_3.2.h\"" >>${header_file}
-    echo -e "\n#endif" >>${header_file}
+    echo -e "#endif" >>${header_file}
 
     # clean up
     make clean

--- a/utils/openssl_offset_3.5.sh
+++ b/utils/openssl_offset_3.5.sh
@@ -57,9 +57,9 @@ function run() {
     echo -e "#define SSL_ST_VERSION SSL_CONNECTION_ST_VERSION\n" >>${header_file}
     echo -e "#define SSL_ST_WBIO SSL_CONNECTION_ST_WBIO\n" >>${header_file}
     echo -e "#define SSL_ST_RBIO SSL_CONNECTION_ST_RBIO\n" >>${header_file}
-    echo -e "\n#include \"openssl.h\"" >>${header_file}
+    echo -e "#include \"openssl.h\"" >>${header_file}
     echo -e "#include \"openssl_masterkey_3.2.h\"" >>${header_file}
-    echo -e "\n#endif" >>${header_file}
+    echo -e "#endif" >>${header_file}
 
     # clean up
     make clean

--- a/variables.mk
+++ b/variables.mk
@@ -35,7 +35,7 @@ CMD_ECHO ?= echo
 
 KERNEL_LESS_5_2_PREFIX ?= _less52.o
 BYTECODE_FILES ?= all
-STYLE    ?= "{BasedOnStyle: Google, IndentWidth: 4, TabWidth: 4, UseTab: Never, ColumnLimit: 120}"
+STYLE    ?= "{BasedOnStyle: Google, IndentWidth: 4, TabWidth: 4, UseTab: Never, ColumnLimit: 120, AlignAfterOpenBracket: DontAlign, BinPackArguments: true, BreakStringLiterals: false}"
 IGNORE_LESS52 ?=
 AUTOGENCMD ?=
 BPFHEADER := -I ./kern
@@ -277,10 +277,6 @@ RPM_SOURCE0 = $(ECAPTURE_NAME)-$(TAG).tar.gz
 #
 
 OUTPUT_DIR = ./bin
-#TAR_DIR = ecapture-$(DEB_VERSION)-linux-$(GOARCH)
-#TAR_DIR_NOCORE = ecapture-$(DEB_VERSION)-linux-$(GOARCH)-nocore
-#TAR_DIR_ANDROID = ecapture-$(DEB_VERSION)-android-$(GOARCH)
-#TAR_DIR_ANDROID_NOCORE = ecapture-$(DEB_VERSION)-android-$(GOARCH)-nocore
 
 # from CLI args.
 RELEASE_NOTES ?= release_notes.txt
@@ -300,8 +296,4 @@ BUILD_DIR = build
 # Create a release snapshot
 #
 
-#OUT_ARCHIVE := $(OUTPUT_DIR)/$(TAR_DIR).tar.gz
-#OUT_ARCHIVE_NOCORE := $(OUTPUT_DIR)/$(TAR_DIR_NOCORE).tar.gz
-#OUT_ARCHIVE_ANDROID := $(OUTPUT_DIR)/$(TAR_DIR_ANDROID).tar.gz
-#OUT_ARCHIVE_ANDROID_NOCORE := $(OUTPUT_DIR)/$(TAR_DIR_ANDROID_NOCORE).tar.gz
 OUT_CHECKSUMS := checksum-$(DEB_VERSION).txt


### PR DESCRIPTION
This pull request introduces support for the `early_secret` field across various OpenSSL versions and updates related structures and utilities to reflect this addition. The changes ensure compatibility with different OpenSSL versions and enhance the ability to capture and process TLS 1.3 secrets.

### Addition of `early_secret` field in OpenSSL version-specific kernel files:

* Added `SSL_ST_EARLY_SECRET` and `SSL_CONNECTION_ST_EARLY_SECRET` definitions to support the `early_secret` field for OpenSSL versions 1.1.1a, 1.1.1b, 1.1.1d, 1.1.1j, 3.0.0, 3.1.0, 3.2.0, 3.2.3, 3.2.4, 3.3.0, 3.3.2, 3.3.3, 3.4.0, 3.4.1, and 3.5.0. [[1]](diffhunk://#diff-abd2feb19ee11bd79e4e96a9565eb06a3e0c49b823a4eccc2b412f66338c2311R40-R42) [[2]](diffhunk://#diff-b4dc2ba984a85fe8e715eeb41f849f1cffe311d01b2bfafc2e0649163ee1c774R40-R42) [[3]](diffhunk://#diff-be77df159e312dab0c4554cbac0bd22b4a36ace4ceec599b9b25db9a5fe2b276R40-R42) [[4]](diffhunk://#diff-dd306767250e60403ec9c508886aedd31bf4c448c502f1df96b2a539de61f727R40-R42) [[5]](diffhunk://#diff-58caa640c9beb7267e7a6b14fd87bf0b57388ae1521f21d3030c769e985c316eR40-R42) [[6]](diffhunk://#diff-4603e3cd34b456968051b93889fed36061a152cc99f3effe7544e5e8a2b34da3R40-R42) [[7]](diffhunk://#diff-71cbc90cee176bdffa33328c0a5c13d39f8144b4a109dda99169bfa8cc338073R43-R45) [[8]](diffhunk://#diff-1111c232f04b5037a1f42c6c02866b3da9a572579ffea1f13da876c092d73f63R43-R45) [[9]](diffhunk://#diff-bbd7d511f11e1e09fab6f5086a192fc6722135e9664090a59cf814399f0c3420R43-R45) [[10]](diffhunk://#diff-196e9f4e1a7ee39fb512a64a3e18d5da4c0411b3cb74de7af6158e3cc6145e13R43-R45) [[11]](diffhunk://#diff-f47697f1051f8aafd4f5b1defd3282e80e1c0405791ca586e2d314584000b4ebR43-R45) [[12]](diffhunk://#diff-ecbe2f50d238fdc5ccab9246937cf97cda96808d6af60e6c97d42a53c88d4231R43-R45) [[13]](diffhunk://#diff-011ff8983da6a02752d5aa818932373cef4d47f085a5822c3f27dcc987d25d16R43-R45) [[14]](diffhunk://#diff-c271ce1e953a752d46d9e04df96d159e23cb5d2035b06a41c73ae58b73aa96f5R43-R45) [[15]](diffhunk://#diff-722a988e5f23cc9e9a1c3988cb2976be7600fa577db37b7028d122fa1d3e878cR43-R45)

### Updates to OpenSSL utilities:

* Added `early_secret` field references in utility files for offset calculations, including `utils/openssl_1_1_1_offset.c`, `utils/openssl_3_0_offset.c`, `utils/openssl_3_2_0_offset.c`, and `utils/openssl_3_5_0_offset.c`. [[1]](diffhunk://#diff-d53bc54324c0b15595bc4c13c9e4866b74269cd5eef596799d0acec0eb185d88R30) [[2]](diffhunk://#diff-e9810c35f3b676b4028e7b51912977ce1d79435f33012d56844ffadb32a65464R20) [[3]](diffhunk://#diff-6c627eb813e0fc4dd5c53fba832f7605bc7dbf23dff3de5e23221213758c40a6R22) [[4]](diffhunk://#diff-2140d0a8bbc4d39aa9aba8fd7d763a2961f9a6f6e5b9986de12f3a3967403e62R23)

### Structural changes to support `early_secret`:

* Updated `struct mastersecret_t` in `kern/openssl_masterkey.h` to include the `early_secret` field for TLS 1.3 support.

### Version update in OpenSSL 3.1.0 kernel file:

* Updated version-related macros in `kern/openssl_3_1_0_kern.c` to reflect OpenSSL 3.1.8 (previously 3.1.7).

### Minor formatting adjustments:

* Added spacing and formatting changes in `kern/openssl_3_2_0_kern.c` and `kern/openssl_3_2_3_kern.c` for consistency. [[1]](diffhunk://#diff-71cbc90cee176bdffa33328c0a5c13d39f8144b4a109dda99169bfa8cc338073R79) [[2]](diffhunk://#diff-1111c232f04b5037a1f42c6c02866b3da9a572579ffea1f13da876c092d73f63R79)