### PR TITLE
feat: update Go version to 1.24.6 across multiple configuration files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.24.3'
+          go-version: '1.24.6'
       - name: Checkout repository
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/go-c-cpp.yml
+++ b/.github/workflows/go-c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version: '1.24.6'
       - name: Install Compilers
         run: |
           sudo apt-get update
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version: '1.24.6'
       - name: Install Compilers
         run: |
           sudo apt-get update

--- a/.github/workflows/pr_build_debug.yml
+++ b/.github/workflows/pr_build_debug.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version: '1.24.6'
 
       - name: Install Compilers
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24.3'
+          go-version: '1.24.6'
       - name: Install Compilers
         run: |
           sudo apt-get update

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update &&\
 # Install golang
 ARG TARGETARCH
 RUN if [ "$TARGETARCH" = "arm64" ] || [ "$TARGETARCH" = "amd64" ]; then\
-  wget -O go.tar.gz https://golang.google.cn/dl/go1.24.3.linux-${TARGETARCH}.tar.gz; \
+  wget -O go.tar.gz https://golang.google.cn/dl/go1.24.6.linux-${TARGETARCH}.tar.gz; \
   else \
   echo "unsupport arch" && /bin/false ; \
   fi && \

--- a/builder/init_env.sh
+++ b/builder/init_env.sh
@@ -60,7 +60,7 @@ if [[ ${UNAME_M} =~ "x86_64" ]];then
     echo "unsupported arch ${UNAME_M}";
 fi
 
-GOBIN_ZIP="go1.24.3.linux-${ARCH}.tar.gz"
+GOBIN_ZIP="go1.24.6.linux-${ARCH}.tar.gz"
 echo "GOBIN_ZIP:${GOBIN_ZIP}"
 
 

--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -125,6 +125,7 @@ func (m *MOpenSSLProbe) initOpensslOffset() {
 	}
 
 	// support openssl 3.0.12
+	// 2025-08-23  3.0.12 is a special version, the offset is different from 3.0.0 - 3.0.11, and 3.0.13 - 3.0.17, so we need to special support it
 	m.sslVersionBpfMap[fmt.Sprintf("openssl 3.0.%d", SupportedOpenSSL30Version12)] = "openssl_3_0_12_kern.o"
 
 	// openssl 3.1.0 - 3.1.8

--- a/utils/openssl_offset_3.0.sh
+++ b/utils/openssl_offset_3.0.sh
@@ -37,12 +37,12 @@ function run() {
   sslVerMap["9"]="0"
   sslVerMap["10"]="0"
   sslVerMap["11"]="0"
-  sslVerMap["12"]="0"
+  sslVerMap["12"]="12"  # 3.0.12 is different from 3.0.0 ~ 3.0.11 and 3.0.13 ~ 3.0.17  2025-08-23
   sslVerMap["13"]="0"
   sslVerMap["14"]="0"
   sslVerMap["15"]="0"
-  sslVerMap["16"]="1"
-  sslVerMap["17"]="2"
+  sslVerMap["16"]="0"
+  sslVerMap["17"]="0"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do


### PR DESCRIPTION
This pull request primarily updates the Go version used across the project from 1.24.3 to 1.24.6 in multiple CI workflow files and build scripts, ensuring consistency and access to the latest bug fixes and features. Additionally, it introduces special handling for OpenSSL 3.0.12, which has unique offsets compared to other 3.0.x versions.

**Go version update across CI and build scripts:**

* Updated the Go version from `1.24.3` to `1.24.6` in GitHub Actions workflows: `.github/workflows/codeql-analysis.yml`, `.github/workflows/go-c-cpp.yml`, `.github/workflows/pr_build_debug.yml`, and `.github/workflows/release.yml`. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L42-R42) [[2]](diffhunk://#diff-11d51e8bc8a13747c44b9bfc9e8bfbb355d0c3f4f5c2a695f8cb75a9abd9c7c1L15-R15) [[3]](diffhunk://#diff-11d51e8bc8a13747c44b9bfc9e8bfbb355d0c3f4f5c2a695f8cb75a9abd9c7c1L75-R75) [[4]](diffhunk://#diff-c91b6ca6fafedb2ed2a084385311a0d166cca0669cbe73ca9ec8e709b333283fL22-R22) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L19-R19)
* Updated the Go download URL in `builder/Dockerfile` and the Go binary filename in `builder/init_env.sh` to reflect the new version. [[1]](diffhunk://#diff-5097196aa827816e990d13cafdea11a1ff82823cee1699a6d74a006d84765eefL15-R15) [[2]](diffhunk://#diff-537513f8be3b6050460501b2acbf530b173b9e8b517c3bdf843f95df5a3f957cL63-R63)

**OpenSSL 3.0.12 special case handling:**

* Added a comment and logic in `user/module/probe_openssl_lib.go` and `utils/openssl_offset_3.0.sh` to treat OpenSSL 3.0.12 as a special case due to its unique offsets, distinguishing it from other 3.0.x versions. [[1]](diffhunk://#diff-1b346c140310f5afd447361b2d76c6fd70d9900d9194dfb82a2d65e1fe242222R128) [[2]](diffhunk://#diff-92a92a35bff98f48a264260d1fda68b26e5b5e0e4d47e2bf932eb8ea791c23bfL40-R45)