### PR TITLE
feat: implement OpenSSL version downgrade logic and improve logging

### DIFF
--- a/user/module/probe_openssl.go
+++ b/user/module/probe_openssl.go
@@ -196,13 +196,11 @@ func (m *MOpenSSLProbe) getSslBpfFile(soPath, sslVersion string) error {
 	}()
 
 	if sslVersion != "" {
-		m.logger.Info().Str("sslVersion", sslVersion).Msg("OpenSSL/BoringSSL version found")
 		bpfFile, found := m.sslVersionBpfMap[sslVersion]
 		if found {
+			m.logger.Info().Str("sslVersion", sslVersion).Msg("OpenSSL/BoringSSL version found")
 			m.sslBpfFile = bpfFile
 			return nil
-		} else {
-			m.logger.Error().Msg("Can't found OpenSSL/BoringSSL bpf bytecode file. auto detected.")
 		}
 	}
 
@@ -248,6 +246,7 @@ func (m *MOpenSSLProbe) getSslBpfFile(soPath, sslVersion string) error {
 	var bpfFileKey, bpfFile string
 	isAndroid := m.conf.(*config.OpensslConfig).IsAndroid
 	androidVer := m.conf.(*config.OpensslConfig).AndroidVer
+	bpfFileKey = sslVersion
 	if verString != "" {
 		m.conf.(*config.OpensslConfig).SslVersion = verString
 		m.logger.Info().Str("origin versionKey", verString).Str("versionKeyLower", verString).Send()
@@ -271,14 +270,10 @@ func (m *MOpenSSLProbe) getSslBpfFile(soPath, sslVersion string) error {
 		}
 	}
 
-	bpfFile = m.getSoDefaultBytecode(soPath, isAndroid)
+	bpfFile = m.autoDetectBytecode(bpfFileKey, soPath, isAndroid)
 	m.sslBpfFile = bpfFile
-	if isAndroid {
-		m.logger.Error().Msgf("OpenSSL/BoringSSL version not found, used default version.%s", fmt.Sprintf(OpensslNoticeUsedDefault, OpensslNoticeVersionGuideAndroid))
-	} else {
-		m.logger.Error().Msgf("OpenSSL/BoringSSL version not found, used default version.%s", fmt.Sprintf(OpensslNoticeUsedDefault, OpensslNoticeVersionGuideLinux))
-	}
-	m.logger.Error().Str("sslVersion", m.conf.(*config.OpensslConfig).SslVersion).Str("bpfFile", bpfFile).Send()
+
+	m.logger.Warn().Str("sslVersion", m.conf.(*config.OpensslConfig).SslVersion).Str("bpfFile", bpfFile).Send()
 	return nil
 }
 

--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/gojue/ecapture/user/config"
@@ -339,7 +340,7 @@ func (m *MOpenSSLProbe) downgradeOpensslVersion(ver string, soPath string) (stri
 
 		// 找到所有匹配前缀的key
 		for libKey := range m.sslVersionBpfMap {
-			if strings.HasPrefix(libKey, prefix) && libKey <= ver {
+			if strings.HasPrefix(libKey, prefix) && isVersionLessOrEqual(libKey, ver) {
 				candidates = append(candidates, libKey)
 			}
 		}
@@ -359,4 +360,83 @@ func (m *MOpenSSLProbe) downgradeOpensslVersion(ver string, soPath string) (stri
 		bpfFile, _ = m.sslVersionBpfMap[LinuxDefaultFilename111]
 	}
 	return bpfFile, false
+}
+
+// isVersionLessOrEqual 比较两个版本号字符串，返回 v1 <= v2
+func isVersionLessOrEqual(v1, v2 string) bool {
+	// 提取版本号部分，去掉 "openssl " 前缀
+	version1 := strings.TrimPrefix(v1, "openssl ")
+	version2 := strings.TrimPrefix(v2, "openssl ")
+
+	// 按点分割版本号
+	parts1 := strings.Split(version1, ".")
+	parts2 := strings.Split(version2, ".")
+
+	// 比较每个部分
+	maxLen := len(parts1)
+	if len(parts2) > maxLen {
+		maxLen = len(parts2)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var p1Str, p2Str string
+		if i < len(parts1) {
+			p1Str = parts1[i]
+		} else {
+			p1Str = "0"
+		}
+		if i < len(parts2) {
+			p2Str = parts2[i]
+		} else {
+			p2Str = "0"
+		}
+
+		// 分别提取数字和字母部分
+		num1, suffix1 := extractVersionPart(p1Str)
+		num2, suffix2 := extractVersionPart(p2Str)
+
+		// 先比较数字部分
+		if num1 < num2 {
+			return true
+		}
+		if num1 > num2 {
+			return false
+		}
+
+		// 数字相等时比较字母后缀
+		if suffix1 < suffix2 {
+			return true
+		}
+		if suffix1 > suffix2 {
+			return false
+		}
+	}
+
+	return true // 相等时返回 true
+}
+
+// extractVersionPart 从版本号部分中提取数字和字母后缀
+func extractVersionPart(s string) (int, string) {
+	var numStr strings.Builder
+	var suffix string
+
+	// 提取开头的数字部分
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		numStr.WriteByte(s[i])
+		i++
+	}
+
+	// 剩余部分作为后缀
+	if i < len(s) {
+		suffix = s[i:]
+	}
+
+	num := 0
+	if numStr.Len() > 0 {
+		// 忽略转换错误，因为我们已经确保了是数字
+		num, _ = strconv.Atoi(numStr.String())
+	}
+
+	return num, suffix
 }


### PR DESCRIPTION
This pull request refactors and enhances the OpenSSL probe's logic for selecting the appropriate BPF bytecode file when the exact OpenSSL/BoringSSL version is not found. The changes improve the robustness of version matching by introducing a downgrade mechanism and clarifying logging. The most important changes are:

### Improved version matching and fallback logic

* Added a new `downgradeOpensslVersion` method to attempt to find the closest lower matching version when the exact version is not available, improving compatibility with unknown or newer OpenSSL versions. (`user/module/probe_openssl_lib.go`)
* Replaced the previous default bytecode selection with a new `autoDetectBytecode` method that incorporates the downgrade logic and provides more informative logging when downgrading or defaulting. (`user/module/probe_openssl_lib.go`) [[1]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222L276-R277) [[2]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222L295-R308)

### Logging and error handling improvements

* Updated logging to better reflect when a downgrade or default fallback is used, including more specific warning and error messages. (`user/module/probe_openssl.go`, `user/module/probe_openssl_lib.go`) [[1]](diffhunk://#diff-779504b2ae7d5c72fdd91b76febcf4f3a108e7bd02638501401a518f773cb195L199-L205) [[2]](diffhunk://#diff-779504b2ae7d5c72fdd91b76febcf4f3a108e7bd02638501401a518f773cb195L274-R276) [[3]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222L295-R308)

### Code organization and clarity

* Renamed and refactored methods for clarity, such as changing `getSoDefaultBytecode` to `autoDetectBytecode`, and added a missing assignment for the `bpfFileKey`. (`user/module/probe_openssl.go`, `user/module/probe_openssl_lib.go`) [[1]](diffhunk://#diff-779504b2ae7d5c72fdd91b76febcf4f3a108e7bd02638501401a518f773cb195R249) [[2]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222L276-R277)
* Added the `sort` package import to support candidate version sorting in the downgrade logic. (`user/module/probe_openssl_lib.go`)

fix:#818