### PR TITLE
Fix: Correctly resolve relative paths in /etc/ld.so.conf

### DIFF
--- a/user/config/common.go
+++ b/user/config/common.go
@@ -83,7 +83,13 @@ func ParseDynLibConf(pattern string) (dirs []string, err error) {
 			// found "include" directive?
 			words := strings.Fields(line)
 			if strings.ToLower(words[0]) == "include" {
-				subdirs, err := ParseDynLibConf(words[1])
+				includePattern := words[1]
+
+				if !filepath.IsAbs(includePattern) {
+					configDir := filepath.Dir(configFile)
+					includePattern = filepath.Join(configDir, includePattern)
+				}
+				subdirs, err := ParseDynLibConf(includePattern)
 				if err != nil && !os.IsNotExist(err) {
 					return dirs, err
 				}


### PR DESCRIPTION
Fix bug，When a relative path (e.g., ld.so.conf.d/*.conf) is specified in /etc/ld.so.conf , ecapture fails to parse it. #807 