### PR TITLE
feat(gotls): add fd extraction from tls.Conn for connection tuple sup…

### DIFF
--- a/kern/gotls_kern.c
+++ b/kern/gotls_kern.c
@@ -34,6 +34,8 @@ struct go_tls_event {
     u32 tid;
     s32 data_len;
     u8 event_type;
+    u8 pad[3];      // Explicit padding for alignment
+    u32 fd;
     char comm[TASK_COMM_LEN];
     char data[MAX_DATA_SIZE_OPENSSL];
 };
@@ -81,9 +83,52 @@ static __always_inline struct go_tls_event *get_gotls_event() {
     event->pid = id >> 32;
     event->tid = (__u32)id;
     event->event_type = GOTLS_EVENT_TYPE_WRITE;
+    event->fd = 0;
     bpf_get_current_comm(event->comm, sizeof(event->comm));
 
     return event;
+}
+
+static __always_inline int extract_fd_from_tls_conn(void *tls_conn_ptr, const char *caller) {
+    if (!tls_conn_ptr) {
+        return 0;
+    }
+
+    // Step 1: tls.Conn.conn is the first field (offset 0), it's an interface (16 bytes: type ptr + data ptr)
+    // Read the data pointer (second 8 bytes of the interface)
+    void *net_conn_ptr = NULL;
+    int ret = bpf_probe_read_user(&net_conn_ptr, sizeof(net_conn_ptr), (void *)((u64)tls_conn_ptr + 8));
+    if (ret < 0 || !net_conn_ptr) {
+        return 0;
+    }
+
+    // Step 2: net.TCPConn.conn (embedded field at offset 0)
+    // net.conn.fd is *netFD at offset 0
+    void *netfd_ptr = NULL;
+    ret = bpf_probe_read_user(&netfd_ptr, sizeof(netfd_ptr), net_conn_ptr);
+    if (ret < 0 || !netfd_ptr) {
+        return 0;
+    }
+    debug_bpf_printk("extract_fd [%s]: netfd_ptr=%p\n", caller, netfd_ptr);
+
+    // Step 3: net.netFD.pfd is internal/poll.FD (VALUE type at offset 0, size 56)
+    // internal/poll.FD structure:
+    //   fdmu fdMutex  // offset 0, size 16 (state uint64 + rsema uint32 + wsema uint32)
+    //   Sysfd int     // offset 16, size 8 (on 64-bit systems, Go's int is 8 bytes!)
+    // So we read from netfd_ptr + 16
+    // IMPORTANT: Use s64 (8 bytes) not int (4 bytes) because Go's int is 8 bytes on 64-bit
+    s64 fd = 0;
+    ret = bpf_probe_read_user(&fd, sizeof(fd), (void *)((u64)netfd_ptr + 16));
+    if (ret < 0) {
+        return 0;
+    }
+
+    // Sanity check: fd should be a non-negative integer
+    if (fd < 0) {
+        return 0;
+    }
+
+    return (int)fd;
 }
 
 static __always_inline int gotls_write(struct pt_regs *ctx, bool is_register_abi) {
@@ -91,6 +136,10 @@ static __always_inline int gotls_write(struct pt_regs *ctx, bool is_register_abi
     const char *str;
     void *record_type_ptr;
     void *len_ptr;
+    void *tls_conn_ptr;
+
+    tls_conn_ptr = (void *)go_get_argument(ctx, is_register_abi, 1);
+
     record_type_ptr = (void *)go_get_argument(ctx, is_register_abi, 2);
     bpf_probe_read_kernel(&record_type, sizeof(record_type), (void *)&record_type_ptr);
     str = (void *)go_get_argument(ctx, is_register_abi, 3);
@@ -109,6 +158,8 @@ static __always_inline int gotls_write(struct pt_regs *ctx, bool is_register_abi
     if (!event) {
         return 0;
     }
+
+    event->fd = extract_fd_from_tls_conn(tls_conn_ptr, "WRITE");
 
     event->data_len =
         (len < MAX_DATA_SIZE_OPENSSL ? (len & (MAX_DATA_SIZE_OPENSSL - 1))
@@ -138,6 +189,9 @@ static __always_inline int gotls_read(struct pt_regs *ctx, bool is_register_abi)
     s32 record_type, ret_len;
     const char *str;
     void *len_ptr, *ret_len_ptr;
+    void *tls_conn_ptr;
+
+    tls_conn_ptr = (void *)go_get_argument(ctx, false, 1);
 
     // golang
     // uretprobe的实现，为选择目标函数中，汇编指令的RET指令地址，即调用子函数的返回后的触发点，此时，此函数参数等地址存放在SP(stack
@@ -164,6 +218,9 @@ static __always_inline int gotls_read(struct pt_regs *ctx, bool is_register_abi)
     if (!event) {
         return 0;
     }
+
+
+    event->fd = extract_fd_from_tls_conn(tls_conn_ptr, "READ");
 
     event->data_len =
         (ret_len < MAX_DATA_SIZE_OPENSSL ? (ret_len & (MAX_DATA_SIZE_OPENSSL - 1))

--- a/user/event/event_gotls.go
+++ b/user/event/event_gotls.go
@@ -5,6 +5,9 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"net"
+	"strconv"
+	"strings"
 
 	pb "github.com/gojue/ecapture/protobuf/gen/v1"
 )
@@ -15,12 +18,16 @@ type inner struct {
 	Tid         uint32   `json:"tid"`
 	Len         int32    `json:"Len"`
 	PayloadType uint8    `json:"payloadType"`
+	Pad         [3]byte  `json:"-"` // Padding for alignment with C struct
+	Fd          uint32   `json:"fd"`
 	Comm        [16]byte `json:"Comm"`
 }
 
 type GoTLSEvent struct {
 	inner
-	Data []byte `json:"data"`
+	Data  []byte `json:"data"`
+	Tuple string `json:"tuple"`
+	Sock  uint64 `json:"sock"`
 }
 
 func (ge *GoTLSEvent) Decode(payload []byte) error {
@@ -59,33 +66,48 @@ func (ge *GoTLSEvent) StringHex() string {
 }
 
 func (ge *GoTLSEvent) Base() Base {
-	return Base{
+	base := Base{
 		Timestamp: int64(ge.TimestampNS),
 		UUID:      ge.GetUUID(),
-		SrcIP:     "127.0.0.1", // GoTLS events do not have SrcIP
-		SrcPort:   0,           // GoTLS events do not have SrcPort
-		DstIP:     "127.0.0.1", // GoTLS events do not have DstIP
-		DstPort:   0,           // GoTLS events do not have DstPort
 		PID:       int64(ge.Pid),
 		PName:     commStr(ge.Comm[:]),
 		Type:      uint32(ge.inner.PayloadType),
 		Length:    uint32(ge.Len),
 	}
+
+	ips := strings.Split(ge.Tuple, "-")
+	if len(ips) == 2 {
+		if srcHost, srcPort, err := net.SplitHostPort(ips[0]); err == nil {
+			base.SrcIP = srcHost
+			if port, err := strconv.ParseInt(srcPort, 10, 32); err == nil {
+				base.SrcPort = uint32(port)
+			}
+		}
+		if dstHost, dstPort, err := net.SplitHostPort(ips[1]); err == nil {
+			base.DstIP = dstHost
+			if port, err := strconv.ParseInt(dstPort, 10, 32); err == nil {
+				base.DstPort = uint32(port)
+			}
+		}
+	}
+
+	return base
 }
 
 func (ge *GoTLSEvent) ToProtobufEvent() *pb.Event {
+	b := ge.Base()
 	return &pb.Event{
-		Timestamp: int64(ge.TimestampNS),
-		Uuid:      ge.GetUUID(),
-		SrcIp:     "127.0.0.1", // GoTLS events do not have SrcIP
-		SrcPort:   0,           // GoTLS events do not have SrcPort
-		DstIp:     "127.0.0.1", // GoTLS events do not have DstIP
-		DstPort:   0,           // GoTLS events do not have DstPort
-		Pid:       int64(ge.Pid),
-		Pname:     commStr(ge.Comm[:]),
-		Type:      uint32(ge.inner.PayloadType),
-		Length:    uint32(ge.Len),
-		Payload:   ge.Data[:ge.Len],
+		Timestamp: b.Timestamp,
+		Uuid:      b.UUID,
+		SrcIp:     b.SrcIP,
+		SrcPort:   b.SrcPort,
+		DstIp:     b.DstIP,
+		DstPort:   b.DstPort,
+		Pid:       b.PID,
+		Pname:     b.PName,
+		Type:      b.Type,
+		Length:    b.Length,
+		Payload:   ge.Payload(),
 	}
 }
 
@@ -98,7 +120,7 @@ func (ge *GoTLSEvent) EventType() Type {
 }
 
 func (ge *GoTLSEvent) GetUUID() string {
-	return fmt.Sprintf("%d_%d_%s", ge.Pid, ge.Tid, ge.Comm)
+	return fmt.Sprintf("gotls:%d_%d_%s_%d_%s_%d", ge.Pid, ge.Tid, commStr(ge.Comm[:]), ge.Fd, ge.Tuple, ge.Sock)
 }
 
 func (ge *GoTLSEvent) Payload() []byte {


### PR DESCRIPTION
…port

Add pad[3]+fd to go_tls_event struct and extract_fd_from_tls_conn() in BPF to walk tls.Conn->netFD->Sysfd. Align Go-side inner struct, add Tuple/Sock to GoTLSEvent, and parse real IP:port in Base() replacing the hardcoded 127.0.0.1.

bpftool prog tracelog:
<img width="1043" height="1189" alt="image" src="https://github.com/user-attachments/assets/0b5a3edf-dc2e-47da-a0e5-4c63a3a6fe26" />
