### PR TITLE
fix: correct return statements and improve error handling in BoringSSL

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -301,8 +301,8 @@ func runModule(modName string, modConfig config.IConfig) error {
 			if err != nil {
 				return err
 			}
-			ecw = eventCollectorWriter{logger: &eventCollector}
 		}
+		ecw = eventCollectorWriter{logger: &eventCollector}
 	}
 
 	// init eCapture

--- a/kern/boringssl_masterkey.h
+++ b/kern/boringssl_masterkey.h
@@ -200,7 +200,7 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     int ret = bpf_probe_read_user(&version, sizeof(version), (void *)ssl_version_ptr);
     if (ret) {
         debug_bpf_printk("bpf_probe_read tls_version failed, ret :%d\n", ret);
-        return 0;
+//        return 0; // 在BoringSSL中，version可能为0，主要是使用了ssl->s3->hs对象
     }
     mastersecret->version = version & 0xFFFF;  //  uint16_t version;
 


### PR DESCRIPTION
This pull request makes several small but important changes to improve robustness and compatibility in the SSL/TLS probing code, especially when handling BoringSSL and OpenSSL differences. The main focus is on error handling and initialization logic, ensuring the code does not return prematurely in certain edge cases, and making pointer casting explicit for clarity.

**Error handling and robustness improvements:**

* Commented out early return statements in several BPF probe functions (`probe_ssl_master_key` in `boringssl_masterkey.h` and `probe_entry_SSL_read` in `openssl.h`) to prevent premature exit when encountering expected conditions, such as `version` being zero in BoringSSL or pointer reads failing, which can be normal in some cases. This allows the probes to continue processing and handle these cases more gracefully. [[1]](diffhunk://#diff-3c58e062da4010ab535ca162257d78dd851ffd08b68ac052ac10d59c9038788bL203-R203) [[2]](diffhunk://#diff-c5620a293aa34d3bee7e8fd42b03bf0f3e3d1fd7d1f68b2bf6aa2b5f82527329L373-L390) [[3]](diffhunk://#diff-c5620a293aa34d3bee7e8fd42b03bf0f3e3d1fd7d1f68b2bf6aa2b5f82527329L402-R401)
* Added comments explaining why early returns are suppressed, particularly noting BoringSSL's use of `ssl->s3->hs` and the possibility of `ssl->version` being empty. [[1]](diffhunk://#diff-3c58e062da4010ab535ca162257d78dd851ffd08b68ac052ac10d59c9038788bL203-R203) [[2]](diffhunk://#diff-c5620a293aa34d3bee7e8fd42b03bf0f3e3d1fd7d1f68b2bf6aa2b5f82527329L373-L390)

**Pointer casting and initialization:**

* Explicitly casted pointers to `void*` in calls to `bpf_probe_read_user` for clarity and correctness in `probe_entry_SSL_read` (`openssl.h`).

**Initialization logic fix:**

* Moved the initialization of `eventCollectorWriter` outside of the error check in the `runModule` function in `root.go`, ensuring it is always set when needed.