### PR TITLE
http2: share same hpack decoder for one tuple connect #744

### DIFF
--- a/pkg/event_processor/http2_response.go
+++ b/pkg/event_processor/http2_response.go
@@ -50,6 +50,7 @@ type HTTP2Response struct {
 	isInit     bool
 	reader     *bytes.Buffer
 	bufReader  *bufio.Reader
+	hdec       *hpack.Decoder
 }
 
 func (h2r *HTTP2Response) detect(payload []byte) error {
@@ -90,6 +91,13 @@ func (h2r *HTTP2Response) Init() {
 	h2r.reader = bytes.NewBuffer(nil)
 	h2r.bufReader = bufio.NewReader(h2r.reader)
 	h2r.framer = http2.NewFramer(nil, h2r.bufReader)
+	/*
+		one tuple connect should share the same dynamic table
+		https://datatracker.ietf.org/doc/html/rfc7541#section-2.2
+	*/
+	if h2r.hdec == nil {
+		h2r.hdec = hpack.NewDecoder(4096, nil)
+	}
 }
 
 func (h2r *HTTP2Response) Write(b []byte) (int, error) {
@@ -124,7 +132,6 @@ func (h2r *HTTP2Response) Display() []byte {
 	encodingMap := make(map[uint32]string)
 	dataBufMap := make(map[uint32]*bytes.Buffer)
 	frameBuf := bytes.NewBufferString("")
-	hdec := hpack.NewDecoder(4096, nil)
 	for {
 		f, err := h2r.framer.ReadFrame()
 		if err != nil {
@@ -138,7 +145,7 @@ func (h2r *HTTP2Response) Display() []byte {
 			streamID := f.StreamID
 			frameBuf.WriteString(fmt.Sprintf("\nFrame Type\t=>\tHEADERS\nFrame StreamID\t=>\t%d\nFrame Length\t=>\t%d\n", streamID, f.Length))
 			if f.HeadersEnded() {
-				fields, err := hdec.DecodeFull(f.HeaderBlockFragment())
+				fields, err := h2r.hdec.DecodeFull(f.HeaderBlockFragment())
 				for _, header := range fields {
 					frameBuf.WriteString(fmt.Sprintf("%s\n", header.String()))
 					if header.Name == "content-encoding" {
@@ -146,10 +153,10 @@ func (h2r *HTTP2Response) Display() []byte {
 					}
 				}
 				if err != nil {
-					frameBuf.WriteString("Incorrect HPACK context, Please use PCAP mode to get correct header fields ...\n")
+					frameBuf.WriteString("[http2 response] Incorrect HPACK context, Please use PCAP mode to get correct header fields ...\n")
 				}
 			} else {
-				frameBuf.WriteString("Not Supported HEADERS Frame with CONTINUATION frames\n")
+				frameBuf.WriteString("[http2 response] Not Supported HEADERS Frame with CONTINUATION frames\n")
 			}
 		case *http2.DataFrame:
 			streamID := f.StreamID

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -84,6 +84,7 @@ type SSLDataEvent struct {
 	Version   int32             `json:"version"`
 	Tuple     string
 	BioType   uint32
+	Sock      uint64
 }
 
 func (se *SSLDataEvent) Decode(payload []byte) (err error) {
@@ -131,7 +132,8 @@ func commStr(comm []byte) string {
 }
 
 func (se *SSLDataEvent) GetUUID() string {
-	return fmt.Sprintf("%d_%d_%s_%d_%d_%s", se.Pid, se.Tid, commStr(se.Comm[:]), se.Fd, se.DataType, se.Tuple)
+	//uuid: sock:Pid_Tid_Comm_Fd_DataType_Tuple_Sock
+	return fmt.Sprintf("%s%d_%d_%s_%d_%d_%s_%d", SocketLifecycleUUIDPrefix, se.Pid, se.Tid, commStr(se.Comm[:]), se.Fd, se.DataType, se.Tuple, se.Sock)
 }
 
 func (se *SSLDataEvent) Payload() []byte {

--- a/user/event/ievent.go
+++ b/user/event/ievent.go
@@ -27,7 +27,7 @@ const (
 	EventTypeEventProcessor
 )
 
-const SocketLifecycleUUIDPrefix = "sock"
+const SocketLifecycleUUIDPrefix = "sock:"
 
 type IEventStruct interface {
 	Decode(payload []byte) (err error)

--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -424,6 +424,10 @@ func (m *MOpenSSLProbe) DestroyConn(sock uint64) {
 	m.pidLocker.Lock()
 	defer m.pidLocker.Unlock()
 
+	if sock > 0 {
+		m.processor.WriteDestroyConn(sock)
+	}
+
 	pidFd, ok := m.sock2pidFd[sock]
 	if !ok {
 		return
@@ -441,16 +445,15 @@ func (m *MOpenSSLProbe) DestroyConn(sock uint64) {
 	if ok {
 		//add sock consistency check to void tuple miss
 		if connInfo.sock != sock {
-			m.logger.Debug().Uint32("fd", fd).Uint64("sock", sock).Uint64("storedSock", connInfo.sock).Msg("DestroyConn skip")
+			m.logger.Debug().Uint32("pid", pid).Uint32("fd", fd).Uint64("sock", sock).Uint64("storedSock", connInfo.sock).Msg("DestroyConn skip")
 			return
 		}
 		delete(connMap, fd)
 		if len(connMap) == 0 {
 			delete(m.pidConns, pid)
 		}
+		m.logger.Debug().Uint32("pid", pid).Uint32("fd", fd).Uint64("sock", sock).Str("tuple", connInfo.tuple).Msg("DestroyConn success")
 	}
-
-	m.logger.Debug().Uint32("pid", pid).Uint32("fd", fd).Uint64("sock", sock).Str("tuple", connInfo.tuple).Msg("DestroyConn success")
 }
 
 // DelConn process exit :fd is 0 , delete all pid map
@@ -463,22 +466,22 @@ func (m *MOpenSSLProbe) DelConn(sock uint64) {
 	})
 }
 
-func (m *MOpenSSLProbe) GetConn(pid, fd uint32) string {
+func (m *MOpenSSLProbe) GetConn(pid, fd uint32) *ConnInfo {
 	if fd <= 0 {
-		return ConnNotFound
+		return nil
 	}
 	m.logger.Debug().Uint32("pid", pid).Uint32("fd", fd).Msg("GetConn")
 	m.pidLocker.Lock()
 	defer m.pidLocker.Unlock()
 	connMap, f := m.pidConns[pid]
 	if !f {
-		return ConnNotFound
+		return nil
 	}
 	connInfo, f := connMap[fd]
 	if !f {
-		return ConnNotFound
+		return nil
 	}
-	return connInfo.tuple
+	return &connInfo
 }
 
 func (m *MOpenSSLProbe) saveMasterSecret(secretEvent *event.MasterSecretEvent) {
@@ -762,12 +765,15 @@ func (m *MOpenSSLProbe) dumpSslData(eventStruct *event.SSLDataEvent) {
 		m.logger.Error().Uint32("pid", eventStruct.Pid).Uint32("fd", eventStruct.Fd).Str("tuple", eventStruct.Tuple).Msg("SSLDataEvent's fd is 0")
 		//return
 	}
-	tuple := m.GetConn(eventStruct.Pid, eventStruct.Fd)
-	m.logger.Debug().Uint32("pid", eventStruct.Pid).Uint32("bio_type", eventStruct.BioType).Uint32("fd", eventStruct.Fd).Str("tuple", tuple).Msg("SSLDataEvent")
-	if tuple == ConnNotFound {
+	connInfo := m.GetConn(eventStruct.Pid, eventStruct.Fd)
+	if connInfo == nil {
 		eventStruct.Tuple = DefaultTuple
+		eventStruct.Sock = 0
 	} else {
-		eventStruct.Tuple = tuple
+		m.logger.Debug().Uint32("pid", eventStruct.Pid).Uint32("bio_type", eventStruct.BioType).Uint32("fd", eventStruct.Fd).
+			Uint64("sock", connInfo.sock).Str("tuple", connInfo.tuple).Msg("SSLDataEvent")
+		eventStruct.Tuple = connInfo.tuple
+		eventStruct.Sock = connInfo.sock
 	}
 
 	m.logger.Info().Msg(eventStruct.BaseInfo())


### PR DESCRIPTION
1. Support two lifecycle manager modes for eventWorker run: a. LifeCycleStateSock: The worker runs continuously until the associated socket is destory.  All incoming playloads share one `parser` b. LifeCycleStateDefault: The worker performs `delWorkerByUUID` and `drainAndClose` after a single timeout
2. HTTP2 steams from same tuple share same hpack decoder