### PR TITLE
feat: make ecaptureq heartbeat interval configurable

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -146,6 +146,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&globalConf.LoggerAddr, "logaddr", "l", "", "send logs to this server. -l /tmp/ecapture.log or -l ws://127.0.0.1:8090/ecapture or -l tcp://127.0.0.1:8080")
 	rootCmd.PersistentFlags().StringVar(&globalConf.EventCollectorAddr, "eventaddr", "", "the server address that receives the captured event. --eventaddr ws://127.0.0.1:8090/ecapture or tcp://127.0.0.1:8090, default: same as logaddr")
 	rootCmd.PersistentFlags().StringVar(&globalConf.EcaptureQ, "ecaptureq", "", "listening server, waiting for clients to connect before sending events and logs; false: send directly to the remote server.")
+	rootCmd.PersistentFlags().IntVar(&globalConf.EcaptureQHeartbeatInterval, "ecaptureq-heartbeat-interval", 20, "modify the heartbeat interval of the websocket server (in seconds).")
 	rootCmd.PersistentFlags().StringVar(&globalConf.Listen, "listen", configUpdateAddr, "Listens on a port, receives HTTP requests, and is used to update the runtime configuration, default: 127.0.0.1:28256")
 	rootCmd.PersistentFlags().Uint64VarP(&globalConf.TruncateSize, "tsize", "t", defaultTruncateSize, "the truncate size in text mode, default: 0 (B), no truncate")
 	rootCmd.PersistentFlags().Uint16Var(&rorateSize, "eventroratesize", 0, "the rorate size(MB) of the event collector file, 1M~65535M, only works for eventaddr server is file. --eventaddr=tls.log --eventroratesize=1 --eventroratetime=30")
@@ -257,7 +258,7 @@ func runModule(modName string, modConfig config.IConfig) error {
 		if err != nil {
 			return err
 		}
-		es := ecaptureq.NewServer(parsedURL.Host, os.Stdout)
+		es := ecaptureq.NewServer(parsedURL.Host, os.Stdout, globalConf.EcaptureQHeartbeatInterval)
 		go func() {
 			err := es.Start()
 			if err != nil {

--- a/pkg/ecaptureq/client.go
+++ b/pkg/ecaptureq/client.go
@@ -45,6 +45,8 @@ type Client struct {
 	heartBeatCount int
 
 	hbTimer *time.Ticker
+
+	heartbeatInterval time.Duration
 }
 
 // readPump pumps messages from the websocket connection to the hub.
@@ -80,11 +82,18 @@ func (c *Client) readPump() {
 // application ensures that there is at most one writer to a connection by
 // executing all writes from this goroutine.
 func (c *Client) writePump() {
-	c.hbTimer = time.NewTicker(60 * time.Second)
+	c.hbTimer = time.NewTicker(c.heartbeatInterval)
 	defer func() {
 		c.hbTimer.Stop()
 		_ = c.conn.Close()
 	}()
+
+	// heartbeat when client connected
+	err := c.Heartbeat()
+	if err != nil {
+		_, _ = c.logger.Write([]byte(fmt.Sprintf("writePump: error sending heartbeat: %v\n", err)))
+	}
+
 	for {
 		select {
 		case message, ok := <-c.send:

--- a/user/config/iconfig.go
+++ b/user/config/iconfig.go
@@ -100,15 +100,16 @@ type BaseConfig struct {
 	TruncateSize uint64 `json:"truncate_size"` // truncate size in text mode
 
 	// eBPF map configuration
-	PerCpuMapSize      int    `json:"per_cpu_map_size"`     // Size of eBPF map per CPU core
-	IsHex              bool   `json:"is_hex"`               // Whether to display output in hexadecimal
-	Debug              bool   `json:"debug"`                // Enable debug mode
-	BtfMode            uint8  `json:"btf_mode"`             // BTF mode selection
-	ByteCodeFileMode   uint8  `json:"byte_code_file_mode"`  // assets/* include bytecode file type
-	LoggerAddr         string `json:"logger_addr"`          // Address for logger output
-	LoggerType         uint8  `json:"logger_type"`          // Logger type (0:stdout, 1:file, 2:tcp)
-	EventCollectorAddr string `json:"event_collector_addr"` // Address of the event collector server
-	EcaptureQ          string `json:"ecapture_q"`           // ecaptureQ 模式，本地监听Server，等待Q连接
+	PerCpuMapSize              int    `json:"per_cpu_map_size"`             // Size of eBPF map per CPU core
+	IsHex                      bool   `json:"is_hex"`                       // Whether to display output in hexadecimal
+	Debug                      bool   `json:"debug"`                        // Enable debug mode
+	BtfMode                    uint8  `json:"btf_mode"`                     // BTF mode selection
+	ByteCodeFileMode           uint8  `json:"byte_code_file_mode"`          // assets/* include bytecode file type
+	LoggerAddr                 string `json:"logger_addr"`                  // Address for logger output
+	LoggerType                 uint8  `json:"logger_type"`                  // Logger type (0:stdout, 1:file, 2:tcp)
+	EventCollectorAddr         string `json:"event_collector_addr"`         // Address of the event collector server
+	EcaptureQ                  string `json:"ecapture_q"`                   // ecaptureQ websocket server
+	EcaptureQHeartbeatInterval int    `json:"ecaptureq_heartbeat_interval"` // ecaptureQ heartbeat interval
 }
 
 func (c *BaseConfig) GetPid() uint64 {


### PR DESCRIPTION
- Added `--ecaptureq-heartbeat-interval` flag (default 20s).
- Updated WebSocket client to use the configured interval instead of the hardcoded 60s.
- Send an immediate heartbeat upon client connection.