### PR TITLE
typo: comment in cmd packages

### DIFF
--- a/cli/cmd/gnutls.go
+++ b/cli/cmd/gnutls.go
@@ -28,7 +28,7 @@ import (
 
 var gc = config.NewGnutlsConfig()
 
-// gnutlsCmd represents the openssl command
+// gnutlsCmd represents the gnutls command
 var gnutlsCmd = &cobra.Command{
 	Use:     "gnutls",
 	Aliases: []string{"gnu"},
@@ -55,7 +55,7 @@ func init() {
 	rootCmd.AddCommand(gnutlsCmd)
 }
 
-// gnuTlsCommandFunc executes the "bash" command.
+// gnuTlsCommandFunc executes the "gnutls" command.
 func gnuTlsCommandFunc(command *cobra.Command, args []string) error {
 	if gc.PcapFilter == "" && len(args) != 0 {
 		gc.PcapFilter = strings.Join(args, " ")

--- a/cli/cmd/gotls.go
+++ b/cli/cmd/gotls.go
@@ -25,7 +25,7 @@ import (
 
 var goc = config.NewGoTLSConfig()
 
-// gotlsCmd represents the openssl command
+// gotlsCmd represents the gotls command
 var gotlsCmd = &cobra.Command{
 	Use:     "gotls",
 	Aliases: []string{"tlsgo"},
@@ -48,7 +48,7 @@ func init() {
 	rootCmd.AddCommand(gotlsCmd)
 }
 
-// goTLSCommandFunc executes the "bash" command.
+// goTLSCommandFunc executes the "gotls" command.
 func goTLSCommandFunc(command *cobra.Command, args []string) error {
 	if goc.PcapFilter == "" && len(args) != 0 {
 		goc.PcapFilter = strings.Join(args, " ")

--- a/cli/cmd/nspr.go
+++ b/cli/cmd/nspr.go
@@ -26,7 +26,7 @@ import (
 
 var nc = config.NewNsprConfig()
 
-// gnutlsCmd represents the openssl command
+// nssCmd represents the nspr command
 var nssCmd = &cobra.Command{
 	Use:     "nspr",
 	Aliases: []string{"nss"},
@@ -45,7 +45,7 @@ func init() {
 	rootCmd.AddCommand(nssCmd)
 }
 
-// nssCommandFunc executes the "bash" command.
+// nssCommandFunc executes the "nspr" command.
 func nssCommandFunc(command *cobra.Command, args []string) error {
 	return runModule(module.ModuleNameNspr, nc)
 }

--- a/cli/cmd/tls.go
+++ b/cli/cmd/tls.go
@@ -58,7 +58,7 @@ func init() {
 	rootCmd.AddCommand(opensslCmd)
 }
 
-// openSSLCommandFunc executes the "bash" command.
+// openSSLCommandFunc executes the "tls" command.
 func openSSLCommandFunc(command *cobra.Command, args []string) error {
 	if oc.PcapFilter == "" && len(args) != 0 {
 		oc.PcapFilter = strings.Join(args, " ")


### PR DESCRIPTION
This pull request updates the documentation comments for several command definitions and handler functions in the CLI codebase. The main goal is to correct and clarify the descriptions, ensuring each comment accurately reflects the command or function it documents.

Documentation improvements:

* Updated comments in `cli/cmd/gnutls.go` to correctly describe `gnutlsCmd` as representing the gnutls command and `gnuTlsCommandFunc` as executing the "gnutls" command. [[1]](diffhunk://#diff-6776943b3e73fbd69be16045db36e268f94fac13a0021034d0e2bad3e05589f7L31-R31) [[2]](diffhunk://#diff-6776943b3e73fbd69be16045db36e268f94fac13a0021034d0e2bad3e05589f7L58-R58)
* Updated comments in `cli/cmd/gotls.go` to correctly describe `gotlsCmd` as representing the gotls command and `goTLSCommandFunc` as executing the "gotls" command. [[1]](diffhunk://#diff-797a4731cbccf3f15310903afdc4cd96774bd3eae540c895a365ea8291f7c0beL28-R28) [[2]](diffhunk://#diff-797a4731cbccf3f15310903afdc4cd96774bd3eae540c895a365ea8291f7c0beL51-R51)
* Updated comments in `cli/cmd/nspr.go` to correctly describe `nssCmd` as representing the nspr command and `nssCommandFunc` as executing the "nspr" command. [[1]](diffhunk://#diff-8edae6dc835b003adeb23706b2a5f49409275c24975c87c9c559ec6a969ffbf2L29-R29) [[2]](diffhunk://#diff-8edae6dc835b003adeb23706b2a5f49409275c24975c87c9c559ec6a969ffbf2L48-R48)
* Updated the comment in `cli/cmd/tls.go` to correctly describe `openSSLCommandFunc` as executing the "tls" command.