### PR TITLE
fix: keylog lost in openssl

### DIFF
--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -537,7 +537,6 @@ func (m *MOpenSSLProbe) saveMasterSecret(secretEvent *event.MasterSecretEvent) {
 		if !m.mk12NullSecrets(length, secretEvent.EarlyTrafficSecret[:]) {
 			b.WriteString(fmt.Sprintf("%s %02x %02x\n",
 				hkdf.KeyLogLabelClientEarlyTafficSecret, secretEvent.ClientRandom, secretEvent.EarlyTrafficSecret[:length]))
-			return
 		}
 
 		b.WriteString(fmt.Sprintf("%s %02x %02x\n",


### PR DESCRIPTION
fix: keylog lost in openssl.

Before:
```
./ecapture tls -m keylog --libssl=/usr/local/openresty/openssl111/lib/libssl.so
2025-06-20T09:54:07+08:00 INF AppName="eCapture(旁观者)"
2025-06-20T09:54:07+08:00 INF HomePage=https://ecapture.cc
2025-06-20T09:54:07+08:00 INF Repository=https://github.com/gojue/ecapture
2025-06-20T09:54:07+08:00 INF Author="CFC4N <cfc4ncs@gmail.com>"
2025-06-20T09:54:07+08:00 INF Description="Capturing SSL/TLS plaintext without a CA certificate using eBPF. Supported on Linux/Android kernels for amd64/arm64."
2025-06-20T09:54:07+08:00 INF Version=linux_amd64:-20250618-9cd91ad:6.1.0-22-amd64
2025-06-20T09:54:07+08:00 INF Listen=localhost:28256
2025-06-20T09:54:07+08:00 INF eCapture running logs logger=
2025-06-20T09:54:07+08:00 INF the file handler that receives the captured event eventCollector=
2025-06-20T09:54:07+08:00 INF Kernel Info=6.1.0 Pid=3982120
2025-06-20T09:54:07+08:00 INF TruncateSize=0 Unit=bytes
2025-06-20T09:54:07+08:00 INF listen=localhost:28256
2025-06-20T09:54:07+08:00 INF https server starting...You can upgrade the configuration file via the HTTP interface.
2025-06-20T09:54:07+08:00 INF BTF bytecode mode: CORE. btfMode=0
2025-06-20T09:54:07+08:00 INF master key keylogger has been set. eBPFProgramType=KeyLog keylogger=ecapture_openssl_key.log
2025-06-20T09:54:07+08:00 INF module initialization. isReload=false moduleName=EBPFProbeOPENSSL
2025-06-20T09:54:07+08:00 INF Module.Run()
2025-06-20T09:54:07+08:00 INF origin versionKey="openssl 1.1.1w" versionKeyLower="openssl 1.1.1w"
2025-06-20T09:54:07+08:00 INF OpenSSL/BoringSSL version found Android=false library version="openssl 1.1.1w"
2025-06-20T09:54:07+08:00 INF HOOK type:Openssl elf ElfType=2 binrayPath=/usr/local/openresty/openssl111/lib/libssl.so masterHookFuncs=["SSL_get_wbio","SSL_in_before","SSL_do_handshake"]
2025-06-20T09:54:07+08:00 INF target all process.
2025-06-20T09:54:07+08:00 INF target all users.
2025-06-20T09:54:07+08:00 INF setupManagers eBPFProgramType=KeyLog
2025-06-20T09:54:07+08:00 INF BPF bytecode file is matched. bpfFileName=user/bytecode/openssl_1_1_1j_kern_core.o
2025-06-20T09:54:07+08:00 INF perfEventReader created mapSize(MB)=4
2025-06-20T09:54:07+08:00 INF module started successfully. isReload=false moduleName=EBPFProbeOPENSSL
2025-06-20T09:54:08+08:00 INF non-TLSv1.3 cipher suite found CLientRandom=f1e67d7d52f8df60fca8e428432849a6a50cbbab843509438aa9f97d690b0f86 CipherId=0
2025-06-20T09:54:08+08:00 INF non-TLSv1.3 cipher suite found CLientRandom=f1e67d7d52f8df60fca8e428432849a6a50cbbab843509438aa9f97d690b0f86 CipherId=0
^C2025-06-20T09:54:24+08:00 INF Module closed,message Received from Context
2025-06-20T09:54:24+08:00 INF module close.
2025-06-20T09:54:25+08:00 INF iModule module close
2025-06-20T09:54:25+08:00 INF bye bye.
```

After:
```
./ecapture tls -m keylog --libssl=/usr/local/openresty/openssl111/lib/libssl.so
2025-06-20T09:56:30+08:00 INF AppName="eCapture(旁观者)"
2025-06-20T09:56:30+08:00 INF HomePage=https://ecapture.cc
2025-06-20T09:56:30+08:00 INF Repository=https://github.com/gojue/ecapture
2025-06-20T09:56:30+08:00 INF Author="CFC4N <cfc4ncs@gmail.com>"
2025-06-20T09:56:30+08:00 INF Description="Capturing SSL/TLS plaintext without a CA certificate using eBPF. Supported on Linux/Android kernels for amd64/arm64."
2025-06-20T09:56:30+08:00 INF Version=linux_amd64:-20250618-9cd91ad:6.1.0-22-amd64
2025-06-20T09:56:30+08:00 INF Listen=localhost:28256
2025-06-20T09:56:30+08:00 INF eCapture running logs logger=
2025-06-20T09:56:30+08:00 INF the file handler that receives the captured event eventCollector=
2025-06-20T09:56:30+08:00 INF Kernel Info=6.1.0 Pid=3982615
2025-06-20T09:56:30+08:00 INF TruncateSize=0 Unit=bytes
2025-06-20T09:56:30+08:00 INF BTF bytecode mode: CORE. btfMode=0
2025-06-20T09:56:30+08:00 INF master key keylogger has been set. eBPFProgramType=KeyLog keylogger=ecapture_openssl_key.log
2025-06-20T09:56:30+08:00 INF module initialization. isReload=false moduleName=EBPFProbeOPENSSL
2025-06-20T09:56:30+08:00 INF Module.Run()
2025-06-20T09:56:30+08:00 INF origin versionKey="openssl 1.1.1w" versionKeyLower="openssl 1.1.1w"
2025-06-20T09:56:30+08:00 INF OpenSSL/BoringSSL version found Android=false library version="openssl 1.1.1w"
2025-06-20T09:56:30+08:00 INF HOOK type:Openssl elf ElfType=2 binrayPath=/usr/local/openresty/openssl111/lib/libssl.so masterHookFuncs=["SSL_get_wbio","SSL_in_before","SSL_do_handshake"]
2025-06-20T09:56:30+08:00 INF target all process.
2025-06-20T09:56:30+08:00 INF target all users.
2025-06-20T09:56:30+08:00 INF setupManagers eBPFProgramType=KeyLog
2025-06-20T09:56:30+08:00 INF BPF bytecode file is matched. bpfFileName=user/bytecode/openssl_1_1_1j_kern_core.o
2025-06-20T09:56:30+08:00 INF listen=localhost:28256
2025-06-20T09:56:30+08:00 INF https server starting...You can upgrade the configuration file via the HTTP interface.
2025-06-20T09:56:30+08:00 INF perfEventReader created mapSize(MB)=4
2025-06-20T09:56:30+08:00 INF module started successfully. isReload=false moduleName=EBPFProbeOPENSSL
2025-06-20T09:56:39+08:00 INF non-TLSv1.3 cipher suite found CLientRandom=6fba09c4601e2d749ef3089e3c4a0fd21fb86fe0d4c3dd41e50330da74e40828 CipherId=0
2025-06-20T09:56:39+08:00 INF non-TLSv1.3 cipher suite found CLientRandom=6fba09c4601e2d749ef3089e3c4a0fd21fb86fe0d4c3dd41e50330da74e40828 CipherId=0
2025-06-20T09:56:40+08:00 INF CLIENT_RANDOM save success CLientRandom=6fba09c4601e2d749ef3089e3c4a0fd21fb86fe0d4c3dd41e50330da74e40828 TlsVersion=TLS1_3_VERSION bytes=1128 eBPFProgramType=KeyLog
^C2025-06-20T09:56:44+08:00 INF module close.
2025-06-20T09:56:44+08:00 INF Module closed,message Received from Context
2025-06-20T09:56:44+08:00 INF iModule module close
2025-06-20T09:56:44+08:00 INF bye bye.
```