### PR TITLE
bugfix: support keylog mode for OpenSSL 3.0.12

### DIFF
--- a/kern/openssl_3_0_12_kern.c
+++ b/kern/openssl_3_0_12_kern.c
@@ -1,0 +1,70 @@
+#ifndef ECAPTURE_OPENSSL_3_0_12_KERN_H
+#define ECAPTURE_OPENSSL_3_0_12_KERN_H
+
+/* OPENSSL_VERSION_TEXT: OpenSSL 3.0.12 Oct 24, 2023 */
+/* OPENSSL_VERSION_NUMBER: 805306575 */
+
+// ssl_st->version
+#define SSL_ST_VERSION 0x0
+
+// ssl_st->session
+#define SSL_ST_SESSION 0x938
+
+// ssl_st->s3
+#define SSL_ST_S3 0xa8
+
+// ssl_st->rbio
+#define SSL_ST_RBIO 0x10
+
+// ssl_st->wbio
+#define SSL_ST_WBIO 0x18
+
+// ssl_st->server
+#define SSL_ST_SERVER 0x38
+
+// ssl_session_st->master_key
+#define SSL_SESSION_ST_MASTER_KEY 0x50
+
+// ssl_st->s3.client_random
+#define SSL_ST_S3_CLIENT_RANDOM 0x160
+
+// ssl_session_st->cipher
+#define SSL_SESSION_ST_CIPHER 0x2f8
+
+// ssl_session_st->cipher_id
+#define SSL_SESSION_ST_CIPHER_ID 0x300
+
+// ssl_cipher_st->id
+#define SSL_CIPHER_ST_ID 0x18
+
+// ssl_st->early_secret
+#define SSL_ST_EARLY_SECRET 0x544
+
+// ssl_st->handshake_secret
+#define SSL_ST_HANDSHAKE_SECRET 0x584
+
+// ssl_st->handshake_traffic_hash
+#define SSL_ST_HANDSHAKE_TRAFFIC_HASH 0x704
+
+// ssl_st->client_app_traffic_secret
+#define SSL_ST_CLIENT_APP_TRAFFIC_SECRET 0x744
+
+// ssl_st->server_app_traffic_secret
+#define SSL_ST_SERVER_APP_TRAFFIC_SECRET 0x784
+
+// ssl_st->exporter_master_secret
+#define SSL_ST_EXPORTER_MASTER_SECRET 0x7c4
+
+// bio_st->num
+#define BIO_ST_NUM 0x38
+
+// bio_st->method
+#define BIO_ST_METHOD 0x8
+
+// bio_method_st->type
+#define BIO_METHOD_ST_TYPE 0x0
+
+#include "openssl.h"
+#include "openssl_masterkey_3.0.h"
+
+#endif

--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -45,6 +45,7 @@ const (
 	MaxSupportedOpenSSL102Version = 'u'
 	MaxSupportedOpenSSL110Version = 'l'
 	MaxSupportedOpenSSL111Version = 'w'
+	SupportedOpenSSL30Version12   = 12 // openssl 3.0.12
 	MaxSupportedOpenSSL30Version  = 17
 	MaxSupportedOpenSSL31Version  = 8
 	SupportedOpenSSL32Version2    = 2 // openssl 3.2.0 ~ 3.2.2
@@ -122,6 +123,9 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 	for ch := 0; ch <= MaxSupportedOpenSSL30Version; ch++ {
 		m.sslVersionBpfMap[fmt.Sprintf("openssl 3.0.%d", ch)] = "openssl_3_0_0_kern.o"
 	}
+
+	// support openssl 3.0.12
+	m.sslVersionBpfMap[fmt.Sprintf("openssl 3.0.%d", SupportedOpenSSL30Version12)] = "openssl_3_0_12_kern.o"
 
 	// openssl 3.1.0 - 3.1.8
 	for ch := 0; ch <= MaxSupportedOpenSSL31Version; ch++ {

--- a/variables.mk
+++ b/variables.mk
@@ -198,6 +198,7 @@ TARGETS += kern/openssl_1_1_1j
 TARGETS += kern/openssl_1_1_0a
 TARGETS += kern/openssl_1_0_2a
 TARGETS += kern/openssl_3_0_0
+TARGETS += kern/openssl_3_0_12
 TARGETS += kern/openssl_3_1_0
 TARGETS += kern/openssl_3_2_0
 TARGETS += kern/openssl_3_2_3


### PR DESCRIPTION
bugfix: support keylog mode for OpenSSL 3.0.12
#825 