### PR TITLE
fix: adjust test counting logic to handle skipped tests in android_tl…

### DIFF
--- a/test/e2e/android/android_tls_e2e_test.sh
+++ b/test/e2e/android/android_tls_e2e_test.sh
@@ -215,7 +215,6 @@ test_pcap_mode() {
 # Test with PID filter
 test_pid_filter() {
     log_info "=== Test 3: PID Filter Test ==="
-    TESTS_TOTAL=$((TESTS_TOTAL + 1))
 
     local test_log="$DEVICE_OUTPUT_DIR/pid_filter.log"
     local client_pid=""
@@ -235,8 +234,12 @@ test_pid_filter() {
 
     if [ -z "$client_pid" ]; then
         log_warn "Could not get client PID, skipping PID filter test"
+        log_warn "✓ Test 3 SKIPPED: PID filter test skipped (no client PID available)"
+        # Not counted in TESTS_TOTAL/TESTS_PASSED since it was skipped before setup
         return 0
     fi
+
+    TESTS_TOTAL=$((TESTS_TOTAL + 1))
 
     log_info "Client PID: $client_pid"
 
@@ -355,14 +358,14 @@ main() {
     # Summary
     log_info "=== Test Execution Complete ==="
 
-    if [ "$TESTS_PASSED" -eq "$TESTS_TOTAL" ] && [ "$TESTS_TOTAL" -gt 0 ]; then
+    if [ "$TESTS_TOTAL" -eq 0 ]; then
+        log_warn "No tests were run (all skipped)"
+        exit 0
+    elif [ "$TESTS_PASSED" -eq "$TESTS_TOTAL" ]; then
         log_success "All $TESTS_TOTAL tests PASSED"
         exit 0
-    elif [ "$TESTS_PASSED" -gt 0 ]; then
-        log_warn "$TESTS_PASSED / $TESTS_TOTAL tests passed"
-        exit 1
     else
-        log_error "All tests FAILED"
+        log_warn "$TESTS_PASSED / $TESTS_TOTAL tests passed"
         exit 1
     fi
 }


### PR DESCRIPTION
This pull request improves the accuracy of test result reporting in the `android_tls_e2e_test.sh` script by refining how skipped tests are handled and enhancing the summary output. The main changes ensure that skipped tests (specifically when a client PID is unavailable) are clearly reported and not counted toward the total test count, resulting in more accurate success/failure metrics.

Test counting and reporting improvements:

* Moved the increment of `TESTS_TOTAL` in `test_pid_filter()` to occur only when the test is actually run, preventing skipped tests from being counted in the total. [[1]](diffhunk://#diff-e5e505dc74220dcf2c46febf6df02c01fc2e8358a5c30f6be17afcb61f451ecaL218) [[2]](diffhunk://#diff-e5e505dc74220dcf2c46febf6df02c01fc2e8358a5c30f6be17afcb61f451ecaR237-R243)
* Added explicit log messages to indicate when the PID filter test is skipped due to the absence of a client PID, clarifying the test outcome.

Summary output enhancements:

* Updated the summary logic in `main()` to handle cases where all tests are skipped, providing a clear warning and exiting with success, and to simplify the reporting of passed/failed tests.