### PR TITLE
feat: add WebSocket server and PacketData structure for log handling

### DIFF
--- a/cli/cmd/ecaptureq.go
+++ b/cli/cmd/ecaptureq.go
@@ -14,7 +14,11 @@
 
 package cmd
 
-import "github.com/gojue/ecapture/pkg/ecaptureq"
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/gojue/ecapture/pkg/ecaptureq"
+)
 
 // ecaptureQLogWriter
 type ecaptureQLogWriter struct {
@@ -30,5 +34,34 @@ type ecaptureQEventWriter struct {
 }
 
 func (eew ecaptureQEventWriter) Write(data []byte) (n int, e error) {
+	// 检查是否包含message键
+	b, message, err := checkMessageKeyWithMap(data)
+	if err != nil {
+		return 0, fmt.Errorf("check message failed: %v", err)
+	}
+	if b {
+		return eew.es.WriteEvent([]byte(message))
+	}
 	return eew.es.WriteEvent(data)
+}
+
+func checkMessageKeyWithMap(jsonData []byte) (bool, string, error) {
+	var data map[string]interface{}
+
+	// 解码JSON到map
+	if err := json.Unmarshal(jsonData, &data); err != nil {
+		return false, "", fmt.Errorf("JSON解码失败: %v", err)
+	}
+
+	// 检查是否存在message键
+	if message, exists := data["message"]; exists {
+		// 尝试将message转换为字符串
+		if msgStr, ok := message.(string); ok {
+			return true, msgStr, nil
+		}
+		// 如果不是字符串类型，返回其字符串表示
+		return true, fmt.Sprintf("%v"), nil
+	}
+
+	return false, "", nil
 }

--- a/cli/cmd/ecaptureq.go
+++ b/cli/cmd/ecaptureq.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/gojue/ecapture/pkg/ecaptureq"
 )
 
