### PR TITLE
fix (iworker): handle empty payload and ignore EOF error in parser write

### DIFF
--- a/pkg/event_processor/iworker.go
+++ b/pkg/event_processor/iworker.go
@@ -252,7 +252,7 @@ func (ew *eventWorker) parserEvents() []byte {
 		ew.parser = NewParser(ew.payload.Bytes())
 	}
 	n, e := ew.parser.Write(ew.payload.Bytes())
-	if e != nil && e != io.EOF {
+	if e != nil && !errors.Is(e, io.EOF) {
 		ew.Log(fmt.Sprintf("ew.parser uuid: %s type %d write payload %d bytes, error:%s", ew.UUID, ew.parser.ParserType(), n, e.Error()))
 	}
 	ew.status = ProcessStateDone


### PR DESCRIPTION
This pull request introduces improvements to the `eventWorker` logic in `pkg/event_processor/iworker.go`, focusing on error handling and code robustness. The most notable changes include refining how parser errors are handled, preventing unnecessary processing of empty payloads, and updating imports for new error checks.

Error handling and robustness improvements:

* Updated the error check in `parserEvents` to ignore `io.EOF` errors, logging only other errors for better clarity and reduced noise.
* Added a guard in the `Display` method to prevent processing when the payload is empty, improving efficiency and avoiding potential issues.

Code maintenance:

* Imported the `io` package to support the new error handling logic.

fix #896