### PR TITLE
bugfix: update permissions and improve error handling in PR comment workflow

### DIFF
--- a/.github/workflows/pr_build_debug.yml
+++ b/.github/workflows/pr_build_debug.yml
@@ -5,9 +5,10 @@ on:
     types: [ opened, synchronize, reopened ]
 
 permissions:
-  contents: write
+  contents: read
   issues: write
   pull-requests: write
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -93,22 +94,29 @@ jobs:
     runs-on: ubuntu-22.04
     name: Comment PR with Download Links
     needs: build-debug-artifacts
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Comment PR with Download Links
         uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const runId = context.runId;
             const prNumber = context.payload.pull_request.number;
             
-            github.rest.issues.createComment({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `🔧 **Debug Build Complete (PR ${prNumber}, RunID ${runId})**
-            
-              📦 Download Links:
-              - [PR ${prNumber} Debug Binary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})
-            
-              ⏰ Files will be retained for 7 days, please download and test promptly.`
-            });
+            try {
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `🔧 **Debug Build Complete (PR ${prNumber}, RunID ${runId})**
+
+            📦 Download Links:
+            - [PR ${prNumber} Debug Binary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})
+
+            ⏰ Files will be retained for 7 days, please download and test promptly.`
+              });
+              console.log('Comment created successfully');
+            } catch (error) {
+              console.log('Failed to create comment:', error.message);
+            }


### PR DESCRIPTION
This pull request updates the `pr_build_debug.yml` GitHub Actions workflow to improve security and reliability. The most important changes are:

**Permissions and Security:**

* Changed the `contents` permission from `write` to `read` and added `actions: read` to limit the workflow’s access scope, following the principle of least privilege.

**Workflow Reliability and Correctness:**

* Added a conditional to the "Comment PR with Download Links" job so it only runs for pull requests from the same repository, preventing issues with forks.
* Explicitly set the `github-token` input for the `actions/github-script` step to ensure proper authentication.
* Wrapped the comment creation in a try/catch block to log success or failure, improving error handling and debugging information.

fix: #852