### PR TITLE
feat: support OpenSSL 3.5.4

### DIFF
--- a/user/module/probe_openssl_lib.go
+++ b/user/module/probe_openssl_lib.go
@@ -57,8 +57,8 @@ const (
 	MaxSupportedOpenSSL33Version  = 4 // openssl 3.3.4
 	SupportedOpenSSL34Version0    = 0 // openssl 3.4.0
 	MaxSupportedOpenSSL34Version  = 2 // openssl 3.4.2
-	SupportedOpenSSL35Version0    = 2 // openssl 3.5.2
-	MaxSupportedOpenSSL35Version  = 0 // openssl 3.5.1
+	SupportedOpenSSL35Version0    = 4 // openssl 3.5.0 ~ 3.5.4
+	MaxSupportedOpenSSL35Version  = 4 // openssl 3.5.4
 )
 
 var (

--- a/utils/openssl_offset_3.5.sh
+++ b/utils/openssl_offset_3.5.sh
@@ -28,6 +28,8 @@ function run() {
   sslVerMap["0"]="0"
   sslVerMap["1"]="1"
   sslVerMap["2"]="2"
+  sslVerMap["3"]="3"
+  sslVerMap["4"]="4"
 
   # shellcheck disable=SC2068
   for ver in ${!sslVerMap[@]}; do


### PR DESCRIPTION
Debian testing is using this version, fix a warn.


<img width="2236" height="1258" alt="image" src="https://github.com/user-attachments/assets/6e121262-3996-459f-89e1-30ce9250721c" />
