### PR TITLE
feat: add remote configuration update API documentation and event forwarding details

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,17 @@ For details of the Protobuf log schema used by eCapture/eCaptureQ, see:
 See [CONTRIBUTING](./CONTRIBUTING.md) for details on submitting patches and the contribution workflow.
 
 # Compilation
+## Custom Compilation
 
-See [COMPILATION](./COMPILATION.md) for details on compiling the eCapture source code.
+You can customize the features you want, such as setting the offset address for `uprobe` to support statically compiled OpenSSL libraries. Refer to the [COMPILATION](./COMPILATION.md) introduction for compilation instructions.
+
+## Configurations Remote Update
+
+After eCapture is running, you can dynamically modify the configurations through HTTP interfaces. Refer to the [HTTP API Documentation](./docs/remote-config-update-api.md).
+
+## Event Forwarding
+
+eCapture supports multiple event forwarding methods. You can forward events to packet capture software such as Burp Suite. For details, refer to the [Event Forwarding API Documentation](./docs/event-forward-api.md).
 
 ## Acknowledgements
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -32,7 +32,7 @@
   - [使用演示](#使用演示)
 - [星标成长曲线](#星标成长曲线)
 - [贡献](#贡献)
-- [编译](#编译)
+- [二次开发](#二次开发)
 - [微信公众号](#微信公众号)
 <!-- /MarkdownTOC -->
 ----
@@ -294,10 +294,16 @@ https://github.com/user-attachments/assets/c8b7a84d-58eb-4fdb-9843-f775c97bdbfb
 
 参考 [CONTRIBUTING](./CONTRIBUTING.md)的介绍，提交缺陷、补丁、建议等，非常感谢。
 
-# 编译
-
+# 二次开发
+## 自行编译
 你可以定制自己想要的功能，比如设定`uprobe`
 的偏移地址，用来支持被静态编译的Openssl类库。编译方法可以参考 [COMPILATION](./COMPILATION_CN.md)的介绍。
+
+## 动态修改配置
+当eCapture运行后，你可以通过HTTP接口动态修改配置，参考[HTTP API 文档](./docs/remote-config-update-api_CN.md)。
+
+## 事件转发
+eCapture支持多种事件转发方式，你可以将事件转发至Burp Suite等抓包软件，详情参考[事件转发API 文档](./docs/event-forward-api_CN.md)。
 
 # 微信公众号
 ![](./images/wechat_gzhh.png)

--- a/cli/http/resp.go
+++ b/cli/http/resp.go
@@ -18,13 +18,13 @@ package http
 type Status uint8
 
 const (
-	RespOK Status = iota
-	RespErrorInvaildRequest
-	RespErrorInternalServer
-	RespErrorNotFound
-	RespConfigDecodeFailed
-	RespConfigCheckFailed
-	RespSendToChanFailed
+	RespOK                  Status = iota // 请求成功
+	RespErrorInvaildRequest               // 请求无效
+	RespErrorInternalServer               // 服务器内部错误
+	RespErrorNotFound                     // 模块资源未找到
+	RespConfigDecodeFailed                // 配置解码失败
+	RespConfigCheckFailed                 // 配置校验失败
+	RespSendToChanFailed                  // 发送配置到通道失败
 )
 
 type Resp struct {

--- a/docs/event-forward-api.md
+++ b/docs/event-forward-api.md
@@ -1,0 +1,216 @@
+# eCapture Event Forwarding API
+
+This document briefly explains **how to receive events and runtime logs from eCapture as a client**, and where to find the detailed protocol and demo code in this repository.
+
+> Notes:
+> 
+> - Default listening address: `ws://127.0.0.1:28257`
+> - The listening address can be modified via the `--ecaptureq` command-line argument, for example: `--ecaptureq=ws://127.0.0.1:28257/`
+> - All interfaces are **Protobuf**
+
+eCapture exposes three parameters related to log / event output:
+
+- `--logaddr`: output for **eCapture runtime logs** (text)
+- `--eventaddr`: output for **captured events** (text)
+- `--ecaptureq`: WebSocket + Protobuf(LogEntry) endpoint for streaming **runtime logs and events** (structured)
+
+The repository already contains detailed protocol docs and a full demo client.  
+This file is intentionally concise and mainly serves as an **index + behavior overview**.
+
+---
+
+## 1. Output parameters and priority
+
+### 1.1 `--logaddr`: runtime logs (text)
+
+- Purpose: specify where **eCapture’s own runtime logs** are written.
+- Supported targets:
+    - File path (e.g. `/var/log/ecapture.log`)
+    - `tcp://host:port`
+    - `ws://host:port/path` or `wss://host:port/path`
+- Content: initialization info, module startup, configuration details, errors, etc.  
+  Format: **plain text**.
+
+### 1.2 `--eventaddr`: captured events (text)
+
+- Purpose: specify where **captured event logs** are written.
+- Supported targets: similar to `--logaddr` (file / TCP / WebSocket), but output is **text-formatted event logs**.
+- Typical use cases:
+    - Directly writing events into files, TCP streams, or an existing log pipeline;
+    - When your downstream system prefers plain text logs and does not need protobuf parsing yet.
+
+### 1.3 `--ecaptureq`: unified event forwarding (WebSocket + Protobuf)
+
+- Purpose: start a **WebSocket server** (eCaptureQ) and stream both **runtime logs and captured events** as structured `LogEntry` Protobuf messages.
+- Example:
+
+  ```bash
+  # Start eCaptureQ on localhost:28257
+  sudo ./ecapture tls --ecaptureq=ws://127.0.0.1:28257/
+  ```
+
+- Characteristics:
+    - Clients connect via WebSocket;
+    - Each message is a binary Protobuf-encoded `LogEntry`;
+    - The `log_type` field distinguishes heartbeat / process log / event.
+
+### 1.4 Relationship between `eventaddr` and `ecaptureq`
+
+Both parameters define “event output channels”:
+
+- `--eventaddr`: event logs in **plain text format**;
+- `--ecaptureq`: events + logs in **Protobuf(LogEntry)** format via WebSocket.
+
+**Priority:**
+
+- If **both `--ecaptureq` and `--eventaddr` are set**, eCapture will **prefer `--ecaptureq`** for streaming events.
+- You can think of it as:
+    - For **structured, programmatically consumable** event streams → use `--ecaptureq`;
+    - For **plain text log output** → use `--eventaddr`.
+
+---
+
+## 2. Using eCaptureQ WebSocket (recommended)
+
+If you want real-time, structured events via WebSocket + Protobuf, use `--ecaptureq` and refer to the existing protocol docs and demo client.
+
+### 2.1 Protocol and message structure
+
+Please read:
+
+- Protobuf definition:  
+  `protobuf/proto/v1/ecaptureq.proto`
+- Protocol overview:  
+  `protobuf/PROTOCOLS.md`
+
+Together they define:
+
+- Top-level message `LogEntry`:
+
+  ```protobuf
+  message LogEntry {
+    LogType log_type = 1;
+
+    oneof payload {
+      Event event_payload = 2;
+      Heartbeat heartbeat_payload = 3;
+      string run_log = 4;
+    }
+  }
+  ```
+
+- `LogType` enum:
+    - `LOG_TYPE_HEARTBEAT` – heartbeat messages;
+    - `LOG_TYPE_PROCESS_LOG` – eCapture runtime logs;
+    - `LOG_TYPE_EVENT` – captured business events (e.g. TLS/HTTP data).
+- `Event` fields:
+    - `timestamp`, `uuid`, `src_ip`, `dst_ip`, `pid`, `pname`, `type`, `length`, `payload`, etc.
+- `Heartbeat` fields:
+    - `timestamp`, `count`, `message`.
+
+`PROTOCOLS.md` provides detailed semantics for each field; use it as the main reference when integrating.
+
+### 2.2 Official Go demo client
+
+If you use Go, the easiest approach is to reuse the official demo:
+
+- Directory: `examples/ecaptureq_client/`
+    - Code: `examples/ecaptureq_client/main.go`
+    - Usage: `examples/ecaptureq_client/README.md`
+
+The demo already implements:
+
+1. Connecting to the WebSocket server specified by `--ecaptureq`;
+2. Continuously reading binary messages;
+3. Decoding them into `pb.LogEntry` (under `protobuf/gen/v1`);
+4. Handling message types by `LogType`:
+    - printing runtime logs;
+    - displaying captured events in a human-friendly way (including payload text/hex/base64);
+    - optionally showing heartbeats in verbose mode.
+
+#### Quick start with the demo
+
+```bash
+# 1. Start eCapture with eCaptureQ enabled
+sudo ./ecapture tls --ecaptureq=ws://127.0.0.1:28257/
+
+# 2. Build the client
+cd examples/ecaptureq_client
+go build -o ecaptureq_client main.go
+
+# 3. Connect and watch events
+./ecaptureq_client -server ws://127.0.0.1:28257/
+# or
+./ecaptureq_client -server ws://192.168.1.100:28257/ -verbose
+```
+
+If you want to integrate this into your own system:
+
+- Copy the core receive + decode + dispatch logic from `main.go`;
+- Replace “print to terminal” with writing to your storage, message queue, or analytics engine.
+
+### 2.3 Integrating from other languages
+
+For other languages (Python / Java / Node.js / Rust / …), the pattern is:
+
+1. Use that language’s Protobuf tooling to generate types from  
+   `protobuf/proto/v1/ecaptureq.proto`.
+2. Use a WebSocket client library to connect to `ws://HOST:PORT/`  
+   (note: the URL must end with `/`).
+3. In a loop:
+    - read a binary message from WebSocket;
+    - decode it into `LogEntry`;
+    - handle it based on `log_type` (heartbeat / process log / event).
+
+You can first run `examples/ecaptureq_client` to observe real traffic and then mirror the same logic in your language of choice.
+
+---
+
+## 3. Using `eventaddr` / `logaddr` for plain text logs
+
+If you don’t want to deal with Protobuf and just need **plain text logs**:
+
+- Use `--logaddr` for eCapture runtime logs;
+- Use `--eventaddr` for captured event logs (text).
+
+Examples:
+
+```bash
+# Runtime logs to one file, event logs to another
+./ecapture tls \
+  --logaddr=/var/log/ecapture.log \
+  --eventaddr=/var/log/ecapture-events.log
+```
+
+or:
+
+```bash
+# Send event logs via TCP to a remote service
+./ecapture tls \
+  --eventaddr=tcp://192.168.1.100:9000
+```
+
+In this mode, as a “client” you only need to:
+
+- Read from the configured file or TCP stream;
+- Parse lines (or whatever text format was chosen) as logs/events.
+
+**Reminder:** If you set both `--ecaptureq` and `--eventaddr`, events will be streamed **via `--ecaptureq` first** (WebSocket + Protobuf).  
+`eventaddr` is mainly useful when you are **not** using eCaptureQ and just need text logs.
+
+---
+
+## 4. Summary
+
+- For **structured, programmatic** consumption of events:
+    - Use `--ecaptureq`, and refer to:
+        - `protobuf/proto/v1/ecaptureq.proto`
+        - `protobuf/PROTOCOLS.md`
+        - `examples/ecaptureq_client/`
+- For **plain text logs**:
+    - Use `--logaddr` for runtime logs;
+    - Use `--eventaddr` for event logs (no Protobuf).
+- When both are configured, `--ecaptureq` has the **highest priority** and is used first to forward events and logs over WebSocket + Protobuf.
+
+This document stays minimal on purpose.  
+For full details, always refer to the protocol docs and the demo client in this repository.

--- a/docs/event-forward-api_CN.md
+++ b/docs/event-forward-api_CN.md
@@ -1,0 +1,189 @@
+# eCapture 事件转发 API
+
+本文档简要说明：**作为客户端，如何接收 eCapture 导出的事件和运行日志**，以及应该去看哪些已有文档和 Demo。
+
+> 说明：
+> 
+> - 默认监听地址：`ws://127.0.0.1:28257`
+> - 可通过命令行参数 `--ecaptureq` 修改监听地址，例如：`--ecaptureq=ws://127.0.0.1:28257/`
+> - 所有接口均为 **Protobuf**
+
+eCapture 目前有三种与“日志 / 事件输出”相关的参数：
+
+- `--logaddr`：eCapture 自身运行日志输出位置（文本）
+- `--eventaddr`：捕获到的事件日志输出位置（文本）
+- `--ecaptureq`：通过 WebSocket + Protobuf(LogEntry) 实时转发运行日志和事件（结构化）
+
+项目中已经包含了详细协议说明和一个完整 Demo，本文件只做“索引 + 行为说明”，方便你快速上手。
+
+---
+
+## 1. 三个输出参数的角色与优先级
+
+### 1.1 `--logaddr`：运行日志（文本）
+
+- 作用：指定 **eCapture 进程自身运行日志** 的输出位置。
+- 支持形式：
+    - 文件路径（如 `/var/log/ecapture.log`）
+    - `tcp://host:port`
+    - `ws://host:port/path` 或 `wss://host:port/path`
+- 内容：初始化信息、模块启动、配置详情、错误日志等，格式为 **纯文本**。
+
+### 1.2 `--eventaddr`：捕获事件日志（文本）
+
+- 作用：指定 **捕获到的事件日志** 的输出位置。
+- 支持形式与 `--logaddr` 类似（文件 / TCP / WebSocket），输出的是 **文本格式** 的事件日志。
+- 适用场景：
+    - 想直接将事件落到文件、TCP、现有日志系统中；
+    - 下游对“文本日志”更友好，而暂时不需要 protobuf 解析。
+
+### 1.3 `--ecaptureq`：统一事件转发（WebSocket + Protobuf）
+
+- 作用：启动一个 **WebSocket 服务**（eCaptureQ），把 **运行日志 + 捕获事件** 统一以 `LogEntry` Protobuf 格式推送给 WebSocket 客户端。
+- 参数示例：
+
+  ```bash
+  # 在本机 28257 端口启动 eCaptureQ
+  sudo ./ecapture tls --ecaptureq=ws://127.0.0.1:28257/
+  ```
+
+- 输出特点：
+    - 通过 WebSocket 推送；
+    - 每条消息都是 `LogEntry` 的 protobuf 二进制编码；
+    - `log_type` 字段区分：心跳 / 运行日志 / 事件。
+
+### 1.4 `eventaddr` 与 `ecaptureq` 的关系
+
+- `--eventaddr` 与 `--ecaptureq` 都是“事件输出通道”：
+    - `--eventaddr`：**文本格式** 输出事件日志；
+    - `--ecaptureq`：**Protobuf(LogEntry)** 格式输出事件和运行日志。
+- **优先级**：
+    - 当 **同时设置了 `--ecaptureq` 和 `--eventaddr`** 时，eCapture 会 **优先使用 `--ecaptureq`**；
+    - 可以简单理解为：
+        - 想要结构化的、可编程消费的事件流 → 用 `--ecaptureq`；
+        - 只想把事件当作文本日志写出去 → 用 `--eventaddr`。
+
+---
+
+## 2. 使用 eCaptureQ WebSocket 接收事件（推荐）
+
+如果你希望通过 WebSocket + Protobuf 的方式实时消费事件，推荐使用 `--ecaptureq`，并参考仓库中现有的文档和 Demo。
+
+### 2.1 协议与消息结构文档
+
+请阅读：
+
+- Protobuf 协议定义：  
+  `protobuf/proto/v1/ecaptureq.proto`
+- 协议说明文档：  
+  `protobuf/PROTOCOLS.md`
+
+这两个文件一起定义了：
+
+- 顶层消息 `LogEntry`：
+    - `log_type`: `LOG_TYPE_HEARTBEAT` / `LOG_TYPE_PROCESS_LOG` / `LOG_TYPE_EVENT`
+    - `payload`：根据 `log_type` 携带 `Heartbeat` / `Event` / `run_log`
+- `Event` 字段：
+    - `timestamp`, `uuid`, `src_ip`, `dst_ip`, `pid`, `pname`, `type`, `length`, `payload` 等
+- `Heartbeat` 字段：
+    - `timestamp`, `count`, `message`
+
+这部分在 `PROTOCOLS.md` 里已经写得比较详细，可以直接对照实现。
+
+### 2.2 官方 Go Demo 客户端
+
+如果你用 Go，最简单的方式是直接参考官方 Demo：
+
+- 目录：`examples/ecaptureq_client/`
+    - 代码：`examples/ecaptureq_client/main.go`
+    - 文档：`examples/ecaptureq_client/README.md`
+
+该 Demo 已经帮你做好了：
+
+1. 用 WebSocket 连接到 `--ecaptureq` 指定的地址；
+2. 不断读取二进制消息；
+3. 使用 `protobuf/gen/v1` 中的 `pb.LogEntry` 解码消息；
+4. 按 `LogType` 分别处理：
+    - 打印运行日志；
+    - 展示捕获事件的详细信息（包括 payload 文本/hex/base64）；
+    - 在 verbose 模式下显示心跳。
+
+#### Demo 快速使用
+
+```bash
+# 1. 启动 eCapture，开启 eCaptureQ WebSocket
+sudo ./ecapture tls --ecaptureq=ws://127.0.0.1:28257/
+
+# 2. 构建客户端
+cd examples/ecaptureq_client
+go build -o ecaptureq_client main.go
+
+# 3. 连接并查看事件
+./ecaptureq_client -server ws://127.0.0.1:28257/
+# 或
+./ecaptureq_client -server ws://192.168.1.100:28257/ -verbose
+```
+
+如果你要集成到自己的系统，建议：
+
+- 直接复制 `main.go` 里的接收 + 解码 + 分发逻辑；
+- 替换“打印到终端”的部分为你自己的存储、分析或转发逻辑。
+
+### 2.3 非 Go 语言的集成思路
+
+对于其他语言（Python / Java / Node.js / Rust 等），可以按以下步骤：
+
+1. 使用对应语言的 protobuf 工具，从 `protobuf/proto/v1/ecaptureq.proto` 生成代码；
+2. 使用该语言的 WebSocket 客户端库，连接到 `ws://HOST:PORT/`（尾部包含 `/`）；
+3. 在循环中读取二进制消息并反序列化为 `LogEntry`；
+4. 根据 `log_type` 分别处理：心跳、运行日志、事件。
+
+可以先跑一遍 `examples/ecaptureq_client` 看行为，再在你的语言里模仿同样的逻辑。
+
+---
+
+## 3. 使用 `eventaddr` / `logaddr` 接收纯文本日志
+
+如果你不想处理 protobuf，只需要“文本日志”：
+
+- 使用 `--logaddr` 输出 eCapture 自身运行日志；
+- 使用 `--eventaddr` 输出捕获事件日志（文本）；
+
+例如：
+
+```bash
+# 运行日志写到文件，事件日志写到另一个文件
+./ecapture tls \
+  --logaddr=/var/log/ecapture.log \
+  --eventaddr=/var/log/ecapture-events.log
+```
+
+或：
+
+```bash
+# 事件日志通过 TCP 推送到远程
+./ecapture tls \
+  --eventaddr=tcp://192.168.1.100:9000
+```
+
+此时，你作为“客户端”只需要：
+
+- 读取对应文件或 TCP 流；
+- 按行（或约定的文本格式）解析日志内容即可。
+
+**提醒**：如果你同时设置了 `--ecaptureq` 和 `--eventaddr`，事件会优先通过 `--ecaptureq` 的 WebSocket + protobuf 输出；`eventaddr` 更适合在没有使用 eCaptureQ 时提供文本日志。
+
+---
+
+## 4. 总结
+
+- 想要 **结构化、可编程消费** 的事件流 → 使用 `--ecaptureq`，并参考：
+    - `protobuf/proto/v1/ecaptureq.proto`
+    - `protobuf/PROTOCOLS.md`
+    - `examples/ecaptureq_client/`
+- 想要 **文本日志**，方便直接写文件/管道 → 使用：
+    - `--logaddr` 输出运行日志；
+    - `--eventaddr` 输出事件日志（不使用 protobuf）；
+- 同时设置时，`--ecaptureq` 优先级最高，优先通过 WebSocket + protobuf 方式转发。
+
+本文件保持简洁，细节以仓库中已有的协议文档和 Demo 为准。

--- a/docs/remote-config-update-api.md
+++ b/docs/remote-config-update-api.md
@@ -1,0 +1,410 @@
+# eCapture Remote Configuration Update API
+
+This document describes how to update eCapture’s runtime configuration via HTTP, **from the client side**.  
+It focuses on how to construct HTTP requests and JSON payloads to communicate with eCapture.
+
+> Notes:
+> - Default listen address: `http://127.0.0.1:28256`
+> - You can change it via CLI flag `--listen`, for example: `--listen 0.0.0.0:28256`
+> - All endpoints are **HTTP POST + JSON**
+> - Endpoint paths have **no prefix**. They are just the module names (e.g. `/tls`, `/gotls`, `/gnutls`).
+
+---
+
+## 1. Overview
+
+### 1.1 Use cases
+
+- Adjust capture behavior **without restarting** the eCapture process
+- Build an external management tool / control panel / script that can “update and apply configuration” on demand
+- Dynamically change target processes, ports, filters, and other runtime parameters
+
+### 1.2 Basic rules
+
+- **Protocol**: HTTP
+- **HTTP method**: `POST`
+- **Content-Type**: `application/json`
+- **Request body**: JSON configuration object for the target module  
+  (same structure as the corresponding `config.*Config` type inside eCapture)
+- **Response body**: a unified JSON structure with status code and module name
+
+---
+
+## 2. Supported HTTP paths and platform differences
+
+The set of supported configuration update paths is slightly different between Linux and Android GKI.
+
+### 2.1 Linux paths
+
+On Linux, you can update configurations via the following HTTP paths:
+
+| Path         | Description                                    |
+|--------------|------------------------------------------------|
+| `/tls`       | OpenSSL / TLS module                           |
+| `/openssl`   | Alias of `/tls`                                |
+| `/boringssl` | Alias of `/tls`                                |
+| `/gotls`     | Go TLS module                                  |
+| `/gnutls`    | GnuTLS module                                  |
+| `/nss`       | NSS / NSPR module                              |
+| `/nspr`      | Alias of `/nss`                                |
+| `/bash`      | Bash command capture (Linux only)              |
+| `/mysqld`    | MySQLd protocol capture (Linux only)           |
+| `/postgress` | PostgreSQL protocol capture (Linux only, note the spelling) |
+
+> Reminder:
+> - `/openssl` and `/boringssl` are aliases of `/tls`; they share the same configuration structure.
+> - `/nss` and `/nspr` share the same configuration structure.
+> - `/bash`, `/mysqld`, and `/postgress` do **not** exist on Android GKI.
+
+### 2.2 Android GKI paths
+
+On Android GKI, the available paths are:
+
+| Path         | Description                                    |
+|--------------|------------------------------------------------|
+| `/tls`       | OpenSSL / TLS module                           |
+| `/openssl`   | Alias of `/tls`                                |
+| `/boringssl` | Alias of `/tls`                                |
+| `/gotls`     | Go TLS module                                  |
+| `/gnutls`    | GnuTLS module                                  |
+| `/nss`       | NSS / NSPR module                              |
+| `/nspr`      | Alias of `/nss`                                |
+
+> Reminder:
+> - Android GKI does **not** expose `/bash`, `/mysqld`, `/postgress` configuration endpoints.
+> - If your management client needs to support both Linux and Android, detect the platform and only call supported paths.
+
+---
+
+## 3. Common request and response format
+
+### 3.1 Request format
+
+All configuration update endpoints use the same HTTP request pattern:
+
+- **Method**: `POST`
+- **URL**: `http://<listen-address>/<path>`  
+  Example: `http://127.0.0.1:28256/tls`
+- **Headers**:
+    - `Content-Type: application/json`
+- **Body**:
+    - JSON object. Its fields depend on the specific module.
+    - Typically includes:
+        - Common fields: `pid`, `uid`, `debug`, `hex`, `btf`, `per_cpu_map_size`, `truncate_size`, etc.
+        - Module-specific fields: target process names, ports, protocol-related options, and so on.
+
+> Exact field names and types are defined in `user/config/*.go`.  
+> Examples below are illustrative only, to show how to call the API from the client side.
+
+### 3.2 Response format
+
+All endpoints return a unified JSON structure:
+
+```json
+{
+  "code": 0,
+  "module_type": "openssl",
+  "msg": "RespOK",
+  "data": null
+}
+```
+
+Field description:
+
+- `code` (`number`): status code
+    - `0` – success (`RespOK`)
+    - `4` – configuration JSON decode failed (`RespConfigDecodeFailed`)
+    - `5` – configuration check failed (`RespConfigCheckFailed`)
+    - `6` – failed to send configuration into internal channel (`RespSendToChanFailed`)
+    - other values – reserved (e.g. invalid request, internal server error)
+- `module_type` (`string`): module identifier for this update (e.g. `openssl`, `gotls`, `gnutls`)
+- `msg` (`string`): human-readable string corresponding to `code`, useful for logging and debugging
+- `data`: currently unused and usually `null`
+
+Relationship between HTTP status and `code` (for clients):
+
+- HTTP 200 + `code == 0`:  
+  Configuration accepted. eCapture has begun applying the new config (by restarting the module internally).
+- HTTP 400:  
+  Request format or config content is invalid (`code` usually 4 or 5).
+- HTTP 503:  
+  eCapture is currently busy and cannot accept new config updates (`code` is 6). You can retry later.
+
+---
+
+## 4. Typical module calls
+
+All examples assume eCapture is running on the local machine with the default address `127.0.0.1:28256`.
+
+> Again, JSON fields below are **examples only**.  
+> Align them with the actual fields from your current `user/config/*.go`.
+
+### 4.1 OpenSSL / TLS module (`/tls` / `/openssl` / `/boringssl`)
+
+Used for applications based on OpenSSL / BoringSSL / generic TLS.  
+The three paths are equivalent; you can pick any of them.
+
+#### 4.1.1 Using curl
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false,
+    "hex": false,
+    "btf": 0,
+    "per_cpu_map_size": 1024,
+    "truncate_size": 0,
+    "filters": {
+      "target_process": ["nginx", "curl"],
+      "ignore_process": ["ecapture"]
+    }
+  }' \
+  http://127.0.0.1:28256/tls
+```
+
+A typical success response:
+
+```json
+{
+  "code": 0,
+  "module_type": "openssl",
+  "msg": "RespOK",
+  "data": null
+}
+```
+
+#### 4.1.2 Using Go
+
+```go
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "log"
+    "net/http"
+)
+
+type TlsConfig struct {
+    Pid           uint64 `json:"pid"`
+    Uid           uint64 `json:"uid"`
+    Debug         bool   `json:"debug"`
+    Hex           bool   `json:"hex"`
+    Btf           uint8  `json:"btf"`
+    PerCpuMapSize int    `json:"per_cpu_map_size"`
+    TruncateSize  uint64 `json:"truncate_size"`
+    // Add real TLS config fields here to match user/config/OpensslConfig
+}
+
+type Resp struct {
+    Code       uint8       `json:"code"`
+    ModuleType string      `json:"module_type"`
+    Msg        string      `json:"msg"`
+    Data       interface{} `json:"data"`
+}
+
+func main() {
+    cfg := TlsConfig{
+        Pid:           0,
+        Uid:           0,
+        Debug:         false,
+        Hex:           false,
+        Btf:           0,
+        PerCpuMapSize: 1024,
+        TruncateSize:  0,
+    }
+
+    body, _ := json.Marshal(cfg)
+    resp, err := http.Post(
+        "http://127.0.0.1:28256/tls",
+        "application/json",
+        bytes.NewReader(body),
+    )
+    if err != nil {
+        log.Fatalf("request failed: %v", err)
+    }
+    defer resp.Body.Close()
+
+    var r Resp
+    if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+        log.Fatalf("decode resp failed: %v", err)
+    }
+
+    log.Printf("status=%d code=%d module=%s msg=%s",
+        resp.StatusCode, r.Code, r.ModuleType, r.Msg)
+}
+```
+
+---
+
+### 4.2 GoTLS module (`/gotls`)
+
+Used for Go applications that use the Go TLS stack.
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": true,
+    "per_cpu_map_size": 2048
+  }' \
+  http://127.0.0.1:28256/gotls
+```
+
+---
+
+### 4.3 GnuTLS module (`/gnutls`)
+
+Used for applications that rely on GnuTLS.
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false
+  }' \
+  http://127.0.0.1:28256/gnutls
+```
+
+---
+
+### 4.4 NSS / NSPR module (`/nss` / `/nspr`)
+
+Used for modules based on NSS / NSPR (e.g. some browsers or system components).
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false
+  }' \
+  http://127.0.0.1:28256/nss
+```
+
+`/nspr` is identical, only the path changes:
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{ ... }' \
+  http://127.0.0.1:28256/nspr
+```
+
+---
+
+### 4.5 Bash command capture module (Linux only: `/bash`)
+
+> Not available on Android GKI.  
+> If your management tool targets multiple platforms, detect the platform before calling this endpoint.
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": true
+  }' \
+  http://127.0.0.1:28256/bash
+```
+
+---
+
+### 4.6 MySQLd module (Linux only: `/mysqld`)
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false
+  }' \
+  http://127.0.0.1:28256/mysqld
+```
+
+---
+
+### 4.7 PostgreSQL module (Linux only: `/postgress`)
+
+> The path is spelled `/postgress` with a double “s”.
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false
+  }' \
+  http://127.0.0.1:28256/postgress
+```
+
+---
+
+## 5. Error handling and retry strategy
+
+### 5.1 Common status codes
+
+You can combine HTTP status and the `code` field from the JSON response:
+
+| HTTP status | `code` | Meaning                                            | Client suggestion                          |
+|-------------|--------|----------------------------------------------------|--------------------------------------------|
+| 200         | 0      | Success, configuration accepted and applied       | Normal flow                                |
+| 200         | 4      | JSON decode failed (syntax error / type mismatch) | Fix request body and retry                 |
+| 200         | 5      | Config check failed (missing field, invalid value)| Fix config content based on logs and retry |
+| 200         | 6      | Internal update channel is full / busy            | Wait and retry later                       |
+| 200         | 1 / 2  | Invalid request / internal server error           | Log and alert as needed                    |
+
+### 5.2 Recommended calling pattern
+
+- Configuration updates are management operations; they should not be called at high frequency.
+- When you see HTTP 503 with `code == 6`:
+    - Use a backoff strategy (e.g. exponential backoff) and retry later.
+- On the caller side, keep a copy of the **last known-good config**:
+    - If a new config causes unexpected behavior, you can quickly rollback by posting the previous config again.
+
+---
+
+## 6. Platform compatibility (Linux vs Android)
+
+- If your tool only targets Linux, you can use all paths listed for Linux.
+- If your tool must work on both Linux and Android GKI:
+    1. Determine the platform using CLI flags, environment variables, or your own detection mechanism.
+    2. Only call `/bash`, `/mysqld`, `/postgress` on Linux, because they do not exist on Android.
+    3. TLS / GoTLS / GnuTLS / NSS paths are shared and can be used on both platforms.
+
+---
+
+## 7. Versioning and field alignment
+
+- Different eCapture versions may slightly change config structures in `user/config/*.go`.
+- Recommended approach:
+    - In your client code, define config structs that mirror the current eCapture version (field names and types match).
+    - Or use dynamic JSON (e.g. `map[string]any`) and only fill fields that you really need.
+    - If you need to support multiple eCapture versions, build your own compatibility layer (e.g. version negotiation or feature flags).
+
+---
+
+## 8. Changelog
+
+| Version | Date       | Description                                   |
+|---------|------------|-----------------------------------------------|
+| 0.1.0   | 2025-12-07 | Initial version of the remote config API doc |

--- a/docs/remote-config-update-api_CN.md
+++ b/docs/remote-config-update-api_CN.md
@@ -1,0 +1,402 @@
+# eCapture 远程配置修改 API
+
+本文档介绍 **eCapture 运行过程中如何通过 HTTP 接口远程修改配置**，面向调用方（HTTP Client），说明如何构造请求和 payload 与 eCapture 通讯。
+
+> 说明：
+> - 默认监听地址：`http://127.0.0.1:28256`
+> - 可通过命令行参数 `--listen` 修改监听地址，例如：`--listen 0.0.0.0:28256`
+> - 所有接口均为 **HTTP POST + JSON**，路径不带前缀，直接是模块名（例如 `/tls`、`/gotls`）
+
+---
+
+## 1. 总体说明
+
+### 1.1 使用场景
+
+- 在不重启 eCapture 进程的情况下，调整各模块的抓取行为
+- 通过外部管理程序、控制台、脚本，实现“点击后生效”的参数更新
+- 按不同场景动态更改目标进程、端口、过滤规则等
+
+### 1.2 基本约定
+
+- **协议**：HTTP
+- **方法**：`POST`
+- **Content-Type**：`application/json`
+- **请求体**：模块对应的配置 JSON（结构与 eCapture 内部 `config.*Config` 一致）
+- **响应体**：统一 JSON 格式，包含状态码和模块名
+
+---
+
+## 2. 支持的 HTTP 路径与平台差异
+
+eCapture 在不同平台支持的配置更新路径略有差异：
+
+### 2.1 Linux 平台可用路径
+
+Linux 下可以通过以下 HTTP 路径更新配置：
+
+| 路径        | 用途简述                          |
+|-------------|-----------------------------------|
+| `/tls`      | OpenSSL / TLS 模块                |
+| `/openssl`  | 同 `/tls`，别名                   |
+| `/boringssl`| 同 `/tls`，别名                   |
+| `/gotls`    | Go TLS 模块                       |
+| `/gnutls`   | GnuTLS 模块                       |
+| `/nss`      | NSS / NSPR 模块                   |
+| `/nspr`     | 同 `/nss`，别名                   |
+| `/bash`     | Bash 命令捕获（仅 Linux）         |
+| `/mysqld`   | MySQLd 协议捕获（仅 Linux）       |
+| `/postgress`| PostgreSQL 协议捕获（仅 Linux）   |
+
+> 提醒：
+> - `/openssl`、`/boringssl` 是 `/tls` 的别名，配置结构完全一致；
+> - `/nss` 与 `/nspr` 使用同一套配置结构；
+> - `/bash`、`/mysqld`、`/postgress` 在 Android GKI 平台上 **不可用**。
+
+### 2.2 Android GKI 平台可用路径
+
+Android GKI 下支持的路径为：
+
+| 路径        | 用途简述                          |
+|-------------|-----------------------------------|
+| `/tls`      | OpenSSL / TLS 模块                |
+| `/openssl`  | 同 `/tls`，别名                   |
+| `/boringssl`| 同 `/tls`，别名                   |
+| `/gotls`    | Go TLS 模块                       |
+| `/gnutls`   | GnuTLS 模块                       |
+| `/nss`      | NSS / NSPR 模块                   |
+| `/nspr`     | 同 `/nss`，别名                   |
+
+> 提醒：
+> - Android 平台 **没有** `/bash`、`/mysqld`、`/postgress` 这些配置更新接口；
+> - 如果你的管理程序需要同时兼容 Linux 和 Android，请在调用前根据平台做一次能力判断。
+
+---
+
+## 3. 通用请求与响应格式
+
+### 3.1 请求格式
+
+所有模块配置更新接口都使用相同的 HTTP 请求格式：
+
+- **方法**：`POST`
+- **URL**：`http://<listen-address>/<path>`  
+  示例：`http://127.0.0.1:28256/tls`
+- **Header**：
+    - `Content-Type: application/json`
+- **Body**：
+    - JSON 对象，字段取决于具体模块。
+    - 一般包含：
+        - 通用字段：如 `pid`、`uid`、`debug`、`hex`、`btf`、`per_cpu_map_size`、`truncate_size` 等
+        - 模块特有字段：如目标进程名、端口、协议相关参数等
+
+> 配置字段请以实际版本中 `user/config/*.go` 的结构体为准，下面示例仅用于演示调用方式。
+
+### 3.2 响应格式
+
+所有接口的响应体为统一结构：
+
+```json
+{
+  "code": 0,
+  "module_type": "openssl",
+  "msg": "RespOK",
+  "data": null
+}
+```
+
+字段说明：
+
+- `code` (`number`)：状态码
+    - `0`：成功（`RespOK`）
+    - `4`：配置 JSON 解码失败（`RespConfigDecodeFailed`）
+    - `5`：配置检查失败（`RespConfigCheckFailed`）
+    - `6`：后台通道写入失败（`RespSendToChanFailed`）
+    - 其他值：预留错误（如无效请求、内部错误等）
+- `module_type` (`string`)：模块名称（如 `openssl`、`gotls`、`gnutls` 等），用于标识本次更新对应的模块
+- `msg` (`string`)：`code` 对应的简短字符串，便于日志和调试
+- `data`：当前接口未使用，一般为 `null`
+
+HTTP 状态码与 `code` 的关系（调用侧可以按以下逻辑判断）：
+
+- HTTP 200 且 `code == 0`：更新成功，后台已开始按新配置重启模块；
+- HTTP 400：请求格式或配置内容不合法（`code` 通常是 4 或 5）；
+- HTTP 503：eCapture 当前忙（内部配置更新通道满），可稍后重试。
+
+---
+
+## 4. 常用模块调用示例
+
+下面示例都假设 eCapture 运行在本机，使用默认监听地址 `127.0.0.1:28256`。
+
+> 注意：示例 JSON 的字段仅用于展示调用方式，不代表完整或最终字段列表，请与实际结构体对齐。
+
+### 4.1 OpenSSL / TLS 模块（`/tls` / `/openssl` / `/boringssl`）
+
+适用于基于 OpenSSL / BoringSSL / 通用 TLS 的应用。三个路径效果相同，可任选其一。
+
+#### 4.1.1 使用 curl 发送配置
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false,
+    "hex": false,
+    "btf": 0,
+    "per_cpu_map_size": 1024,
+    "truncate_size": 0,
+    "filters": {
+      "target_process": ["nginx", "curl"],
+      "ignore_process": ["ecapture"]
+    }
+  }' \
+  http://127.0.0.1:28256/tls
+```
+
+可能的成功响应：
+
+```json
+{
+  "code": 0,
+  "module_type": "openssl",
+  "msg": "RespOK",
+  "data": null
+}
+```
+
+#### 4.1.2 使用 Go 代码发送配置
+
+```go
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "log"
+    "net/http"
+)
+
+type TlsConfig struct {
+    Pid           uint64 `json:"pid"`
+    Uid           uint64 `json:"uid"`
+    Debug         bool   `json:"debug"`
+    Hex           bool   `json:"hex"`
+    Btf           uint8  `json:"btf"`
+    PerCpuMapSize int    `json:"per_cpu_map_size"`
+    TruncateSize  uint64 `json:"truncate_size"`
+    // 这里可以继续补充你真正使用的字段
+}
+
+type Resp struct {
+    Code       uint8       `json:"code"`
+    ModuleType string      `json:"module_type"`
+    Msg        string      `json:"msg"`
+    Data       interface{} `json:"data"`
+}
+
+func main() {
+    cfg := TlsConfig{
+        Pid:           0,
+        Uid:           0,
+        Debug:         false,
+        Hex:           false,
+        Btf:           0,
+        PerCpuMapSize: 1024,
+        TruncateSize:  0,
+    }
+
+    body, _ := json.Marshal(cfg)
+    resp, err := http.Post(
+        "http://127.0.0.1:28256/tls",
+        "application/json",
+        bytes.NewReader(body),
+    )
+    if err != nil {
+        log.Fatalf("request failed: %v", err)
+    }
+    defer resp.Body.Close()
+
+    var r Resp
+    if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+        log.Fatalf("decode resp failed: %v", err)
+    }
+
+    log.Printf("status=%d code=%d module=%s msg=%s",
+        resp.StatusCode, r.Code, r.ModuleType, r.Msg)
+}
+```
+
+---
+
+### 4.2 GoTLS 模块（`/gotls`）
+
+适用于 Go 程序使用的 TLS 实现。
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": true,
+    "per_cpu_map_size": 2048
+  }' \
+  http://127.0.0.1:28256/gotls
+```
+
+---
+
+### 4.3 GnuTLS 模块（`/gnutls`）
+
+适用于使用 GnuTLS 的应用程序。
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false
+  }' \
+  http://127.0.0.1:28256/gnutls
+```
+
+---
+
+### 4.4 NSS / NSPR 模块（`/nss` / `/nspr`）
+
+适用于基于 NSS / NSPR 的 TLS 实现（例如部分浏览器、系统组件）。
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false
+  }' \
+  http://127.0.0.1:28256/nss
+```
+
+`/nspr` 用法完全相同，只是路径不同：
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{ ... }' \
+  http://127.0.0.1:28256/nspr
+```
+
+---
+
+### 4.5 Bash 命令捕获模块（仅 Linux：`/bash`）
+
+> Android GKI 平台不支持此接口，如你的程序需要兼容多平台，请在调用前判断。
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": true
+  }' \
+  http://127.0.0.1:28256/bash
+```
+
+---
+
+### 4.6 MySQLd 模块（仅 Linux：`/mysqld`）
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false
+  }' \
+  http://127.0.0.1:28256/mysqld
+```
+
+---
+
+### 4.7 PostgreSQL 模块（仅 Linux：`/postgress`）
+
+> 注意路径拼写为 `/postgress`（双 s）。
+
+```bash
+curl -v \
+  -H "Content-Type: application/json" \
+  -X POST \
+  --data '{
+    "pid": 0,
+    "uid": 0,
+    "debug": false
+  }' \
+  http://127.0.0.1:28256/postgress
+```
+
+---
+
+## 5. 错误处理与重试策略
+
+### 5.1 常见错误码
+
+调用方可以结合 HTTP 状态码与 `code` 字段做判断：
+
+| HTTP 状态 | `code` | 含义说明                                   | 调用方建议          |
+|-----------|--------|--------------------------------------------|----------------|
+| 200       | 0      | 成功，配置已被后台接受并进入重启流程       | 正常处理           |
+| 200       | 1      | 请求无效                              | 请求包构建异常，修正     |
+| 200       | 2      | 服务器内部错误                         | 间隔一段时间后重试              |
+| 200       | 4      | JSON 解析失败（语法错误或字段类型错误）    | 修正请求体后重试       |
+| 200       | 5      | 配置校验失败（必填字段缺失、值非法等）     | 根据错误日志修正配置后再发送 |
+| 200       | 6      | 后台通道已满，暂时无法接受新的配置         | 间隔一段时间后重试      |
+| 其他      | 1 / 2  | 无效请求 / 内部错误（当前接口不常用）      | 视情况记录日志并报警     |
+
+更多相应码见 `cli/http/resp.go` 中的定义。
+
+### 5.2 建议的调用模式
+
+- 配置更新一般是管理行为，不建议高频调用；
+- 对于非立即生效要求的场景，出现 `503` 时可指数退避重试；
+- 在上游保留一份“上一次成功下发的配置”，发生异常时可以快速回滚。
+
+---
+
+## 6. 平台兼容性提醒（Linux vs Android）
+
+- 如果你的管理程序只面向 Linux，可直接使用文中全部路径；
+- 如果需要同时兼容 Linux 和 Android GKI，建议：
+    1. 通过命令行参数、环境变量或探测接口确认当前运行平台；
+    2. 对 `bash` / `mysqld` / `postgress` 等 **仅 Linux 支持** 的路径做条件调用；
+    3. TLS / GoTLS / GnuTLS / NSS 相关路径两端一致，可通用。
+
+---
+
+## 7. 版本与字段对齐建议
+
+- 不同版本的 eCapture，`user/config/*.go` 中的字段可能会有微调；
+- 推荐做法：
+    - 在你的项目中定义与 eCapture 相同的配置结构（同名字段 / 同类型）；
+    - 或直接使用 JSON 动态对象，只填你实际需要控制的字段，其余使用默认值；
+    - 如需对接多版本，可通过 eCapture 的版本信息自行做兼容处理。
+
+---
+
+## 8. 变更历史
+
+| 版本  | 日期       | 说明                               |
+|-------|------------|------------------------------------|
+| 0.1.0 | 2025-12-07 | 初版：远程配置修改 HTTP API 说明   |


### PR DESCRIPTION
This pull request adds comprehensive documentation for eCapture's event forwarding capabilities and updates both the English and Chinese README files to reference these new docs. It also improves code clarity in the HTTP response status definitions. The changes are grouped into documentation enhancements and code improvements.

**Documentation Enhancements:**

* Added `docs/event-forward-api.md` and `docs/event-forward-api_CN.md` to explain how clients can receive eCapture events and runtime logs, including usage of output parameters (`--logaddr`, `--eventaddr`, `--ecaptureq`), protocol details, and demo client references. [[1]](diffhunk://#diff-ea1a2b8da29b6b92f894ed8ec516f7e57e9992ef8324b99d3e3e87fbaca4809aR1-R216) [[2]](diffhunk://#diff-e9854bc7496ef21bbe8ac862c47738f92be58e89c212a1bdcca96c93ba03be59R1-R189)
* Updated `README.md` and `README_CN.md` to reference the new event forwarding and remote config update documentation, and clarified compilation instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R317-R327) [[2]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L35-R35) [[3]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7L297-R307)

**Code Improvements:**

* Improved the `Status` enum in `cli/http/resp.go` by adding descriptive comments for each HTTP response status, clarifying their meanings for future development and maintenance.