### PR TITLE
feat: update OpenSSL version offsets for 3.0, 3.2, 3.3, 3.4, and 3.5

### DIFF
--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -45,18 +45,18 @@ const (
 	MaxSupportedOpenSSL102Version = 'u'
 	MaxSupportedOpenSSL110Version = 'l'
 	MaxSupportedOpenSSL111Version = 'w'
-	MaxSupportedOpenSSL30Version  = 15
+	MaxSupportedOpenSSL30Version  = 17
 	MaxSupportedOpenSSL31Version  = 8
 	SupportedOpenSSL32Version2    = 2 // openssl 3.2.0 ~ 3.2.2
 	SupportedOpenSSL32Version3    = 3 // openssl 3.2.3
-	SupportedOpenSSL32Version4    = 4 // openssl 3.2.4
+	SupportedOpenSSL32Version4    = 5 // openssl 3.2.5
 	MaxSupportedOpenSSL32Version  = 3 // openssl 3.2.3 ~ newer
 	SupportedOpenSSL33Version1    = 1 // openssl 3.3.0 ~ 3.3.1
 	SupportedOpenSSL33Version2    = 2 // openssl 3.3.2
-	MaxSupportedOpenSSL33Version  = 3 // openssl 3.3.3
+	MaxSupportedOpenSSL33Version  = 4 // openssl 3.3.4
 	SupportedOpenSSL34Version0    = 0 // openssl 3.4.0
-	MaxSupportedOpenSSL34Version  = 1 // openssl 3.4.1
-	SupportedOpenSSL35Version0    = 0 // openssl 3.5.0
+	MaxSupportedOpenSSL34Version  = 2 // openssl 3.4.2
+	SupportedOpenSSL35Version0    = 2 // openssl 3.5.2
 	MaxSupportedOpenSSL35Version  = 0 // openssl 3.5.1
 )
 
@@ -136,7 +136,7 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 
 	// openssl 3.2.3
 	m.sslVersionBpfMap[fmt.Sprintf("openssl 3.2.%d", SupportedOpenSSL32Version3)] = "openssl_3_2_3_kern.o"
-	// openssl 3.2.4
+	// openssl 3.2.5
 	m.sslVersionBpfMap[fmt.Sprintf("openssl 3.2.%d", SupportedOpenSSL32Version4)] = "openssl_3_2_4_kern.o"
 
 	// openssl 3.3.0 - 3.3.1
@@ -149,7 +149,7 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.3.%d", ch)] = "openssl_3_3_2_kern.o"
 	}
 
-	// openssl 3.3.3
+	// openssl 3.3.4
 	for ch := 3; ch <= MaxSupportedOpenSSL33Version; ch++ {
 		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.3.%d", ch)] = "openssl_3_3_3_kern.o"
 	}

--- a/utils/openssl_offset_3.0.sh
+++ b/utils/openssl_offset_3.0.sh
@@ -41,6 +41,8 @@ function run() {
   sslVerMap["13"]="0"
   sslVerMap["14"]="0"
   sslVerMap["15"]="0"
+  sslVerMap["16"]="1"
+  sslVerMap["17"]="2"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do

--- a/utils/openssl_offset_3.2.sh
+++ b/utils/openssl_offset_3.2.sh
@@ -30,6 +30,7 @@ function run() {
   sslVerMap["2"]="0"
   sslVerMap["3"]="3"
   sslVerMap["4"]="4"
+  sslVerMap["5"]="5"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do

--- a/utils/openssl_offset_3.3.sh
+++ b/utils/openssl_offset_3.3.sh
@@ -30,6 +30,7 @@ function run() {
   sslVerMap["1"]="0"
   sslVerMap["2"]="2"
   sslVerMap["3"]="3"
+  sslVerMap["4"]="4"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do

--- a/utils/openssl_offset_3.4.sh
+++ b/utils/openssl_offset_3.4.sh
@@ -28,7 +28,7 @@ function run() {
   declare -A sslVerMap=()
   sslVerMap["0"]="0"
   sslVerMap["1"]="1"
-#  sslVerMap["2"]="2"
+  sslVerMap["2"]="2"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do

--- a/utils/openssl_offset_3.5.sh
+++ b/utils/openssl_offset_3.5.sh
@@ -26,6 +26,8 @@ function run() {
   cp -f ${PROJECT_ROOT_DIR}/utils/openssl_3_5_0_offset.c ${OPENSSL_DIR}/offset.c
   declare -A sslVerMap=()
   sslVerMap["0"]="0"
+  sslVerMap["1"]="1"
+  sslVerMap["2"]="2"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do


### PR DESCRIPTION
This pull request updates the version mapping and support for various OpenSSL 3.x releases across both the Go module and related shell scripts. The main goal is to add support for newer OpenSSL patch versions and ensure all version mappings are up to date and consistent.

**OpenSSL version support and mapping updates:**

* Updated version constants in `probe_openssl_lib.go` to support newer OpenSSL 3.0, 3.2, 3.3, 3.4, and 3.5 patch versions, including incrementing `MaxSupportedOpenSSL30Version` to 17, `SupportedOpenSSL32Version4` to 5, `MaxSupportedOpenSSL33Version` to 4, and others. (`user/module/probe_openssl_lib.go`)
* Updated the `sslVersionBpfMap` in `initOpensslOffset()` to correctly reference the latest supported OpenSSL patch versions, such as mapping 3.2.5 and 3.3.4 to their respective kernel object files. (`user/module/probe_openssl_lib.go`) [[1]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222L139-R139) [[2]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222L152-R152)

**Shell script mapping updates:**

* Added or updated entries in the version-to-offset maps for OpenSSL 3.0, 3.2, 3.3, 3.4, and 3.5 in their respective helper scripts, ensuring that all supported patch versions are included and mapped to the correct offsets. (`utils/openssl_offset_3.0.sh`, `utils/openssl_offset_3.2.sh`, `utils/openssl_offset_3.3.sh`, `utils/openssl_offset_3.4.sh`, `utils/openssl_offset_3.5.sh`) [[1]](diffhunk://#diff-92a92a35bff98f48a264260d1fda68b26e5b5e0e4d47e2bf932eb8ea791c23bfR44-R45) [[2]](diffhunk://#diff-6aa34c8928116ca700aa329d9d70c819e6c6970d9ef664e23dbbd7e52eaa5702R33) [[3]](diffhunk://#diff-3c08d8497cea98b0734f0ae973a378ed9cf6f1888daa96e74d0a5cf6d7e832bdR33) [[4]](diffhunk://#diff-5ee6ffeec10708c7d7c127de818f69d6f572cc025da53b214cc7eeae290ee80eL31-R31) [[5]](diffhunk://#diff-978409480ff08408c60c12bc2de9cb8c540c48572f53683c578d88d44743c2b5R29-R30)