@@ -37,7 +38,7 @@ func (eew ecaptureQEventWriter) Write(data []byte) (n int, e error) {
 	// 检查是否包含message键
 	b, message, err := checkMessageKeyWithMap(data)
 	if err != nil {
-		return 0, fmt.Errorf("check message failed: %v", err)
+		return 0, fmt.Errorf("check message failed: %w", err)
 	}
 	if b {
 		return eew.es.WriteEvent([]byte(message))
@@ -50,7 +51,7 @@ func checkMessageKeyWithMap(jsonData []byte) (bool, string, error) {
 
 	// 解码JSON到map
 	if err := json.Unmarshal(jsonData, &data); err != nil {
-		return false, "", fmt.Errorf("JSON解码失败: %v", err)
+		return false, "", fmt.Errorf("JSON解码失败: %w", err)
 	}
 
 	// 检查是否存在message键
@@ -60,7 +61,7 @@ func checkMessageKeyWithMap(jsonData []byte) (bool, string, error) {
 			return true, msgStr, nil
 		}
 		// 如果不是字符串类型，返回其字符串表示
-		return true, fmt.Sprintf("%v"), nil
+		return true, "", nil
 	}
 
 	return false, "", nil

--- a/cli/cmd/ecaptureq.go
+++ b/cli/cmd/ecaptureq.go
@@ -47,7 +47,7 @@ func (eew ecaptureQEventWriter) Write(data []byte) (n int, e error) {
 }
 
 func checkMessageKeyWithMap(jsonData []byte) (bool, string, error) {
-	var data map[string]interface{}
+	var data map[string]any
 
 	// 解码JSON到map
 	if err := json.Unmarshal(jsonData, &data); err != nil {

--- a/cli/cmd/ecaptureq.go
+++ b/cli/cmd/ecaptureq.go
@@ -1,0 +1,34 @@
+// Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "github.com/gojue/ecapture/pkg/ecaptureq"
+
+// ecaptureQLogWriter
+type ecaptureQLogWriter struct {
+	es *ecaptureq.Server
+}
+
+func (eew ecaptureQLogWriter) Write(data []byte) (n int, e error) {
+	return eew.es.WriteLog(data)
+}
+
+type ecaptureQEventWriter struct {
+	es *ecaptureq.Server
+}
+
+func (eew ecaptureQEventWriter) Write(data []byte) (n int, e error) {
+	return eew.es.WriteEvent(data)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gojue/ecapture/pkg/ecaptureq"
 	"io"
 	"net"
 	"net/url"
@@ -27,6 +26,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/gojue/ecapture/pkg/ecaptureq"
 
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -264,18 +265,16 @@ func runModule(modName string, modConfig config.IConfig) error {
 		if err != nil {
 			return err
 		}
-		// TODO 将logger的内容写入到es 里， 要区分 log 和 event两个不同的logger
 		es := ecaptureq.NewServer(parsedURL.Host, os.Stdout)
 		go func() {
 			err := es.Start()
 			if err != nil {
-				fmt.Println(fmt.Sprintf("eCaptureQ addr listen failed:%s", err.Error()))
+				fmt.Println(fmt.Sprintf("eCaptureQ addr listen failed:%s\n", err.Error()))
 				return
 			}
 		}()
 
 		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
-		logger = zerolog.New(consoleWriter).With().Timestamp().Logger()
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 		if modConfig.GetDebug() {
 			zerolog.SetGlobalLevel(zerolog.DebugLevel)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -285,8 +285,9 @@ func runModule(modName string, modConfig config.IConfig) error {
 		multi := zerolog.MultiLevelWriter(consoleWriter, eqWriter)
 		logger = zerolog.New(multi).With().Timestamp().Logger()
 
+		evConsoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339, NoColor: true}
 		eqeWriter := ecaptureQEventWriter{es: es}
-		multiEvent := zerolog.MultiLevelWriter(consoleWriter, eqeWriter)
+		multiEvent := zerolog.MultiLevelWriter(evConsoleWriter, eqeWriter)
 		ecw = zerolog.New(multiEvent).With().Timestamp().Logger()
 	} else {
 		logger, err = initLogger(globalConf.LoggerAddr, modConfig, false)

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -64,16 +64,15 @@ const (
 )
 
 const (
-	loggerTypeStdout              = 0
-	loggerTypeFile                = 1
-	loggerTypeTcp                 = 2
-	loggerTypeWebsocket           = 3
-	loggerTypeWebsocketServerMode = 4 // Websocket server mode, used for event collector
+	loggerTypeStdout    uint8 = 0
+	loggerTypeFile      uint8 = 1
+	loggerTypeTcp       uint8 = 2
+	loggerTypeWebsocket uint8 = 3
 )
 
 // ListenPort1 or ListenPort2 are the default ports for the http server.
 const (
-	eCaptureListenAddr = "localhost:28256"
+	configUpdateAddr = "localhost:28256"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -144,8 +143,8 @@ func init() {
 	rootCmd.PersistentFlags().Uint64VarP(&globalConf.Uid, "uid", "u", defaultUid, "if uid is 0 then we target all users")
 	rootCmd.PersistentFlags().StringVarP(&globalConf.LoggerAddr, "logaddr", "l", "", "send logs to this server. -l /tmp/ecapture.log or -l ws://127.0.0.1:8090/ecapture or -l tcp://127.0.0.1:8080")
 	rootCmd.PersistentFlags().StringVar(&globalConf.EventCollectorAddr, "eventaddr", "", "the server address that receives the captured event. --eventaddr ws://127.0.0.1:8090/ecapture or tcp://127.0.0.1:8090, default: same as logaddr")
-	rootCmd.PersistentFlags().BoolVar(&globalConf.LogEventSendMode, "lemode", false, "Log and event sending mode: true: local listening server, waiting for clients to connect before sending events and logs; false: send directly to the remote server.")
-	rootCmd.PersistentFlags().StringVar(&globalConf.Listen, "listen", eCaptureListenAddr, "Listens on a port, receives HTTP requests, and is used to update the runtime configuration, default: 127.0.0.1:28256")
+	rootCmd.PersistentFlags().StringVar(&globalConf.EcaptureQ, "ecaptureq", "", "listening server, waiting for clients to connect before sending events and logs; false: send directly to the remote server.")
+	rootCmd.PersistentFlags().StringVar(&globalConf.Listen, "listen", configUpdateAddr, "Listens on a port, receives HTTP requests, and is used to update the runtime configuration, default: 127.0.0.1:28256")
 	rootCmd.PersistentFlags().Uint64VarP(&globalConf.TruncateSize, "tsize", "t", defaultTruncateSize, "the truncate size in text mode, default: 0 (B), no truncate")
 	rootCmd.PersistentFlags().Uint16Var(&rorateSize, "eventroratesize", 0, "the rorate size(MB) of the event collector file, 1M~65535M, only works for eventaddr server is file. --eventaddr=tls.log --eventroratesize=1 --eventroratetime=30")
 	rootCmd.PersistentFlags().Uint16Var(&rorateTime, "eventroratetime", 0, "the rorate time(s) of the event collector file, 1s~65535s, only works for eventaddr server is file. --eventaddr=tls.log --eventroratesize=1 --eventroratetime=30")
@@ -216,30 +215,14 @@ func initLogger(addr string, modConfig config.IConfig, isRorate bool) (zerolog.L
 				return zerolog.Logger{}, errors.New("URL scheme must be 'ws' or 'wss'")
 			}
 
-			if modConfig.GetLogEventSendMode() {
-				// 如果是事件收集器模式，使用WebSocket服务器模式
-				modConfig.SetAddrType(loggerTypeWebsocketServerMode)
-				// 创建 WebSocket服务器
-				es := ecaptureq.NewServer(parsedURL.Host, logger)
-				logger.Info().Str("addr", addr).Str("parsedURL", parsedURL.Host).Msg("Starting WebSocket server")
-				go func() {
-					err := es.Start()
-					if err != nil {
-						logger.Error().Msg("Failed to start server")
-						return
-					}
-				}()
-				writer = es
-			} else {
-				modConfig.SetAddrType(loggerTypeWebsocket)
-				// 连接到WebSocket服务器
-				var wsConn = ws.NewClient()
-				err = wsConn.Dial(addr, "", "http://localhost")
-				if err != nil {
-					return zerolog.Logger{}, fmt.Errorf("failed to connect to WebSocket server: %s", err.Error())
-				}
-				writer = wsConn
+			modConfig.SetAddrType(loggerTypeWebsocket)
+			// 连接到WebSocket服务器
+			var wsConn = ws.NewClient()
+			err = wsConn.Dial(addr, "", "http://localhost")
+			if err != nil {
+				return zerolog.Logger{}, fmt.Errorf("failed to connect to WebSocket server: %s", err.Error())
 			}
+			writer = wsConn
 		} else {
 			modConfig.SetAddrType(loggerTypeFile)
 			//modConfig.SetLoggerTCPAddr("")
@@ -273,23 +256,55 @@ func initLogger(addr string, modConfig config.IConfig, isRorate bool) (zerolog.L
 // runModule run module
 func runModule(modName string, modConfig config.IConfig) error {
 	setModConfig(globalConf, modConfig)
-	if globalConf.LogEventSendMode {
-		modConfig.SetLogEventSendMode(true)
-	}
-	logger, err := initLogger(globalConf.LoggerAddr, modConfig, false)
-	if err != nil {
-		return err
-	}
-	var eventCollector zerolog.Logger
-	if globalConf.EventCollectorAddr == "" {
-		eventCollector = logger
-	} else {
-		eventCollector, err = initLogger(globalConf.EventCollectorAddr, modConfig, true)
+	var logger, eventCollector zerolog.Logger
+	var err error
+	var ecw io.Writer
+	if globalConf.EcaptureQ != "" {
+		parsedURL, err := url.Parse(globalConf.EcaptureQ)
 		if err != nil {
 			return err
 		}
+		// TODO 将logger的内容写入到es 里， 要区分 log 和 event两个不同的logger
+		es := ecaptureq.NewServer(parsedURL.Host, os.Stdout)
+		go func() {
+			err := es.Start()
+			if err != nil {
+				fmt.Println(fmt.Sprintf("eCaptureQ addr listen failed:%s", err.Error()))
+				return
+			}
+		}()
+
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+		logger = zerolog.New(consoleWriter).With().Timestamp().Logger()
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		if modConfig.GetDebug() {
+			zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		}
+		eqWriter := ecaptureQLogWriter{es: es}
+
+		multi := zerolog.MultiLevelWriter(consoleWriter, eqWriter)
+		logger = zerolog.New(multi).With().Timestamp().Logger()
+
+		// TODO  多写
+		eqeWriter := ecaptureQEventWriter{es: es}
+		multiEvent := zerolog.MultiLevelWriter(consoleWriter, eqeWriter)
+		ecw = zerolog.New(multiEvent).With().Timestamp().Logger()
+	} else {
+		logger, err = initLogger(globalConf.LoggerAddr, modConfig, false)
+		if err != nil {
+			return err
+		}
+		if globalConf.EventCollectorAddr == "" {
+			eventCollector = logger
+		} else {
+			eventCollector, err = initLogger(globalConf.EventCollectorAddr, modConfig, true)
+			if err != nil {
+				return err
+			}
+			ecw = eventCollectorWriter{logger: &eventCollector}
+		}
 	}
-	var ecw = eventCollectorWriter{logger: &eventCollector}
+
 	// init eCapture
 	logger.Info().Str("AppName", fmt.Sprintf("%s(%s)", CliName, CliNameZh)).Send()
 	logger.Info().Str("HomePage", CliHomepage).Send()

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -270,6 +270,7 @@ func runModule(modName string, modConfig config.IConfig) error {
 			err := es.Start()
 			if err != nil {
 				fmt.Println(fmt.Sprintf("eCaptureQ addr listen failed:%s\n", err.Error()))
+				os.Exit(1)
 				return
 			}
 		}()
@@ -284,7 +285,6 @@ func runModule(modName string, modConfig config.IConfig) error {
 		multi := zerolog.MultiLevelWriter(consoleWriter, eqWriter)
 		logger = zerolog.New(multi).With().Timestamp().Logger()
 
-		// TODO  多写
 		eqeWriter := ecaptureQEventWriter{es: es}
 		multiEvent := zerolog.MultiLevelWriter(consoleWriter, eqeWriter)
 		ecw = zerolog.New(multiEvent).With().Timestamp().Logger()
@@ -311,8 +311,8 @@ func runModule(modName string, modConfig config.IConfig) error {
 	logger.Info().Str("Author", CliAuthor).Send()
 	logger.Info().Str("Description", CliDescription).Send()
 	logger.Info().Str("Version", GitVersion).Send()
-
 	logger.Info().Str("Listen", globalConf.Listen).Send()
+	logger.Info().Str("Listen for eCaptureQ", globalConf.EcaptureQ).Send()
 	logger.Info().Str("logger", globalConf.LoggerAddr).Msg("eCapture running logs")
 	logger.Info().Str("eventCollector", globalConf.EventCollectorAddr).Msg("the file handler that receives the captured event")
 

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -269,7 +269,7 @@ func runModule(modName string, modConfig config.IConfig) error {
 		go func() {
 			err := es.Start()
 			if err != nil {
-				fmt.Println(fmt.Sprintf("eCaptureQ addr listen failed:%s\n", err.Error()))
+				fmt.Printf("eCaptureQ addr listen failed:%s\n", err.Error())
 				os.Exit(1)
 				return
 			}

--- a/pkg/ecaptureq/client.go
+++ b/pkg/ecaptureq/client.go
@@ -62,7 +62,7 @@ type Client struct {
 func (c *Client) readPump() {
 	defer func() {
 		c.hub.unregister <- c
-		c.conn.Close()
+		_ = c.conn.Close()
 	}()
 	_, _ = c.logger.Write([]byte("readPump: starting to read messages from WebSocket connection\n"))
 	for {
@@ -90,7 +90,7 @@ func (c *Client) writePump() {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
-		c.conn.Close()
+		_ = c.conn.Close()
 	}()
 	for {
 		select {

--- a/pkg/ecaptureq/client.go
+++ b/pkg/ecaptureq/client.go
@@ -1,0 +1,112 @@
+// Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecaptureq
+
+import (
+	"bytes"
+	"github.com/rs/zerolog"
+	"golang.org/x/net/websocket"
+	"time"
+)
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+
+	// Maximum message size allowed from peer.
+	maxMessageSize = 512
+)
+
+var (
+	newline = []byte{'\n'}
+	space   = []byte{' '}
+)
+
+// Client is a middleman between the websocket connection and the hub.
+type Client struct {
+	hub *Hub
+
+	// The websocket connection.
+	conn *websocket.Conn
+
+	// Buffered channel of outbound messages.
+	send chan []byte
+
+	logger zerolog.Logger
+}
+
+// readPump pumps messages from the websocket connection to the hub.
+//
+// The application runs readPump in a per-connection goroutine. The application
+// ensures that there is at most one reader on a connection by executing all
+// reads from this goroutine.
+func (c *Client) readPump() {
+	defer func() {
+		c.hub.unregister <- c
+		c.conn.Close()
+	}()
+	c.logger.Debug().Msgf("WebSocket connection info %s, origin:%s", c.conn.LocalAddr().String(), c.conn.RemoteAddr().String())
+	for {
+		var data []byte
+		// 检查连接状态
+		if c.conn == nil {
+			c.logger.Error().Msg("WebSocket connection is nil")
+			break
+		}
+		err := websocket.Message.Receive(c.conn, &data)
+		if err != nil {
+			c.logger.Error().Err(err).Msg("readPump: error receiving message")
+			break
+		}
+		c.logger.Info().Msgf("Client:%s:%s, readPump: %s", c.conn.LocalAddr().String(), c.conn.RemoteAddr().String(), string(data))
+	}
+}
+
+// writePump pumps messages from the hub to the websocket connection.
+//
+// A goroutine running writePump is started for each connection. The
+// application ensures that there is at most one writer to a connection by
+// executing all writes from this goroutine.
+func (c *Client) writePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		c.conn.Close()
+	}()
+	for {
+		select {
+		case message, ok := <-c.send:
+			if !ok {
+				// The hub closed the channel.
+				c.logger.Error().Msg("writePump: sender channel closed")
+				return
+			}
+			err := websocket.Message.Send(c.conn, string(message))
+			if err != nil {
+				c.logger.Error().Err(err).Msg("writePump: error sending message")
+				return
+			}
+			c.logger.Debug().Msgf("Client:%s:%s, writePump: %s", c.conn.LocalAddr().String(), c.conn.RemoteAddr().String(), string(bytes.TrimSpace(message)))
+		case <-ticker.C:
+			websocket.Message.Send(c.conn, newline)
+		}
+	}
+}

--- a/pkg/ecaptureq/client.go
+++ b/pkg/ecaptureq/client.go
@@ -77,7 +77,7 @@ func (c *Client) readPump() {
 			_, _ = c.logger.Write([]byte("readPump: error receiving message\n"))
 			break
 		}
-		_, _ = c.logger.Write([]byte(fmt.Sprintf("Client:%s:%s, readPump: %s", c.conn.LocalAddr().String(), c.conn.RemoteAddr().String(), string(data))))
+		_, _ = c.logger.Write([]byte(fmt.Sprintf("Client:%s:%s, readPump: %s\n", c.conn.LocalAddr().String(), c.conn.RemoteAddr().String(), string(data))))
 	}
 }
 

--- a/pkg/ecaptureq/client.go
+++ b/pkg/ecaptureq/client.go
@@ -17,23 +17,9 @@ package ecaptureq
 import (
 	"bytes"
 	"fmt"
-	"golang.org/x/net/websocket"
 	"io"
-	"time"
-)
 
-const (
-	// Time allowed to write a message to the peer.
-	writeWait = 10 * time.Second
-
-	// Time allowed to read the next pong message from the peer.
-	pongWait = 60 * time.Second
-
-	// Send pings to peer with this period. Must be less than pongWait.
-	pingPeriod = (pongWait * 9) / 10
-
-	// Maximum message size allowed from peer.
-	maxMessageSize = 512
+	"golang.org/x/net/websocket"
 )
 
 var (
@@ -87,9 +73,7 @@ func (c *Client) readPump() {
 // application ensures that there is at most one writer to a connection by
 // executing all writes from this goroutine.
 func (c *Client) writePump() {
-	ticker := time.NewTicker(pingPeriod)
 	defer func() {
-		ticker.Stop()
 		_ = c.conn.Close()
 	}()
 	for {
@@ -106,11 +90,6 @@ func (c *Client) writePump() {
 				return
 			}
 			_, _ = c.logger.Write([]byte(fmt.Sprintf("Client:%s:%s, writePump: %s\n", c.conn.LocalAddr().String(), c.conn.RemoteAddr().String(), string(bytes.TrimSpace(message)))))
-		case <-ticker.C:
-			err := websocket.Message.Send(c.conn, newline)
-			if err != nil {
-				_, _ = c.logger.Write([]byte("writePump: error sending message\n"))
-			}
 		}
 	}
 }

--- a/pkg/ecaptureq/hub.go
+++ b/pkg/ecaptureq/hub.go
@@ -1,0 +1,70 @@
+// Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecaptureq
+
+// Hub maintains the set of active clients and broadcasts messages to the
+// clients.
+type Hub struct {
+	// Registered clients.
+	clients map[*Client]bool
+
+	// Inbound messages from the clients.
+	broadcast chan []byte
+
+	// Register requests from the clients.
+	register chan *Client
+
+	// Unregister requests from clients.
+	unregister chan *Client
+}
+
+func newHub() *Hub {
+	return &Hub{
+		broadcast:  make(chan []byte),
+		register:   make(chan *Client),
+		unregister: make(chan *Client),
+		clients:    make(map[*Client]bool),
+	}
+}
+
+func (h *Hub) run() {
+	for {
+		select {
+		case client := <-h.register:
+			h.clients[client] = true
+		case client := <-h.unregister:
+			if _, ok := h.clients[client]; ok {
+				delete(h.clients, client)
+				close(client.send)
+			}
+		case message := <-h.broadcast:
+			for client := range h.clients {
+				select {
+				case client.send <- message:
+				default:
+					close(client.send)
+					delete(h.clients, client)
+				}
+			}
+		}
+	}
+}
+
+func (h *Hub) broadcastMessage(message []byte) {
+	select {
+	case h.broadcast <- message:
+	default:
+	}
+}

--- a/pkg/ecaptureq/proto.go
+++ b/pkg/ecaptureq/proto.go
@@ -25,8 +25,8 @@ const (
 )
 
 type eqMessage struct {
-	LogType eqMessageType `json:"log_type"`
-	Payload []byte        `json:"payload"`
+	LogType eqMessageType   `json:"log_type"`
+	Payload json.RawMessage `json:"payload"`
 }
 
 // Encode 将 eqMessage 编码为 JSON 字节流
@@ -62,4 +62,10 @@ func (p *PacketData) Encode() ([]byte, error) {
 // Decode 从 JSON 字节流解码为 PacketData
 func (p *PacketData) Decode(data []byte) error {
 	return json.Unmarshal(data, p)
+}
+
+type HeartbeatMessage struct {
+	Timestamp int64  `json:"timestamp"`
+	Count     int32  `json:"count"`
+	Message   string `json:"message"`
 }

--- a/pkg/ecaptureq/proto.go
+++ b/pkg/ecaptureq/proto.go
@@ -39,31 +39,6 @@ func (m *eqMessage) Decode(data []byte) error {
 	return json.Unmarshal(data, m)
 }
 
-// PacketData 结构体与您 Rust 项目中的 core::models::PacketData 完全对应。
-// 我们使用 `json:"..."` 标签来确保生成的 JSON 字段名与前端期望的一致。
-type PacketData struct {
-	Timestamp     int64  `json:"timestamp"`
-	SrcIP         string `json:"src_ip"`
-	SrcPort       uint32 `json:"src_port"`
-	DstIP         string `json:"dst_ip"`
-	DstPort       uint32 `json:"dst_port"`
-	PID           int32  `json:"pid"`
-	PName         string `json:"pname"`
-	Type          string `json:"type"` // 对应 Rust 的 `r#type`
-	Length        uint32 `json:"length"`
-	PayloadBase64 string `json:"payload_base64"`
-}
-
-// Encode 将 PacketData 编码为 JSON 字节流
-func (p *PacketData) Encode() ([]byte, error) {
-	return json.Marshal(p)
-}
-
-// Decode 从 JSON 字节流解码为 PacketData
-func (p *PacketData) Decode(data []byte) error {
-	return json.Unmarshal(data, p)
-}
-
 type HeartbeatMessage struct {
 	Timestamp int64  `json:"timestamp"`
 	Count     int32  `json:"count"`

--- a/pkg/ecaptureq/proto.go
+++ b/pkg/ecaptureq/proto.go
@@ -16,6 +16,29 @@ package ecaptureq
 
 import "encoding/json"
 
+type eqMessageType uint8
+
+const (
+	LogTypeHeartBeat  eqMessageType = 0
+	LogTypeProcessLog eqMessageType = 1
+	LogTypeEvent      eqMessageType = 2
+)
+
+type eqMessage struct {
+	LogType eqMessageType `json:"log_type"`
+	Payload []byte        `json:"payload"`
+}
+
+// Encode 将 eqMessage 编码为 JSON 字节流
+func (m *eqMessage) Encode() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// Decode 从 JSON 字节流解码为 eqMessage
+func (m *eqMessage) Decode(data []byte) error {
+	return json.Unmarshal(data, m)
+}
+
 // PacketData 结构体与您 Rust 项目中的 core::models::PacketData 完全对应。
 // 我们使用 `json:"..."` 标签来确保生成的 JSON 字段名与前端期望的一致。
 type PacketData struct {

--- a/pkg/ecaptureq/proto.go
+++ b/pkg/ecaptureq/proto.go
@@ -1,0 +1,42 @@
+// Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecaptureq
+
+import "encoding/json"
+
+// PacketData 结构体与您 Rust 项目中的 core::models::PacketData 完全对应。
+// 我们使用 `json:"..."` 标签来确保生成的 JSON 字段名与前端期望的一致。
+type PacketData struct {
+	Timestamp     int64  `json:"timestamp"`
+	SrcIP         string `json:"src_ip"`
+	SrcPort       uint32 `json:"src_port"`
+	DstIP         string `json:"dst_ip"`
+	DstPort       uint32 `json:"dst_port"`
+	PID           int32  `json:"pid"`
+	PName         string `json:"pname"`
+	Type          string `json:"type"` // 对应 Rust 的 `r#type`
+	Length        uint32 `json:"length"`
+	PayloadBase64 string `json:"payload_base64"`
+}
+
+// Encode 将 PacketData 编码为 JSON 字节流
+func (p *PacketData) Encode() ([]byte, error) {
+	return json.Marshal(p)
+}
+
+// Decode 从 JSON 字节流解码为 PacketData
+func (p *PacketData) Decode(data []byte) error {
+	return json.Unmarshal(data, p)
+}

--- a/pkg/ecaptureq/server.go
+++ b/pkg/ecaptureq/server.go
@@ -17,9 +17,10 @@ package ecaptureq
 import (
 	"context"
 	"fmt"
+	"io"
+
 	"github.com/gojue/ecapture/pkg/util/ws"
 	"golang.org/x/net/websocket"
-	"io"
 )
 
 const LogBuffLen = 128

--- a/pkg/ecaptureq/server.go
+++ b/pkg/ecaptureq/server.go
@@ -1,0 +1,70 @@
+// Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ecaptureq
+
+import (
+	"github.com/gojue/ecapture/pkg/util/ws"
+	"github.com/rs/zerolog"
+)
+
+const LogBuffLen = 100
+
+type Server struct {
+	addr    string
+	logbuff []string
+	handler func([]byte)
+	ws      *ws.Server
+	logger  *zerolog.Logger
+}
+
+// NewServer 创建一个新的服务器实例
+func NewServer(addr string, logger *zerolog.Logger) *Server {
+	return &Server{
+		addr:    addr,
+		logbuff: make([]string, 0, LogBuffLen),
+		logger:  logger,
+	}
+}
+
+// Start 启动服务器
+func (s *Server) Start() error {
+	server := ws.NewServer(s.addr, s.handler)
+	s.ws = server
+	err := s.ws.Start()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) Write(data []byte) error {
+	pd := new(PacketData)
+	err := pd.Decode(data)
+	if err != nil {
+		return err
+	}
+	err = s.ws.Write(data)
+	return err
+}
+
+func (s *Server) Read(data []byte) error {
+	pd := new(PacketData)
+	err := pd.Decode(data)
+	if err != nil {
+		return err
+	}
+	s.logger.Info().Msg(string(data))
+	return nil
+}

--- a/pkg/ecaptureq/server.go
+++ b/pkg/ecaptureq/server.go
@@ -19,8 +19,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/gojue/ecapture/pkg/util/ws"
 	"golang.org/x/net/websocket"
+
+	"github.com/gojue/ecapture/pkg/util/ws"
 )
 
 const LogBuffLen = 128

--- a/pkg/ecaptureq/server.go
+++ b/pkg/ecaptureq/server.go
@@ -97,7 +97,6 @@ func (s *Server) handleWebSocket(conn *websocket.Conn) {
 
 func (s *Server) sendLogBuff(c *Client) {
 	for _, log := range s.logbuff {
-		fmt.Println("sendLogBuff: ", log)
 		c.send <- []byte(log)
 	}
 }
@@ -126,7 +125,6 @@ func (s *Server) write(data []byte, logType eqMessageType) (int, error) {
 func (s *Server) WriteLog(data []byte) (n int, e error) {
 	// 如果程序初始化的日志缓冲区已满，则不再添加新的日志
 	if len(s.logbuff) <= LogBuffLen {
-		fmt.Println(string(data))
 		hb := new(eqMessage)
 		hb.LogType = LogTypeProcessLog
 		hb.Payload = data

--- a/pkg/util/ws/server.go
+++ b/pkg/util/ws/server.go
@@ -39,6 +39,8 @@ func (s *Server) Start() error {
 	if s.handleWebSocket == nil {
 		return fmt.Errorf("handleWebSocket function is not set")
 	}
-	http.Handle("/", websocket.Handler(s.handleWebSocket))
-	return http.ListenAndServe(s.addr, nil)
+
+	mux := http.NewServeMux()
+	mux.Handle("/", websocket.Handler(s.handleWebSocket))
+	return http.ListenAndServe(s.addr, mux)
 }

--- a/pkg/util/ws/server.go
+++ b/pkg/util/ws/server.go
@@ -23,85 +23,22 @@ import (
 
 // Server 是一个简单的WebSocket服务器，接收base64编码的消息并调用处理函数
 type Server struct {
-	addr        string
-	readHandler func([]byte)
-	writeChan   chan []byte
+	addr            string
+	handleWebSocket func(*websocket.Conn)
 }
 
-const WriteChanLength = 1024 * 4
-
-/*
-	server := NewServer(":8080", func(data []byte) {
-	    fmt.Printf("Received: %s\n", string(data))
-	})
-
-server.Start()
-*/
-
 // NewServer 创建一个新的WebSocket服务器实例
-func NewServer(addr string, handler func([]byte)) *Server {
+func NewServer(addr string, handler func(conn *websocket.Conn)) *Server {
 	return &Server{
-		addr:        addr,
-		readHandler: handler,
-		writeChan:   make(chan []byte, WriteChanLength),
+		addr:            addr,
+		handleWebSocket: handler,
 	}
 }
 
 func (s *Server) Start() error {
+	if s.handleWebSocket == nil {
+		return fmt.Errorf("handleWebSocket function is not set")
+	}
 	http.Handle("/", websocket.Handler(s.handleWebSocket))
 	return http.ListenAndServe(s.addr, nil)
-}
-
-// Write 向WebSocket连接发送数据
-func (s *Server) Write(data []byte) error {
-	if data == nil {
-		return nil // 如果数据为nil，直接返回
-	}
-
-	select {
-	case s.writeChan <- data:
-		return nil // 成功写入数据到通道
-	default:
-		return fmt.Errorf("write channel is full") // 如果通道已满，返回错误
-	}
-}
-
-// handleWebSocket 处理WebSocket连接
-func (s *Server) handleWebSocket(ws *websocket.Conn) {
-	defer func() {
-		_ = ws.Close()
-	}()
-
-	go func() {
-		for {
-			var data []byte
-			err := websocket.Message.Receive(ws, &data)
-			if err != nil {
-				fmt.Printf("WebSocket receive error: %v\n", err)
-				break
-			}
-
-			// 调用处理函数
-			if s.readHandler != nil {
-				s.readHandler(data)
-			}
-		}
-	}()
-
-	go func() {
-		for range s.writeChan {
-			// 从写入通道中读取数据
-			data := <-s.writeChan
-			if data == nil {
-				continue // 如果数据为nil，跳过
-			}
-
-			// 发送数据到WebSocket连接
-			err := websocket.Message.Send(ws, data)
-			if err != nil {
-				fmt.Printf("WebSocket write error: %v\n", err)
-				break
-			}
-		}
-	}()
 }

--- a/pkg/util/ws/server_test.go
+++ b/pkg/util/ws/server_test.go
@@ -72,7 +72,7 @@ func TestServer_HandleWebSocket(t *testing.T) {
 }
 
 func TestServer_Start(t *testing.T) {
-	server := NewServer(":0", nil)
+	server := NewServer(":0", wsHandler)
 
 	// 测试启动服务器（这里只验证不会panic）
 	go func() {

--- a/pkg/util/ws/server_test.go
+++ b/pkg/util/ws/server_test.go
@@ -15,7 +15,8 @@
 package ws
 
 import (
-	"encoding/base64"
+	"context"
+	"fmt"
 	"net/http/httptest"
 	"sync"
 	"testing"
@@ -25,19 +26,29 @@ import (
 )
 
 func TestServer_HandleWebSocket(t *testing.T) {
-	var receivedData []byte
+	var receivedData string
 	var wg sync.WaitGroup
 	wg.Add(1)
 
+	wsUrl := "ws://127.0.0.1:28257"
 	// 创建服务器
-	server := NewServer(":0", wsHandler)
+	server := NewServer("127.0.0.1:28257", wsHandler)
+	go func() {
+		err := server.Start()
+		if err != nil {
+			t.Errorf("Failed to start server: %v", err)
+		}
+	}()
+
+	time.Sleep(1 * time.Second) // 等待服务器启动
 
 	// 创建测试服务器
 	testServer := httptest.NewServer(websocket.Handler(server.handleWebSocket))
 	defer testServer.Close()
 
 	// 创建客户端连接
-	url := "ws" + testServer.URL[4:] + "/"
+	url := wsUrl
+	fmt.Println("Connecting to WebSocket at:", url)
 	conn, err := websocket.Dial(url, "", "http://localhost/")
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -47,12 +58,19 @@ func TestServer_HandleWebSocket(t *testing.T) {
 	}()
 
 	// 发送base64编码的数据
-	testData := "hello world"
-	encodedData := base64.StdEncoding.EncodeToString([]byte(testData))
-	err = websocket.Message.Send(conn, encodedData)
+	err = websocket.Message.Send(conn, "ping")
 	if err != nil {
 		t.Fatalf("Failed to send message: %v", err)
 	}
+
+	go func() {
+		err = websocket.Message.Receive(conn, &receivedData)
+		if err != nil {
+			t.Error("Failed to receive message:", err)
+		}
+		t.Logf("Received data: %s", receivedData)
+		wg.Done()
+	}()
 
 	// 等待数据处理
 	done := make(chan bool)
@@ -63,10 +81,10 @@ func TestServer_HandleWebSocket(t *testing.T) {
 
 	select {
 	case <-done:
-		if string(receivedData) != testData {
-			t.Errorf("Expected %s, got %s", testData, string(receivedData))
+		if receivedData != "pong" {
+			t.Errorf("Expected %s, got %s", "pong", receivedData)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(3 * time.Second):
 		t.Error("Timeout waiting for data processing")
 	}
 }
@@ -87,6 +105,7 @@ func TestServer_Start(t *testing.T) {
 }
 
 func wsHandler(conn *websocket.Conn) {
+	ctx := context.Background()
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -101,9 +120,14 @@ func wsHandler(conn *websocket.Conn) {
 			}
 			if msg == "ping" {
 				if err := websocket.Message.Send(conn, "pong"); err != nil {
+					fmt.Println(err)
 					return
 				}
+			} else {
+				fmt.Println("Received message:", msg)
 			}
 		}
 	}()
+
+	<-ctx.Done()
 }

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -66,6 +66,9 @@ type IConfig interface {
 	// Set/Get TruncateSize
 	SetTruncateSize(uint64)
 	GetTruncateSize() uint64
+
+	GetLogEventSendMode() bool
+	SetLogEventSendMode(bool)
 }
 
 // TLS capture mode constants defining different output formats
@@ -107,6 +110,7 @@ type BaseConfig struct {
 	LoggerAddr         string `json:"logger_addr"`          // Address for logger output
 	LoggerType         uint8  `json:"logger_type"`          // Logger type (0:stdout, 1:file, 2:tcp)
 	EventCollectorAddr string `json:"event_collector_addr"` // Address of the event collector server
+	LogEventSendMode bool `json:"log_event_send_mode"`      // 日志和事件的发送模式，true: 本地监听server，等待客户端来连接，再发送事件和日志；false: 直接发送到远程服务器
 }
 
 func (c *BaseConfig) GetPid() uint64 {
@@ -183,6 +187,14 @@ func (c *BaseConfig) SetTruncateSize(TruncateSize uint64) {
 
 func (c *BaseConfig) GetTruncateSize() uint64 {
 	return c.TruncateSize
+}
+
+func (c *BaseConfig) GetLogEventSendMode() bool {
+	return c.LogEventSendMode
+}
+
+func (c *BaseConfig) SetLogEventSendMode(b bool) {
+	c.LogEventSendMode = b
 }
 
 func (c *BaseConfig) EnableGlobalVar() bool {

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -110,7 +110,7 @@ type BaseConfig struct {
 	LoggerAddr         string `json:"logger_addr"`          // Address for logger output
 	LoggerType         uint8  `json:"logger_type"`          // Logger type (0:stdout, 1:file, 2:tcp)
 	EventCollectorAddr string `json:"event_collector_addr"` // Address of the event collector server
-	LogEventSendMode bool `json:"log_event_send_mode"`      // 日志和事件的发送模式，true: 本地监听server，等待客户端来连接，再发送事件和日志；false: 直接发送到远程服务器
+	LogEventSendMode   bool   `json:"log_event_send_mode"`  // 日志和事件的发送模式，true: 本地监听server，等待客户端来连接，再发送事件和日志；false: 直接发送到远程服务器
 }
 
 func (c *BaseConfig) GetPid() uint64 {

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -51,6 +51,7 @@ type IConfig interface {
 	SetDebug(bool)
 	// SetAddrType sets the logger output type
 	SetAddrType(uint8)
+	GetAddrType() uint8
 	// SetEventCollectorAddr sets the address for the event collector
 	SetEventCollectorAddr(string)
 	// GetEventCollectorAddr returns the event collector address
@@ -66,9 +67,6 @@ type IConfig interface {
 	// Set/Get TruncateSize
 	SetTruncateSize(uint64)
 	GetTruncateSize() uint64
-
-	GetLogEventSendMode() bool
-	SetLogEventSendMode(bool)
 }
 
 // TLS capture mode constants defining different output formats
@@ -110,7 +108,7 @@ type BaseConfig struct {
 	LoggerAddr         string `json:"logger_addr"`          // Address for logger output
 	LoggerType         uint8  `json:"logger_type"`          // Logger type (0:stdout, 1:file, 2:tcp)
 	EventCollectorAddr string `json:"event_collector_addr"` // Address of the event collector server
-	LogEventSendMode   bool   `json:"log_event_send_mode"`  // 日志和事件的发送模式，true: 本地监听server，等待客户端来连接，再发送事件和日志；false: 直接发送到远程服务器
+	EcaptureQ          string `json:"ecapture_q"`           // ecaptureQ 模式，本地监听Server，等待Q连接
 }
 
 func (c *BaseConfig) GetPid() uint64 {
@@ -147,6 +145,10 @@ func (c *BaseConfig) GetEventCollectorAddr() string {
 
 func (c *BaseConfig) SetAddrType(t uint8) {
 	c.LoggerType = t
+}
+
+func (c *BaseConfig) GetAddrType() uint8 {
+	return c.LoggerType
 }
 
 func (c *BaseConfig) SetDebug(b bool) {
@@ -187,14 +189,6 @@ func (c *BaseConfig) SetTruncateSize(TruncateSize uint64) {
 
 func (c *BaseConfig) GetTruncateSize() uint64 {
 	return c.TruncateSize
-}
-
-func (c *BaseConfig) GetLogEventSendMode() bool {
-	return c.LogEventSendMode
-}
-
-func (c *BaseConfig) SetLogEventSendMode(b bool) {
-	c.LogEventSendMode = b
 }
 
 func (c *BaseConfig) EnableGlobalVar() bool {

--- a/user/event/event_base.go
+++ b/user/event/event_base.go
@@ -1,0 +1,43 @@
+// Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import "encoding/json"
+
+// Base 结构体与eCaptureQ 保持一致
+type Base struct {
+	Timestamp     int64  `json:"timestamp"`
+	UUID          string `json:"uuid"`
+	SrcIP         string `json:"src_ip"`
+	SrcPort       uint32 `json:"src_port"`
+	DstIP         string `json:"dst_ip"`
+	DstPort       uint32 `json:"dst_port"`
+	PID           int32  `json:"pid"`
+	PName         string `json:"pname"`
+	Type          uint32 `json:"type"` //
+	Length        uint32 `json:"length"`
+	PayloadBase64 string `json:"payload_base64"`
+}
+
+// Encode 将 PacketData 编码为 JSON 字节流
+func (b *Base) Encode() ([]byte, error) {
+	b.Length = uint32(len(b.PayloadBase64))
+	return json.Marshal(b)
+}
+
+// Decode 从 JSON 字节流解码为 PacketData
+func (b *Base) Decode(data []byte) error {
+	return json.Unmarshal(data, b)
+}

--- a/user/event/event_gotls.go
+++ b/user/event/event_gotls.go
@@ -3,6 +3,7 @@ package event
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 )
@@ -45,7 +46,17 @@ func (ge *GoTLSEvent) Decode(payload []byte) error {
 
 func (ge *GoTLSEvent) String() string {
 	s := fmt.Sprintf("PID: %d, Comm: %s, TID: %d, PayloadType:%d, Payload: %s\n", ge.Pid, string(ge.Comm[:]), ge.Tid, ge.inner.PayloadType, string(ge.Data[:ge.Len]))
-	return s
+	eb := new(Base)
+	eb.UUID = ge.GetUUID()
+	eb.PID = int32(ge.Pid)
+	eb.PName = string(ge.Comm[:])
+	eb.Type = uint32(ge.inner.PayloadType)
+	eb.PayloadBase64 = base64.StdEncoding.EncodeToString(ge.Data[:])
+	p, e := eb.Encode()
+	if e != nil {
+		return s
+	}
+	return string(p)
 }
 
 func (ge *GoTLSEvent) StringHex() string {

--- a/user/event/ievent.go
+++ b/user/event/ievent.go
@@ -36,8 +36,6 @@ type IEventStruct interface {
 	String() string
 	StringHex() string
 	Clone() IEventStruct
-	//Module() IModule
-	//SetModule(IModule)
 	EventType() EventType
 	GetUUID() string
 }


### PR DESCRIPTION
support eCaptureQ

This pull request introduces several new features and refactors to the `ecaptureq` package, focusing on implementing a WebSocket server, creating a data model for packet handling, and improving the WebSocket utility. The changes add functionality for encoding and decoding packet data, handling WebSocket read/write operations, and managing concurrency through buffered channels.

### New features in `ecaptureq` package:

* **Packet data model and JSON serialization**:
  - Added the `PacketData` struct to represent packet information, including fields such as `Timestamp`, `SrcIP`, `DstIP`, and `PayloadBase64`. The struct uses JSON tags for serialization compatibility with frontend expectations.
  - Implemented `Encode` and `Decode` methods for converting `PacketData` instances to and from JSON byte streams.

* **WebSocket server implementation**:
  - Added the `Server` struct with fields for address, logging buffer, WebSocket instance, and logger.
  - Implemented methods `Start`, `Write`, and `Read` for starting the server, writing data to WebSocket connections, and logging received data.

### Refactor and enhancements to WebSocket utility (`pkg/util/ws`):

* **Buffered write channel**:
  - Introduced a `writeChan` with a configurable buffer size (`WriteChanLength`) to handle concurrent writes to WebSocket connections efficiently. [[1]](diffhunk://#diff-be0a092522db67cf366b561f29cac94ce5749aa9bc8472a7df6853821deec4e7L28-R32) [[2]](diffhunk://#diff-be0a092522db67cf366b561f29cac94ce5749aa9bc8472a7df6853821deec4e7L43-R46)

* **Separation of read and write handlers**:
  - Refactored the `Server` struct to use distinct `readHandler` and `writeChan` fields, improving clarity and functionality for WebSocket message handling.

* **Concurrent WebSocket operations**:
  - Enhanced the `handleWebSocket` method to use two goroutines: one for processing incoming messages via `readHandler` and another for sending messages from `writeChan`. This ensures non-blocking operations for both reading and writing.