### PR TITLE
bugfix: keep nanoseconds precision for timestamps

### DIFF
--- a/user/event/event_gnutls.go
+++ b/user/event/event_gnutls.go
@@ -58,7 +58,7 @@ func (ge *GnutlsDataEvent) Decode(payload []byte) (err error) {
 
 	decodedKtime, err := DecodeKtime(int64(ge.Timestamp), true)
 	if err == nil {
-		ge.Timestamp = uint64(uint64(decodedKtime.UnixNano()))
+		ge.Timestamp = uint64(decodedKtime.UnixNano())
 	}
 
 	return nil

--- a/user/event/event_gotls.go
+++ b/user/event/event_gotls.go
@@ -38,7 +38,7 @@ func (ge *GoTLSEvent) Decode(payload []byte) error {
 	}
 	decodedKtime, err := DecodeKtime(int64(ge.TimestampNS), true)
 	if err == nil {
-		ge.TimestampNS = uint64(uint64(decodedKtime.UnixNano()))
+		ge.TimestampNS = uint64(decodedKtime.UnixNano())
 	}
 
 	return err

--- a/user/event/event_mysqld.go
+++ b/user/event/event_mysqld.go
@@ -101,7 +101,7 @@ func (me *MysqldEvent) Decode(payload []byte) (err error) {
 
 	decodedKtime, err := DecodeKtime(int64(me.Timestamp), true)
 	if err == nil {
-		me.Timestamp = uint64(uint64(decodedKtime.UnixNano()))
+		me.Timestamp = uint64(decodedKtime.UnixNano())
 	}
 
 	return nil

--- a/user/event/event_nspr.go
+++ b/user/event/event_nspr.go
@@ -58,7 +58,7 @@ func (ne *NsprDataEvent) Decode(payload []byte) (err error) {
 	}
 	decodedKtime, err := DecodeKtime(int64(ne.Timestamp), true)
 	if err == nil {
-		ne.Timestamp = uint64(uint64(decodedKtime.UnixNano()))
+		ne.Timestamp = uint64(decodedKtime.UnixNano())
 	}
 	return nil
 }

--- a/user/event/event_openssl.go
+++ b/user/event/event_openssl.go
@@ -124,7 +124,7 @@ func (se *SSLDataEvent) Decode(payload []byte) (err error) {
 
 	decodedKtime, err := DecodeKtime(int64(se.Timestamp), true)
 	if err == nil {
-		se.Timestamp = uint64(uint64(decodedKtime.UnixNano()))
+		se.Timestamp = uint64(decodedKtime.UnixNano())
 	}
 	return nil
 }

--- a/user/event/event_postgres.go
+++ b/user/event/event_postgres.go
@@ -57,7 +57,7 @@ func (pe *PostgresEvent) Decode(payload []byte) (err error) {
 	}
 	decodedKtime, err := DecodeKtime(int64(pe.Timestamp), true)
 	if err == nil {
-		pe.Timestamp = uint64(uint64(decodedKtime.UnixNano()))
+		pe.Timestamp = uint64(decodedKtime.UnixNano())
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #849

@dosu

cc: @cfc4n 