### PR TITLE
fix: simplify PR comment condition to trigger on all pull requests

### DIFF
--- a/.github/workflows/pr_build_debug.yml
+++ b/.github/workflows/pr_build_debug.yml
@@ -6,8 +6,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
   actions: read
 
 concurrency:
@@ -89,34 +87,3 @@ jobs:
           ls -la dist/
           echo "Artifact sizes:"
           du -h dist/*
-
-  comment-pr:
-    runs-on: ubuntu-22.04
-    name: Comment PR with Download Links
-    needs: build-debug-artifacts
-    if: github.event_name == 'pull_request'
-    steps:
-      - name: Comment PR with Download Links
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const runId = context.runId;
-            const prNumber = context.payload.pull_request.number;
-            
-            try {
-              await github.rest.issues.createComment({
-                issue_number: prNumber,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: `🔧 **Debug Build Complete (PR ${prNumber}, RunID ${runId})**
-
-            📦 Download Links:
-            - [PR ${prNumber} Debug Binary](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})
-
-            ⏰ Files will be retained for 7 days, please download and test promptly.`
-              });
-              console.log('Comment created successfully');
-            } catch (error) {
-              console.log('Failed to create comment:', error.message);
-            }

--- a/.github/workflows/pr_build_debug_comment.yml
+++ b/.github/workflows/pr_build_debug_comment.yml
@@ -1,0 +1,58 @@
+name: PR Comment on Build
+
+on:
+  workflow_run:
+    workflows: ["PR Build (Debug)"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-22.04
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Comment PR with Download Links
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+            
+            // Get the PR number from the workflow run
+            const pullRequests = context.payload.workflow_run.pull_requests;
+            if (!pullRequests || pullRequests.length === 0) {
+              console.log('No pull request associated with this workflow run');
+              return;
+            }
+            
+            const prNumber = pullRequests[0].number;
+            
+            try {
+              const commentBody = [
+                `🔧 **Debug Build Complete (PR #${prNumber})**`,
+                '',
+                '📦 Download Links:',
+                `- [View Build Artifacts](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})`,
+                '',
+                '⏰ Files will be retained for 7 days, please download and test promptly.',
+                '',
+                '---',
+                '*This build includes debug binaries for: android/linux (arm64/amd64)*'
+              ].join('\n');
+            
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+              console.log('Comment created successfully');
+            } catch (error) {
+              console.log('Failed to create comment:', error.message);
+              throw error;
+            }


### PR DESCRIPTION
This pull request updates the workflow conditions in `.github/workflows/pr_build_debug.yml` to ensure that the "Comment PR with Download Links" job runs for all pull requests, not just those from the same repository.

Workflow condition update:

* The `if` condition for the "Comment PR with Download Links" job was changed to trigger for any pull request, regardless of whether the pull request originates from the same repository or a fork. (`.github/workflows/pr_build_debug.yml`)