### PR TITLE
feat: enhance PR build debug workflow with permissions and detailed completion message

### DIFF
--- a/.github/workflows/pr_build_debug.yml
+++ b/.github/workflows/pr_build_debug.yml
@@ -4,6 +4,11 @@ on:
     branches: [ master, main ]
     types: [ opened, synchronize, reopened ]
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -100,7 +105,7 @@ jobs:
               issue_number: prNumber,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `🔧 **Debug Build Complete**
+              body: `🔧 **Debug Build Complete (PR ${prNumber}, RunID ${runId})**
             
               📦 Download Links:
               - [PR ${prNumber} Debug Binary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})


### PR DESCRIPTION

> RequestError [HttpError]: Resource not accessible by integration
Error: Unhandled error: HttpError: Resource not accessible by integration
This pull request updates the GitHub Actions workflow for pull request debug builds. The main changes are the addition of explicit permissions for the workflow and an improved debug build completion message that includes the PR number and run ID.


Workflow configuration improvements:

* Added explicit permissions for `contents`, `issues`, and `pull-requests` with `write` access in `.github/workflows/pr_build_debug.yml` to ensure the workflow can perform required actions.

Debug build notification enhancements:

* Updated the debug build completion message in `.github/workflows/pr_build_debug.yml` to include the PR number and run ID for clearer traceability.