### PR TITLE
fix: missing trailing bytes for some keys in gotls keylog

### DIFF
--- a/kern/gotls_kern.c
+++ b/kern/gotls_kern.c
@@ -245,7 +245,7 @@ static __always_inline int gotls_mastersecret(struct pt_regs *ctx, bool is_regis
     }
 
     debug_bpf_printk("gotls_mastersecret read mastersecret label:%s\n", mastersecret_gotls.label);
-    ret = bpf_probe_read_user_str(
+    ret = bpf_probe_read_user(
         &mastersecret_gotls.client_random, sizeof(mastersecret_gotls.client_random), (void *)cr_ptr);
     if (ret < 0) {
         debug_bpf_printk(
@@ -255,7 +255,7 @@ static __always_inline int gotls_mastersecret(struct pt_regs *ctx, bool is_regis
         return 0;
     }
 
-    ret = bpf_probe_read_user_str(&mastersecret_gotls.secret_, sizeof(mastersecret_gotls.secret_), (void *)secret_ptr);
+    ret = bpf_probe_read_user(&mastersecret_gotls.secret_, sizeof(mastersecret_gotls.secret_), (void *)secret_ptr);
     if (ret < 0) {
         debug_bpf_printk(
             "gotls_mastersecret read mastersecret secret_ failed, ret:%d, "


### PR DESCRIPTION
由于使用 `bpf_probe_read_user_str` 方法读取 gotls client random 和 secret 导致若随机密钥中存在 `\x00` 字节，其后的内容会被忽略。因此改为使用 `bpf_probe_read_user` 方法。

以下是一个例子：

执行命令：

```bash
sudo ecapture gotls -m key -k keylog.log -e path/to/goelf
```

v1.3.1 输出结果: （其中有部分 client random 或 secret 带有大量 `00` 后缀）

```
CLIENT_RANDOM af8ca9934b499b382363e7252ec5405ed7d850e81d5e803fbcfd5df87f83eb8f a47f925e343a62dc293cca384d688c577fd29b0477a890e9bd3796bc0b5f8ae60f2b593dff90e9e66b7baaa58a15c5f4
CLIENT_RANDOM 84fde0396cdd8db9c9b7d209851b748e7129824c9e7984fc153e040f4e970aad 90c5cbfc1c69ad31b68706af7cd1e2c3a311f52162cbcbc9b2f8c2e20d5ffe0b92656fb10520d3e88092271f0acb8212
CLIENT_RANDOM b21a82cc2da65a34f44fb525a0c15bd13e8f5741fb08816736a345dd3cfd4f86 d030f9c8f6a5f8988782eebb1732c6b9b05c5e726ef67d33398b2ac78a7d99d95be88b19e6ee3ecf4a5d34e34924d155
CLIENT_RANDOM ab0dbc54b89a88c7be06c117e2b277155519ff4d9978fc9fbf6e7f5ea287891e 9ab8d8d08f05c4dbdd2b833a59f5c7196f6fe26e10d46e193fdc69690000000000000000000000000000000000000000
CLIENT_RANDOM 6dc7b9957491f2d5278044a10fd51963e762fec86c421e93c7d51d27bff03fd9 75298aac9ba5658c7bfdd518a40a541c25cd99ce2bcc86f5d288e1dd2821b64f8137e16f83091496a97e0929d4896952
CLIENT_RANDOM 54a6173a88b79347da5beb35660d092500000000000000000000000000000000 010a49801985ae5c2b92fbf817029c7df18feb2200000000000000000000000000000000000000000000000000000000
CLIENT_RANDOM 26829a92b6b6a0027d46d784deedb4720673bd4126f0f6d3eff40a3ac0abe37f 875928acb6bb6258eaba914a4e79cfae73f769a2a8f389682e3c564d66a413376f201893ca53c2e5a8711b337e7b11dd
CLIENT_RANDOM d8779bd0dc1ca6f90d5251a24a28afbce25043d67d8636e571964377c081aefc b461af0791b1a2552dfeb00808f0eb9c371c64135bcb6147c8a546ab87847cd7820bb51cde6b02e570fb7c07033f8f94
CLIENT_RANDOM 43323bfe1129b35a3c648930c89df86b77e3d258ecf7d71cd3901b071172ad65 3f18f3baf7823f4c66991b909822c2b8ec89a739a67a85b1c6a7a2751ae9f020934bd6d664b55e6cc6b4683601596209
CLIENT_RANDOM 67449e9a48f6af132c0862eeb8a7575794b63955ff81d6a49225f7ac54a6a16d 0c30e85280f17a55424e6e534d0e5d9ab9cc8338eac0d4d205ff14540c7629640a01359d0bab5564d3bc1e7ed976c196
CLIENT_RANDOM 6a5ec224c6b0256cb1ccfbb517465a18b9b98eab733e6e3bce471fce27203463 b07050fa7d1a3dce3021a44a1391cdbd015f987cd3962b96fdfcf23a22812f6914b524bf3a56523fe2710b926e9bed16
CLIENT_RANDOM 9fe7da0f151822c4441a6195a7b4e8f39d1b1861638fc65c20407f26da4b410c c396760ab8dde60000000000000000000000000000000000000000000000000000000000000000000000000000000000
CLIENT_RANDOM 14ce23fc1fe3116bb4f7da92653a3311f22f6aeecac862a0889af7b3617c820a 7702bc31dbc45a4c93688c02e51fa6b70795e6652c34792c8a93c2727469edb4712912c6df60c277074279f64acaec8e
CLIENT_RANDOM 85281a81db561531dd734c80d19bff6ee4f487dc937771a3421c1c32543e7e58 d1bdb5550d156f065c7eed29a74b428a543da13bc13d1580c58972f0166efae5a5fc8f3d2ada415dd76820486a01e416
CLIENT_RANDOM b5696195471d8289cd9ce8a74d82ed2bc14e4fe627db0c07f2521869886cdaaa f84d5f2cf9ffc56a6a9ae8499de169c37142c30e3f41f79a5fed28f5d13e28695097092b350880e099c73719a2b08bd2
CLIENT_RANDOM bca426d7631fee257f37712096840998480b13e23c930b6d56c49e3d6859682c 18bf1d96ca466ad997553a5acff684aed960c7ab23d420a1271d9fe79e1992cfe1a2d9127305bde790275d69566c02c3
CLIENT_RANDOM fe87626e2be4f2a5818095a725cec71fedd2302330d59124ac1930b5d5312c02 0fc9da3b234ec238c0f493a4b3f2118524e18072d9730df9ecf4dd2595c4350254673b55fd4877ffd47b2f60aec097b5
CLIENT_RANDOM dd4b225483e5fa4654a104c66315745b23a4a8346b79f4d051cf1bd412884749 d6fae51108125f4bcdc310dcc3c2bb94c8a3000000000000000000000000000000000000000000000000000000000000
CLIENT_RANDOM 2d4d4e389b726b4763b5e1d74857085419bd3ae5f47538c0e77c274e87f381d6 147b93b58c13511dc86111da2c7228502ed92ae6e891253f500adfb1a3a10d6ed72f0000000000000000000000000000
CLIENT_RANDOM 9fb34214263835d4298f32eebf1d3be47bafea36e0974f27b7f61a41ebf057e1 dc7aeda3acf7637195c03b9b63f8e80cca674382a4fcb4fd467b66c4cfc25791d8692b2c310f82d56c9d7fc3756d071f
```

修复后的版本输出结果：

```
CLIENT_RANDOM af8ca9934b499b382363e7252ec5405ed7d850e81d5e803fbcfd5df87f83eb8f a47f925e343a62dc293cca384d688c577fd29b0477a890e9bd3796bc0b5f8ae60f2b593dff90e9e66b7baaa58a15c5f4
CLIENT_RANDOM 84fde0396cdd8db9c9b7d209851b748e7129824c9e7984fc153e040f4e970aad 90c5cbfc1c69ad31b68706af7cd1e2c3a311f52162cbcbc9b2f8c2e20d5ffe0b92656fb10520d3e88092271f0acb8212
CLIENT_RANDOM b21a82cc2da65a34f44fb525a0c15bd13e8f5741fb08816736a345dd3cfd4f86 d030f9c8f6a5f8988782eebb1732c6b9b05c5e726ef67d33398b2ac78a7d99d95be88b19e6ee3ecf4a5d34e34924d155
CLIENT_RANDOM ab0dbc54b89a88c7be06c117e2b277155519ff4d9978fc9fbf6e7f5ea287891e 9ab8d8d08f05c4dbdd2b833a59f5c7196f6fe26e10d46e193fdc6969004a95c55c8a646d81e45c7b85143ec73817fe2b
CLIENT_RANDOM 6dc7b9957491f2d5278044a10fd51963e762fec86c421e93c7d51d27bff03fd9 75298aac9ba5658c7bfdd518a40a541c25cd99ce2bcc86f5d288e1dd2821b64f8137e16f83091496a97e0929d4896952
CLIENT_RANDOM 54a6173a88b79347da5beb35660d092500885bb04cdbb736768ffa93a58a69c7 010a49801985ae5c2b92fbf817029c7df18feb2200f14eab4495fe108039e4a1670c52161f935bd8c305fa7c3cd4f55f
CLIENT_RANDOM 26829a92b6b6a0027d46d784deedb4720673bd4126f0f6d3eff40a3ac0abe37f 875928acb6bb6258eaba914a4e79cfae73f769a2a8f389682e3c564d66a413376f201893ca53c2e5a8711b337e7b11dd
CLIENT_RANDOM d8779bd0dc1ca6f90d5251a24a28afbce25043d67d8636e571964377c081aefc b461af0791b1a2552dfeb00808f0eb9c371c64135bcb6147c8a546ab87847cd7820bb51cde6b02e570fb7c07033f8f94
CLIENT_RANDOM 43323bfe1129b35a3c648930c89df86b77e3d258ecf7d71cd3901b071172ad65 3f18f3baf7823f4c66991b909822c2b8ec89a739a67a85b1c6a7a2751ae9f020934bd6d664b55e6cc6b4683601596209
CLIENT_RANDOM 67449e9a48f6af132c0862eeb8a7575794b63955ff81d6a49225f7ac54a6a16d 0c30e85280f17a55424e6e534d0e5d9ab9cc8338eac0d4d205ff14540c7629640a01359d0bab5564d3bc1e7ed976c196
CLIENT_RANDOM 6a5ec224c6b0256cb1ccfbb517465a18b9b98eab733e6e3bce471fce27203463 b07050fa7d1a3dce3021a44a1391cdbd015f987cd3962b96fdfcf23a22812f6914b524bf3a56523fe2710b926e9bed16
CLIENT_RANDOM 9fe7da0f151822c4441a6195a7b4e8f39d1b1861638fc65c20407f26da4b410c c396760ab8dde600e2bb9793bfca3d3106b6ecbab9ec55ca49a08013fd3d691da51c30001650df6c473522d5ef5d40a4
CLIENT_RANDOM 14ce23fc1fe3116bb4f7da92653a3311f22f6aeecac862a0889af7b3617c820a 7702bc31dbc45a4c93688c02e51fa6b70795e6652c34792c8a93c2727469edb4712912c6df60c277074279f64acaec8e
CLIENT_RANDOM 85281a81db561531dd734c80d19bff6ee4f487dc937771a3421c1c32543e7e58 d1bdb5550d156f065c7eed29a74b428a543da13bc13d1580c58972f0166efae5a5fc8f3d2ada415dd76820486a01e416
CLIENT_RANDOM b5696195471d8289cd9ce8a74d82ed2bc14e4fe627db0c07f2521869886cdaaa f84d5f2cf9ffc56a6a9ae8499de169c37142c30e3f41f79a5fed28f5d13e28695097092b350880e099c73719a2b08bd2
CLIENT_RANDOM bca426d7631fee257f37712096840998480b13e23c930b6d56c49e3d6859682c 18bf1d96ca466ad997553a5acff684aed960c7ab23d420a1271d9fe79e1992cfe1a2d9127305bde790275d69566c02c3
CLIENT_RANDOM fe87626e2be4f2a5818095a725cec71fedd2302330d59124ac1930b5d5312c02 0fc9da3b234ec238c0f493a4b3f2118524e18072d9730df9ecf4dd2595c4350254673b55fd4877ffd47b2f60aec097b5
CLIENT_RANDOM dd4b225483e5fa4654a104c66315745b23a4a8346b79f4d051cf1bd412884749 d6fae51108125f4bcdc310dcc3c2bb94c8a300c4d2311a3331d4865d1a69e09df886c24b34b2a9cf259776de759263fd
CLIENT_RANDOM 2d4d4e389b726b4763b5e1d74857085419bd3ae5f47538c0e77c274e87f381d6 147b93b58c13511dc86111da2c7228502ed92ae6e891253f500adfb1a3a10d6ed72f007cb7f6d373915ee15454702e82
CLIENT_RANDOM 9fb34214263835d4298f32eebf1d3be47bafea36e0974f27b7f61a41ebf057e1 dc7aeda3acf7637195c03b9b63f8e80cca674382a4fcb4fd467b66c4cfc25791d8692b2c310f82d56c9d7fc3756d071f
```