### PR TITLE
feat: gotls Upload sequence; Fix the issue where disorderly arrival c…

### DIFF
--- a/cli/cmd/gotls.go
+++ b/cli/cmd/gotls.go
@@ -36,11 +36,16 @@ ecapture gotls --elfpath=/home/cfc4n/go_https_client --hex --pid=3423
 ecapture gotls -m keylog -k /tmp/ecap_gotls_key.log --elfpath=/home/cfc4n/go_https_client -l save.log --pid=3423
 ecapture gotls -m pcap --pcapfile=save_android.pcapng -i wlan0 --elfpath=/home/cfc4n/go_https_client tcp port 443
 `,
+	Example: `  # userland perf reorder (flag name uses hyphens, not underscores)
+  ecapture gotls --elfpath=/path/to/go/binary --btf=1 --debug --perf-reorder -m text
+  ecapture gotls -e /path/to/go/binary --perf-reorder --perf-reorder-lag-ms=20 -m text`,
 	RunE: goTLSCommandFunc,
 }
 
 func init() {
 	gotlsCmd.PersistentFlags().StringVarP(&gotlsConfig.ElfPath, "elfpath", "e", "", "ELF path to binary built with Go toolchain.")
+	gotlsCmd.PersistentFlags().BoolVar(&gotlsConfig.PerfReorder, "perf-reorder", false, "enable userland reorder of GoTLS perf events before dispatch (reduces out-of-order vs raw perf read order)")
+	gotlsCmd.PersistentFlags().UintVar(&gotlsConfig.PerfReorderLagMs, "perf-reorder-lag-ms", 10, "reorder batching window in milliseconds (only with --perf-reorder; default 10)")
 	gotlsCmd.PersistentFlags().StringVarP(&gotlsConfig.PcapFile, "pcapfile", "w", "ecapture_gotls.pcapng", "write the  raw packets to file as pcapng format.")
 	gotlsCmd.PersistentFlags().StringVarP(&gotlsConfig.CaptureMode, "model", "m", "text", "capture model, such as : text, pcap/pcapng, key/keylog")
 	gotlsCmd.PersistentFlags().StringVarP(&gotlsConfig.KeylogFile, "keylogfile", "k", "ecapture_gotls_key.log", "The file stores SSL/TLS keys, and eCapture captures these keys during encrypted traffic communication and saves them to the file.")

--- a/internal/probe/base/base_probe.go
+++ b/internal/probe/base/base_probe.go
@@ -19,6 +19,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
+	"sync"
 	"sync/atomic"
 
 	"github.com/cilium/ebpf"
@@ -43,14 +44,15 @@ const (
 // BaseProbe provides common functionality for all probes.
 // Concrete probes should embed this struct and implement probe-specific logic.
 type BaseProbe struct {
-	name       string
-	logger     *logger.Logger
-	ctx        context.Context
-	config     domain.Configuration
-	dispatcher domain.EventDispatcher
-	isRunning  atomic.Bool
-	readers    []io.Closer
-	closers    []closer
+	name         string
+	logger       *logger.Logger
+	ctx          context.Context
+	config       domain.Configuration
+	dispatcher   domain.EventDispatcher
+	isRunning    atomic.Bool
+	readers      []io.Closer
+	closers      []closer
+	readerLoopsW sync.WaitGroup // perf/ringbuf read goroutines; see GoReaderLoop
 }
 
 // closer interface for resources that need to be closed.
@@ -185,6 +187,10 @@ func (p *BaseProbe) Close() error {
 
 	p.readers = nil
 
+	// Reader Close() unblocks rd.Read(); read loops may still run deferred work
+	// (e.g. GoTLS reorder flush) that calls Dispatch. Wait before closing dispatcher.
+	p.readerLoopsW.Wait()
+
 	for _, cler := range p.closers {
 		if err := cler.Close(); err != nil {
 			if p.logger != nil {
@@ -278,8 +284,20 @@ func (p *BaseProbe) StartPerfEventReader(em *ebpf.Map, decoder domain.EventDecod
 		Int("size_mb", mapSize/1024/1024).
 		Msg("Perf event reader started")
 
-	go p.perfEventLoop(rd, em, decoder)
+	p.GoReaderLoop(func() { p.perfEventLoop(rd, em, decoder) })
 	return nil
+}
+
+// GoReaderLoop runs fn in a goroutine tracked for shutdown ordering: Close() closes
+// perf/ringbuf readers first, waits for all GoReaderLoop goroutines to exit, then
+// closes the dispatcher. Probes must use this for read loops that may Dispatch after
+// Read returns (e.g. deferred flush).
+func (p *BaseProbe) GoReaderLoop(fn func()) {
+	p.readerLoopsW.Add(1)
+	go func() {
+		defer p.readerLoopsW.Done()
+		fn()
+	}()
 }
 
 // TrackReader registers a reader to be closed when the probe shuts down.
@@ -355,7 +373,7 @@ func (p *BaseProbe) StartRingbufReader(em *ebpf.Map, decoder domain.EventDecoder
 		Str("map", em.String()).
 		Msg("Ringbuf reader started")
 
-	go p.ringbufEventLoop(rd, em, decoder)
+	p.GoReaderLoop(func() { p.ringbufEventLoop(rd, em, decoder) })
 	return nil
 }
 

--- a/internal/probe/base/base_probe.go
+++ b/internal/probe/base/base_probe.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io"
 	"sync/atomic"
 
 	"github.com/cilium/ebpf"
@@ -48,7 +49,7 @@ type BaseProbe struct {
 	config     domain.Configuration
 	dispatcher domain.EventDispatcher
 	isRunning  atomic.Bool
-	readers    []closer
+	readers    []io.Closer
 	closers    []closer
 }
 
@@ -61,7 +62,7 @@ type closer interface {
 func NewBaseProbe(name string) *BaseProbe {
 	return &BaseProbe{
 		name:    name,
-		readers: make([]closer, 0),
+		readers: make([]io.Closer, 0),
 		closers: make([]closer, 0),
 	}
 }
@@ -238,6 +239,14 @@ func (p *BaseProbe) Dispatcher() domain.EventDispatcher {
 	return p.dispatcher
 }
 
+// TrackPerfReader registers a perf/ringbuf reader to be closed in Close().
+func (p *BaseProbe) TrackPerfReader(c io.Closer) {
+	if c == nil {
+		return
+	}
+	p.readers = append(p.readers, c)
+}
+
 func (p *BaseProbe) SetDispatcher(dispatcher domain.EventDispatcher) {
 	p.dispatcher = dispatcher
 }
@@ -262,7 +271,7 @@ func (p *BaseProbe) StartPerfEventReader(em *ebpf.Map, decoder domain.EventDecod
 		return errors.NewEBPFAttachError(em.String(), err)
 	}
 
-	p.readers = append(p.readers, rd)
+	p.TrackReader(rd)
 
 	p.logger.Info().
 		Str("map", em.String()).
@@ -271,6 +280,16 @@ func (p *BaseProbe) StartPerfEventReader(em *ebpf.Map, decoder domain.EventDecod
 
 	go p.perfEventLoop(rd, em, decoder)
 	return nil
+}
+
+// TrackReader registers a reader to be closed when the probe shuts down.
+// Probes that implement a custom perf read loop should call TrackReader with the same reader
+// instance they pass to the goroutine, matching StartPerfEventReader lifecycle.
+func (p *BaseProbe) TrackReader(c io.Closer) {
+	if c == nil {
+		return
+	}
+	p.readers = append(p.readers, c)
 }
 
 // perfEventLoop reads events from a perf buffer.

--- a/internal/probe/gotls/config.go
+++ b/internal/probe/gotls/config.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/gojue/ecapture/internal/config"
 	"github.com/gojue/ecapture/internal/probe/base/handlers"
@@ -85,6 +86,13 @@ type Config struct {
 
 	// IsPieBuildMode indicates whether the Go binary is built in PIE mode (position-independent executable)
 	IsPieBuildMode bool `json:"is_pie_build_mode"`
+
+	// PerfReorder enables userland lag-reorder of GoTLS perf events before Dispatch.
+	PerfReorder bool `json:"perf_reorder"`
+
+	// PerfReorderLagMs is the lag window in milliseconds for reorder batching when PerfReorder is set.
+	// Zero selects the default (10 ms).
+	PerfReorderLagMs uint `json:"perf_reorder_lag_ms"`
 
 	goSymTab  *gosym.Table
 	goElfArch string    //
@@ -549,4 +557,13 @@ func (c *Config) GetPcapFile() string {
 // GetKeylogFile returns the keylog file path.
 func (c *Config) GetKeylogFile() string {
 	return c.KeylogFile
+}
+
+// PerfReorderLagNs returns the reorder lag in nanoseconds. Used when PerfReorder is enabled.
+func (c *Config) PerfReorderLagNs() uint64 {
+	ms := c.PerfReorderLagMs
+	if ms == 0 {
+		return uint64(10 * time.Millisecond)
+	}
+	return uint64(ms) * uint64(time.Millisecond)
 }

--- a/internal/probe/gotls/event.go
+++ b/internal/probe/gotls/event.go
@@ -36,23 +36,30 @@ const (
 // C struct layout (go_tls_event):
 //
 //	u64 ts_ns;           // offset 0,  size 8
-//	u32 pid;             // offset 8,  size 4
-//	u32 tid;             // offset 12, size 4
-//	s32 data_len;        // offset 16, size 4
-//	u8  event_type;      // offset 20, size 1
-//	u8  pad[3];          // offset 21, size 3 (alignment padding)
-//	u32 fd;              // offset 24, size 4
-//	u8  src_ip[16];      // offset 28, size 16
-//	u16 src_port;        // offset 44, size 2
-//	u16 pad2;            // offset 46, size 2 (alignment padding)
-//	u8  dst_ip[16];      // offset 48, size 16
-//	u16 dst_port;        // offset 64, size 2
-//	u8  ip_version;      // offset 66, size 1 (4=IPv4, 6=IPv6)
-//	u8  pad3;            // offset 67, size 1 (alignment padding)
-//	char comm[16];       // offset 68, size 16
-//	char data[...];      // offset 84, variable
+//	u64 seq;             // offset 8,  size 8 (per-CPU counter)
+//	u32 emit_cpu;        // offset 16, size 4
+//	u32 pid;             // offset 20, size 4
+//	u32 tid;             // offset 24, size 4
+//	s32 data_len;        // offset 28, size 4
+//	u8  event_type;      // offset 32, size 1
+//	u8  pad[3];          // offset 33, size 3 (alignment padding)
+//	u32 fd;              // offset 36, size 4
+//	u8  src_ip[16];      // offset 40, size 16
+//	u16 src_port;        // offset 56, size 2
+//	u16 pad2;            // offset 58, size 2 (alignment padding)
+//	u8  dst_ip[16];      // offset 60, size 16
+//	u16 dst_port;        // offset 76, size 2
+//	u8  ip_version;      // offset 78, size 1 (4=IPv4, 6=IPv6)
+//	u8  pad3;            // offset 79, size 1 (alignment padding)
+//	char comm[16];       // offset 80, size 16
+//	char data[...];      // offset 96, variable
 type GoTLSDataEvent struct {
 	Timestamp uint64 `json:"timestamp"`
+	// BpfMonoNs is bpf_ktime_get_ns from the wire (first u64); used with Seq/EmitCPU for stable order.
+	// If Timestamp is replaced (e.g. zero fallback to wall clock), BpfMonoNs stays on the wire value.
+	BpfMonoNs uint64 `json:"-"`
+	Seq       uint64 `json:"-"`
+	EmitCPU   uint32 `json:"-"`
 	Pid       uint32 `json:"pid"`
 	Tid       uint32 `json:"tid"`
 	DataLen   int32  `json:"dataLen"`
@@ -78,6 +85,13 @@ func (e *GoTLSDataEvent) DecodeFromBytes(data []byte) error {
 	// Read fields in order matching the eBPF structure
 	if err := binary.Read(buf, binary.LittleEndian, &e.Timestamp); err != nil {
 		return errors.NewEventDecodeError("gotls.Timestamp", err)
+	}
+	e.BpfMonoNs = e.Timestamp
+	if err := binary.Read(buf, binary.LittleEndian, &e.Seq); err != nil {
+		return errors.NewEventDecodeError("gotls.Seq", err)
+	}
+	if err := binary.Read(buf, binary.LittleEndian, &e.EmitCPU); err != nil {
+		return errors.NewEventDecodeError("gotls.EmitCPU", err)
 	}
 	if err := binary.Read(buf, binary.LittleEndian, &e.Pid); err != nil {
 		return errors.NewEventDecodeError("gotls.Pid", err)
@@ -147,6 +161,18 @@ func (e *GoTLSDataEvent) DecodeFromBytes(data []byte) error {
 	e.GetTuple()
 
 	return nil
+}
+
+// LessGoTLSDataEventByPerfOrder compares two events for emit order after merging per-CPU perf buffers.
+// Ordering matches gimli (bpf monotonic time, then EmitCPU, then per-CPU Seq).
+func LessGoTLSDataEventByPerfOrder(a, b *GoTLSDataEvent) bool {
+	if a.BpfMonoNs != b.BpfMonoNs {
+		return a.BpfMonoNs < b.BpfMonoNs
+	}
+	if a.EmitCPU != b.EmitCPU {
+		return a.EmitCPU < b.EmitCPU
+	}
+	return a.Seq < b.Seq
 }
 
 // GetTimestamp returns the event timestamp in nanoseconds.

--- a/internal/probe/gotls/event.go
+++ b/internal/probe/gotls/event.go
@@ -36,30 +36,25 @@ const (
 // C struct layout (go_tls_event):
 //
 //	u64 ts_ns;           // offset 0,  size 8
-//	u64 seq;             // offset 8,  size 8 (per-CPU counter)
-//	u32 emit_cpu;        // offset 16, size 4
-//	u32 pid;             // offset 20, size 4
-//	u32 tid;             // offset 24, size 4
-//	s32 data_len;        // offset 28, size 4
-//	u8  event_type;      // offset 32, size 1
-//	u8  pad[3];          // offset 33, size 3 (alignment padding)
-//	u32 fd;              // offset 36, size 4
-//	u8  src_ip[16];      // offset 40, size 16
-//	u16 src_port;        // offset 56, size 2
-//	u16 pad2;            // offset 58, size 2 (alignment padding)
-//	u8  dst_ip[16];      // offset 60, size 16
-//	u16 dst_port;        // offset 76, size 2
-//	u8  ip_version;      // offset 78, size 1 (4=IPv4, 6=IPv6)
-//	u8  pad3;            // offset 79, size 1 (alignment padding)
-//	char comm[16];       // offset 80, size 16
-//	char data[...];      // offset 96, variable
+//	u32 pid;             // offset 8,  size 4
+//	u32 tid;             // offset 12, size 4
+//	s32 data_len;        // offset 16, size 4
+//	u8  event_type;      // offset 20, size 1
+//	u8  pad[3];          // offset 21, size 3 (alignment padding)
+//	u32 fd;              // offset 24, size 4
+//	u8  src_ip[16];      // offset 28, size 16
+//	u16 src_port;        // offset 44, size 2
+//	u16 pad2;            // offset 46, size 2 (alignment padding)
+//	u8  dst_ip[16];      // offset 48, size 16
+//	u16 dst_port;        // offset 64, size 2
+//	u8  ip_version;      // offset 66, size 1 (4=IPv4, 6=IPv6)
+//	u8  pad3;            // offset 67, size 1 (alignment padding)
+//	char comm[16];       // offset 68, size 16
+//	char data[...];      // offset 84, variable
 type GoTLSDataEvent struct {
 	Timestamp uint64 `json:"timestamp"`
-	// BpfMonoNs is bpf_ktime_get_ns from the wire (first u64); used with Seq/EmitCPU for stable order.
-	// If Timestamp is replaced (e.g. zero fallback to wall clock), BpfMonoNs stays on the wire value.
+	// BpfMonoNs is bpf_ktime_get_ns from the wire (same as Timestamp until zero fallback replaces display time).
 	BpfMonoNs uint64 `json:"-"`
-	Seq       uint64 `json:"-"`
-	EmitCPU   uint32 `json:"-"`
 	Pid       uint32 `json:"pid"`
 	Tid       uint32 `json:"tid"`
 	DataLen   int32  `json:"dataLen"`
@@ -87,12 +82,6 @@ func (e *GoTLSDataEvent) DecodeFromBytes(data []byte) error {
 		return errors.NewEventDecodeError("gotls.Timestamp", err)
 	}
 	e.BpfMonoNs = e.Timestamp
-	if err := binary.Read(buf, binary.LittleEndian, &e.Seq); err != nil {
-		return errors.NewEventDecodeError("gotls.Seq", err)
-	}
-	if err := binary.Read(buf, binary.LittleEndian, &e.EmitCPU); err != nil {
-		return errors.NewEventDecodeError("gotls.EmitCPU", err)
-	}
 	if err := binary.Read(buf, binary.LittleEndian, &e.Pid); err != nil {
 		return errors.NewEventDecodeError("gotls.Pid", err)
 	}
@@ -164,15 +153,9 @@ func (e *GoTLSDataEvent) DecodeFromBytes(data []byte) error {
 }
 
 // LessGoTLSDataEventByPerfOrder compares two events for emit order after merging per-CPU perf buffers.
-// Ordering matches gimli (bpf monotonic time, then EmitCPU, then per-CPU Seq).
+// Ordering uses only bpf monotonic time (ts_ns on the wire).
 func LessGoTLSDataEventByPerfOrder(a, b *GoTLSDataEvent) bool {
-	if a.BpfMonoNs != b.BpfMonoNs {
-		return a.BpfMonoNs < b.BpfMonoNs
-	}
-	if a.EmitCPU != b.EmitCPU {
-		return a.EmitCPU < b.EmitCPU
-	}
-	return a.Seq < b.Seq
+	return a.BpfMonoNs < b.BpfMonoNs
 }
 
 // GetTimestamp returns the event timestamp in nanoseconds.

--- a/internal/probe/gotls/event_test.go
+++ b/internal/probe/gotls/event_test.go
@@ -27,7 +27,7 @@ import (
 // buildEventBytes constructs a raw eBPF byte payload for GoTLSDataEvent.
 // Offsets match the C struct go_tls_event exactly.
 func buildEventBytes(t *testing.T,
-	timestamp uint64, pid, tid uint32, dataLen int32, eventType uint8,
+	timestamp uint64, seq uint64, emitCPU uint32, pid, tid uint32, dataLen int32, eventType uint8,
 	fd uint32, srcIP [16]byte, srcPort uint16, dstIP [16]byte, dstPort uint16,
 	ipVersion uint8, comm [16]byte, payload []byte,
 ) []byte {
@@ -38,23 +38,25 @@ func buildEventBytes(t *testing.T,
 			t.Fatalf("binary.Write failed: %v", err)
 		}
 	}
-	write(timestamp) // offset 0,  u64
-	write(pid)       // offset 8,  u32
-	write(tid)       // offset 12, u32
-	write(dataLen)   // offset 16, s32
-	write(eventType) // offset 20, u8
-	write([3]byte{}) // offset 21, pad[3]
-	write(fd)        // offset 24, u32
-	write(srcIP)     // offset 28, u8[16]
-	write(srcPort)   // offset 44, u16
-	write([2]byte{}) // offset 46, pad2
-	write(dstIP)     // offset 48, u8[16]
-	write(dstPort)   // offset 64, u16
-	write(ipVersion) // offset 66, u8
-	write(uint8(0))  // offset 67, pad3
-	write(comm)      // offset 68, char[16]
+	write(timestamp) // offset 0,  u64 ts_ns
+	write(seq)       // offset 8,  u64 seq
+	write(emitCPU)   // offset 16, u32 emit_cpu
+	write(pid)       // offset 20, u32
+	write(tid)       // offset 24, u32
+	write(dataLen)   // offset 28, s32
+	write(eventType) // offset 32, u8
+	write([3]byte{}) // offset 33, pad[3]
+	write(fd)        // offset 36, u32
+	write(srcIP)     // offset 40, u8[16]
+	write(srcPort)   // offset 56, u16
+	write([2]byte{}) // offset 58, pad2
+	write(dstIP)     // offset 60, u8[16]
+	write(dstPort)   // offset 76, u16
+	write(ipVersion) // offset 78, u8
+	write(uint8(0))  // offset 79, pad3
+	write(comm)      // offset 80, char[16]
 	if len(payload) > 0 {
-		buf.Write(payload) // offset 84, variable data
+		buf.Write(payload) // offset 96, variable data
 	}
 	return buf.Bytes()
 }
@@ -84,7 +86,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv4_Write(t *testing.T) {
 	payload := []byte("GET / HTTP/1.1\r\n")
 
 	raw := buildEventBytes(t,
-		1000000, 42, 99, int32(len(payload)), 0, // eventType=WRITE
+		1000000, 1, 0, 42, 99, int32(len(payload)), 0, // eventType=WRITE
 		7, srcIP, 12345, dstIP, 443, 4, // ipVersion=4
 		commBytes("curl"), payload,
 	)
@@ -96,6 +98,15 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv4_Write(t *testing.T) {
 
 	if e.Timestamp != 1000000 {
 		t.Errorf("Timestamp = %d, want 1000000", e.Timestamp)
+	}
+	if e.BpfMonoNs != 1000000 {
+		t.Errorf("BpfMonoNs = %d, want 1000000", e.BpfMonoNs)
+	}
+	if e.Seq != 1 {
+		t.Errorf("Seq = %d, want 1", e.Seq)
+	}
+	if e.EmitCPU != 0 {
+		t.Errorf("EmitCPU = %d, want 0", e.EmitCPU)
 	}
 	if e.Pid != 42 {
 		t.Errorf("Pid = %d, want 42", e.Pid)
@@ -141,7 +152,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv4_Read(t *testing.T) {
 	payload := []byte("HTTP/1.1 200 OK\r\n")
 
 	raw := buildEventBytes(t,
-		2000000, 100, 200, int32(len(payload)), 1, // eventType=READ
+		2000000, 2, 0, 100, 200, int32(len(payload)), 1, // eventType=READ
 		5, srcIP, 443, dstIP, 54321, 4,
 		commBytes("myapp"), payload,
 	)
@@ -174,7 +185,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv6(t *testing.T) {
 
 	payload := []byte("hello")
 	raw := buildEventBytes(t,
-		3000000, 7, 8, int32(len(payload)), 0,
+		3000000, 3, 0, 7, 8, int32(len(payload)), 0,
 		3, ipv6Bytes(src6), 8080, ipv6Bytes(dst6), 9090, 6, // ipVersion=6
 		commBytes("server"), payload,
 	)
@@ -196,7 +207,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv6(t *testing.T) {
 
 func TestGoTLSDataEvent_DecodeFromBytes_ZeroDataLen(t *testing.T) {
 	raw := buildEventBytes(t,
-		1000, 1, 2, 0, 0, // dataLen=0
+		1000, 4, 0, 1, 2, 0, 0, // dataLen=0
 		1, ipv4Bytes(1, 2, 3, 4), 100, ipv4Bytes(5, 6, 7, 8), 200, 4,
 		commBytes("app"), nil,
 	)
@@ -212,9 +223,27 @@ func TestGoTLSDataEvent_DecodeFromBytes_ZeroDataLen(t *testing.T) {
 	}
 }
 
+func TestLessGoTLSDataEventByPerfOrder(t *testing.T) {
+	a := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 1, Seq: 5}
+	b := &GoTLSDataEvent{BpfMonoNs: 200, EmitCPU: 0, Seq: 1}
+	if !LessGoTLSDataEventByPerfOrder(a, b) {
+		t.Fatal("expected a before b (mono time)")
+	}
+	sameT := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 2, Seq: 1}
+	otherCPU := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 1, Seq: 99}
+	if !LessGoTLSDataEventByPerfOrder(otherCPU, sameT) {
+		t.Fatal("expected CPU tie-break")
+	}
+	sameTS := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 1, Seq: 1}
+	sameTS2 := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 1, Seq: 2}
+	if !LessGoTLSDataEventByPerfOrder(sameTS, sameTS2) {
+		t.Fatal("expected seq tie-break")
+	}
+}
+
 func TestGoTLSDataEvent_DecodeFromBytes_TimestampZeroFallback(t *testing.T) {
 	raw := buildEventBytes(t,
-		0, 1, 2, 0, 0, // timestamp=0 → should be filled by time.Now()
+		0, 5, 0, 1, 2, 0, 0, // timestamp=0 → should be filled by time.Now()
 		1, ipv4Bytes(1, 2, 3, 4), 80, ipv4Bytes(5, 6, 7, 8), 8080, 4,
 		commBytes("app"), nil,
 	)
@@ -241,7 +270,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_TruncatedInput(t *testing.T) {
 func TestGoTLSDataEvent_DecodeFromBytes_DataLenExceedsBuffer(t *testing.T) {
 	// claim dataLen=100 but provide no payload bytes
 	raw := buildEventBytes(t,
-		1000, 1, 2, 100, 0, // dataLen=100
+		1000, 6, 0, 1, 2, 100, 0, // dataLen=100
 		1, ipv4Bytes(1, 2, 3, 4), 80, ipv4Bytes(5, 6, 7, 8), 8080, 4,
 		commBytes("app"), nil, // no payload
 	)
@@ -584,7 +613,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_RoundTrip(t *testing.T) {
 	copy(comm[:], "myservice")
 
 	raw := buildEventBytes(t,
-		999888777, 12345, 67890, int32(len(wantPayload)), 0,
+		999888777, 7, 0, 12345, 67890, int32(len(wantPayload)), 0,
 		8, ipv4Bytes(172, 16, 0, 1), 54321, ipv4Bytes(172, 16, 0, 2), 443, 4,
 		comm, wantPayload,
 	)
@@ -594,6 +623,12 @@ func TestGoTLSDataEvent_DecodeFromBytes_RoundTrip(t *testing.T) {
 		t.Fatalf("DecodeFromBytes error: %v", err)
 	}
 
+	if e.Seq != 7 {
+		t.Errorf("Seq = %d, want 7", e.Seq)
+	}
+	if e.EmitCPU != 0 {
+		t.Errorf("EmitCPU = %d, want 0", e.EmitCPU)
+	}
 	if e.Pid != 12345 {
 		t.Errorf("Pid = %d, want 12345", e.Pid)
 	}

--- a/internal/probe/gotls/event_test.go
+++ b/internal/probe/gotls/event_test.go
@@ -27,7 +27,7 @@ import (
 // buildEventBytes constructs a raw eBPF byte payload for GoTLSDataEvent.
 // Offsets match the C struct go_tls_event exactly.
 func buildEventBytes(t *testing.T,
-	timestamp uint64, seq uint64, emitCPU uint32, pid, tid uint32, dataLen int32, eventType uint8,
+	timestamp uint64, pid, tid uint32, dataLen int32, eventType uint8,
 	fd uint32, srcIP [16]byte, srcPort uint16, dstIP [16]byte, dstPort uint16,
 	ipVersion uint8, comm [16]byte, payload []byte,
 ) []byte {
@@ -39,24 +39,22 @@ func buildEventBytes(t *testing.T,
 		}
 	}
 	write(timestamp) // offset 0,  u64 ts_ns
-	write(seq)       // offset 8,  u64 seq
-	write(emitCPU)   // offset 16, u32 emit_cpu
-	write(pid)       // offset 20, u32
-	write(tid)       // offset 24, u32
-	write(dataLen)   // offset 28, s32
-	write(eventType) // offset 32, u8
-	write([3]byte{}) // offset 33, pad[3]
-	write(fd)        // offset 36, u32
-	write(srcIP)     // offset 40, u8[16]
-	write(srcPort)   // offset 56, u16
-	write([2]byte{}) // offset 58, pad2
-	write(dstIP)     // offset 60, u8[16]
-	write(dstPort)   // offset 76, u16
-	write(ipVersion) // offset 78, u8
-	write(uint8(0))  // offset 79, pad3
-	write(comm)      // offset 80, char[16]
+	write(pid)       // offset 8,  u32
+	write(tid)       // offset 12, u32
+	write(dataLen)   // offset 16, s32
+	write(eventType) // offset 20, u8
+	write([3]byte{}) // offset 21, pad[3]
+	write(fd)        // offset 24, u32
+	write(srcIP)     // offset 28, u8[16]
+	write(srcPort)   // offset 44, u16
+	write([2]byte{}) // offset 46, pad2
+	write(dstIP)     // offset 48, u8[16]
+	write(dstPort)   // offset 64, u16
+	write(ipVersion) // offset 66, u8
+	write(uint8(0))  // offset 67, pad3
+	write(comm)      // offset 68, char[16]
 	if len(payload) > 0 {
-		buf.Write(payload) // offset 96, variable data
+		buf.Write(payload) // offset 84, variable data
 	}
 	return buf.Bytes()
 }
@@ -86,7 +84,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv4_Write(t *testing.T) {
 	payload := []byte("GET / HTTP/1.1\r\n")
 
 	raw := buildEventBytes(t,
-		1000000, 1, 0, 42, 99, int32(len(payload)), 0, // eventType=WRITE
+		1000000, 42, 99, int32(len(payload)), 0, // eventType=WRITE
 		7, srcIP, 12345, dstIP, 443, 4, // ipVersion=4
 		commBytes("curl"), payload,
 	)
@@ -101,12 +99,6 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv4_Write(t *testing.T) {
 	}
 	if e.BpfMonoNs != 1000000 {
 		t.Errorf("BpfMonoNs = %d, want 1000000", e.BpfMonoNs)
-	}
-	if e.Seq != 1 {
-		t.Errorf("Seq = %d, want 1", e.Seq)
-	}
-	if e.EmitCPU != 0 {
-		t.Errorf("EmitCPU = %d, want 0", e.EmitCPU)
 	}
 	if e.Pid != 42 {
 		t.Errorf("Pid = %d, want 42", e.Pid)
@@ -152,7 +144,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv4_Read(t *testing.T) {
 	payload := []byte("HTTP/1.1 200 OK\r\n")
 
 	raw := buildEventBytes(t,
-		2000000, 2, 0, 100, 200, int32(len(payload)), 1, // eventType=READ
+		2000000, 100, 200, int32(len(payload)), 1, // eventType=READ
 		5, srcIP, 443, dstIP, 54321, 4,
 		commBytes("myapp"), payload,
 	)
@@ -185,7 +177,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv6(t *testing.T) {
 
 	payload := []byte("hello")
 	raw := buildEventBytes(t,
-		3000000, 3, 0, 7, 8, int32(len(payload)), 0,
+		3000000, 7, 8, int32(len(payload)), 0,
 		3, ipv6Bytes(src6), 8080, ipv6Bytes(dst6), 9090, 6, // ipVersion=6
 		commBytes("server"), payload,
 	)
@@ -207,7 +199,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_IPv6(t *testing.T) {
 
 func TestGoTLSDataEvent_DecodeFromBytes_ZeroDataLen(t *testing.T) {
 	raw := buildEventBytes(t,
-		1000, 4, 0, 1, 2, 0, 0, // dataLen=0
+		1000, 1, 2, 0, 0, // dataLen=0
 		1, ipv4Bytes(1, 2, 3, 4), 100, ipv4Bytes(5, 6, 7, 8), 200, 4,
 		commBytes("app"), nil,
 	)
@@ -224,26 +216,21 @@ func TestGoTLSDataEvent_DecodeFromBytes_ZeroDataLen(t *testing.T) {
 }
 
 func TestLessGoTLSDataEventByPerfOrder(t *testing.T) {
-	a := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 1, Seq: 5}
-	b := &GoTLSDataEvent{BpfMonoNs: 200, EmitCPU: 0, Seq: 1}
+	a := &GoTLSDataEvent{BpfMonoNs: 100}
+	b := &GoTLSDataEvent{BpfMonoNs: 200}
 	if !LessGoTLSDataEventByPerfOrder(a, b) {
 		t.Fatal("expected a before b (mono time)")
 	}
-	sameT := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 2, Seq: 1}
-	otherCPU := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 1, Seq: 99}
-	if !LessGoTLSDataEventByPerfOrder(otherCPU, sameT) {
-		t.Fatal("expected CPU tie-break")
-	}
-	sameTS := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 1, Seq: 1}
-	sameTS2 := &GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 1, Seq: 2}
-	if !LessGoTLSDataEventByPerfOrder(sameTS, sameTS2) {
-		t.Fatal("expected seq tie-break")
+	x := &GoTLSDataEvent{BpfMonoNs: 100}
+	y := &GoTLSDataEvent{BpfMonoNs: 100}
+	if LessGoTLSDataEventByPerfOrder(x, y) || LessGoTLSDataEventByPerfOrder(y, x) {
+		t.Fatal("equal mono_ns should not be ordered strictly")
 	}
 }
 
 func TestGoTLSDataEvent_DecodeFromBytes_TimestampZeroFallback(t *testing.T) {
 	raw := buildEventBytes(t,
-		0, 5, 0, 1, 2, 0, 0, // timestamp=0 → should be filled by time.Now()
+		0, 1, 2, 0, 0, // timestamp=0 → should be filled by time.Now()
 		1, ipv4Bytes(1, 2, 3, 4), 80, ipv4Bytes(5, 6, 7, 8), 8080, 4,
 		commBytes("app"), nil,
 	)
@@ -270,7 +257,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_TruncatedInput(t *testing.T) {
 func TestGoTLSDataEvent_DecodeFromBytes_DataLenExceedsBuffer(t *testing.T) {
 	// claim dataLen=100 but provide no payload bytes
 	raw := buildEventBytes(t,
-		1000, 6, 0, 1, 2, 100, 0, // dataLen=100
+		1000, 1, 2, 100, 0, // dataLen=100
 		1, ipv4Bytes(1, 2, 3, 4), 80, ipv4Bytes(5, 6, 7, 8), 8080, 4,
 		commBytes("app"), nil, // no payload
 	)
@@ -613,7 +600,7 @@ func TestGoTLSDataEvent_DecodeFromBytes_RoundTrip(t *testing.T) {
 	copy(comm[:], "myservice")
 
 	raw := buildEventBytes(t,
-		999888777, 7, 0, 12345, 67890, int32(len(wantPayload)), 0,
+		999888777, 12345, 67890, int32(len(wantPayload)), 0,
 		8, ipv4Bytes(172, 16, 0, 1), 54321, ipv4Bytes(172, 16, 0, 2), 443, 4,
 		comm, wantPayload,
 	)
@@ -623,12 +610,6 @@ func TestGoTLSDataEvent_DecodeFromBytes_RoundTrip(t *testing.T) {
 		t.Fatalf("DecodeFromBytes error: %v", err)
 	}
 
-	if e.Seq != 7 {
-		t.Errorf("Seq = %d, want 7", e.Seq)
-	}
-	if e.EmitCPU != 0 {
-		t.Errorf("EmitCPU = %d, want 0", e.EmitCPU)
-	}
 	if e.Pid != 12345 {
 		t.Errorf("Pid = %d, want 12345", e.Pid)
 	}

--- a/internal/probe/gotls/gotls_perf_reader.go
+++ b/internal/probe/gotls/gotls_perf_reader.go
@@ -53,9 +53,9 @@ func (p *Probe) startGoTLSDataPerfReader(em *ebpf.Map, decoder domain.EventDecod
 		Msg("Perf event reader started (GoTLS)")
 
 	if p.config.PerfReorder {
-		go p.goTLSOrderedPerfLoop(rd, em, decoder)
+		p.GoReaderLoop(func() { p.goTLSOrderedPerfLoop(rd, em, decoder) })
 	} else {
-		go p.goTLSPlainPerfLoop(rd, em, decoder)
+		p.GoReaderLoop(func() { p.goTLSPlainPerfLoop(rd, em, decoder) })
 	}
 	return nil
 }

--- a/internal/probe/gotls/gotls_perf_reader.go
+++ b/internal/probe/gotls/gotls_perf_reader.go
@@ -24,8 +24,8 @@ const dispatchLogAfterReorder = "after reorder"
 
 func logGotlsPerfDispatch(p *Probe, label string, ev *GoTLSDataEvent) {
 	p.Logger().Debug().Msg(fmt.Sprintf(
-		"gotls perf dispatch (%s) mono_ns=%d emit_cpu=%d seq=%d",
-		label, ev.BpfMonoNs, ev.EmitCPU, ev.Seq,
+		"gotls perf dispatch (%s) mono_ns=%d",
+		label, ev.BpfMonoNs,
 	))
 }
 

--- a/internal/probe/gotls/gotls_perf_reader.go
+++ b/internal/probe/gotls/gotls_perf_reader.go
@@ -1,0 +1,172 @@
+// Copyright 2024 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+
+package gotls
+
+import (
+	stderrors "errors"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/perf"
+
+	"github.com/gojue/ecapture/internal/domain"
+	"github.com/gojue/ecapture/internal/errors"
+)
+
+// dispatchLogNoReorder is logged immediately before Dispatch in raw perf order (for verify_gotls_reorder_log.py).
+const dispatchLogNoReorder = "no reorder"
+
+// dispatchLogAfterReorder is logged immediately before Dispatch after userland reorder.
+const dispatchLogAfterReorder = "after reorder"
+
+func logGotlsPerfDispatch(p *Probe, label string, ev *GoTLSDataEvent) {
+	p.Logger().Debug().Msg(fmt.Sprintf(
+		"gotls perf dispatch (%s) mono_ns=%d emit_cpu=%d seq=%d",
+		label, ev.BpfMonoNs, ev.EmitCPU, ev.Seq,
+	))
+}
+
+// startGoTLSDataPerfReader starts a perf reader for TLS data events with optional userland reorder.
+func (p *Probe) startGoTLSDataPerfReader(em *ebpf.Map, decoder domain.EventDecoder) error {
+	if em == nil {
+		return errors.New(errors.ErrCodeEBPFMapAccess, "eBPF map cannot be nil")
+	}
+	if decoder == nil {
+		return errors.New(errors.ErrCodeConfiguration, "event decoder cannot be nil")
+	}
+
+	mapSize := p.config.GetPerCpuMapSize()
+	rd, err := perf.NewReader(em, mapSize)
+	if err != nil {
+		return errors.NewEBPFAttachError(em.String(), err)
+	}
+
+	p.TrackPerfReader(rd)
+
+	p.Logger().Info().
+		Str("map", em.String()).
+		Int("size_mb", mapSize/1024/1024).
+		Bool("perf_reorder", p.config.PerfReorder).
+		Msg("Perf event reader started (GoTLS)")
+
+	if p.config.PerfReorder {
+		go p.goTLSOrderedPerfLoop(rd, em, decoder)
+	} else {
+		go p.goTLSPlainPerfLoop(rd, em, decoder)
+	}
+	return nil
+}
+
+func (p *Probe) goTLSPlainPerfLoop(rd *perf.Reader, em *ebpf.Map, decoder domain.EventDecoder) {
+	for {
+		select {
+		case <-p.Context().Done():
+			p.Logger().Debug().Msg("GoTLS perf reader stopping")
+			return
+		default:
+		}
+
+		record, err := rd.Read()
+		if err != nil {
+			if stderrors.Is(err, perf.ErrClosed) {
+				return
+			}
+			p.Logger().Warn().Err(err).Msg("Error reading from perf buffer")
+			continue
+		}
+		if record.LostSamples != 0 {
+			p.Logger().Warn().
+				Uint64("lost_samples", record.LostSamples).
+				Msg("Perf buffer full, samples lost")
+			continue
+		}
+
+		event, err := decoder.Decode(em, record.RawSample)
+		if err != nil {
+			if stderrors.Is(err, errors.ErrEventNotReady) {
+				p.Logger().Debug().Msg("Event not ready, skipping")
+				continue
+			}
+			p.Logger().Warn().Err(err).Msg("Failed to decode event")
+			continue
+		}
+		p.Logger().Debug().Str("event", event.String()).Msg("Perf event decoded")
+
+		gte, ok := event.(*GoTLSDataEvent)
+		if !ok {
+			if err := p.Dispatcher().Dispatch(event); err != nil {
+				p.Logger().Warn().Err(err).Msg("Failed to dispatch event")
+			}
+			continue
+		}
+		logGotlsPerfDispatch(p, dispatchLogNoReorder, gte)
+		if err := p.Dispatcher().Dispatch(event); err != nil {
+			p.Logger().Warn().Err(err).Msg("Failed to dispatch GoTLS event")
+		}
+	}
+}
+
+func (p *Probe) goTLSOrderedPerfLoop(rd *perf.Reader, em *ebpf.Map, decoder domain.EventDecoder) {
+	reorder := newGoTLSPerfReorder(p.config.PerfReorderLagNs())
+	defer func() {
+		for _, ev := range reorder.flushAll() {
+			logGotlsPerfDispatch(p, dispatchLogAfterReorder, ev)
+			if err := p.Dispatcher().Dispatch(ev); err != nil {
+				p.Logger().Warn().Err(err).Msg("Failed to dispatch reordered GoTLS event")
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-p.Context().Done():
+			p.Logger().Debug().Msg("GoTLS perf reader stopping")
+			return
+		default:
+		}
+
+		record, err := rd.Read()
+		if err != nil {
+			if stderrors.Is(err, perf.ErrClosed) {
+				return
+			}
+			p.Logger().Warn().Err(err).Msg("Error reading from perf buffer")
+			continue
+		}
+		if record.LostSamples != 0 {
+			p.Logger().Warn().
+				Uint64("lost_samples", record.LostSamples).
+				Msg("Perf buffer full, samples lost")
+			continue
+		}
+
+		event, err := decoder.Decode(em, record.RawSample)
+		if err != nil {
+			if stderrors.Is(err, errors.ErrEventNotReady) {
+				p.Logger().Debug().Msg("Event not ready, skipping")
+				continue
+			}
+			p.Logger().Warn().Err(err).Msg("Failed to decode event")
+			continue
+		}
+		p.Logger().Debug().Str("event", event.String()).Msg("Perf event decoded")
+
+		gte, ok := event.(*GoTLSDataEvent)
+		if !ok {
+			if err := p.Dispatcher().Dispatch(event); err != nil {
+				p.Logger().Warn().Err(err).Msg("Failed to dispatch event")
+			}
+			continue
+		}
+
+		for _, ev := range reorder.push(gte) {
+			logGotlsPerfDispatch(p, dispatchLogAfterReorder, ev)
+			if err := p.Dispatcher().Dispatch(ev); err != nil {
+				p.Logger().Warn().Err(err).Msg("Failed to dispatch reordered GoTLS event")
+			}
+		}
+	}
+}

--- a/internal/probe/gotls/gotls_probe.go
+++ b/internal/probe/gotls/gotls_probe.go
@@ -94,6 +94,8 @@ func (p *Probe) Initialize(ctx context.Context, cfg domain.Configuration) error 
 		Bool("is_register_abi", gotlsConfig.IsRegisterABI).
 		Str("capture_mode", gotlsConfig.CaptureMode).
 		Str("elf_path", gotlsConfig.ElfPath).
+		Bool("perf_reorder", gotlsConfig.PerfReorder).
+		Uint64("perf_reorder_lag_ns", gotlsConfig.PerfReorderLagNs()).
 		Msg("GoTLS probe initialized")
 
 	return nil
@@ -137,8 +139,14 @@ func (p *Probe) Start(ctx context.Context) error {
 
 	// Start event readers for all configured maps
 	for em, decoder := range p.eventFuncMaps {
-		if err := p.StartPerfEventReader(em, decoder); err != nil {
-			return err
+		if _, ok := decoder.(*tlsDataEventDecoder); ok {
+			if err := p.startGoTLSDataPerfReader(em, decoder); err != nil {
+				return err
+			}
+		} else {
+			if err := p.StartPerfEventReader(em, decoder); err != nil {
+				return err
+			}
 		}
 		p.Logger().Debug().
 			Str("map", em.String()).
@@ -554,7 +562,6 @@ type tlsDataEventDecoder struct {
 
 func (d *tlsDataEventDecoder) Decode(_ *ebpf.Map, data []byte) (domain.Event, error) {
 	event := &GoTLSDataEvent{}
-	fmt.Println("Decoding TLSDataEvent from bytes, data length:", len(data))
 	if err := event.DecodeFromBytes(data); err != nil {
 		return nil, err
 	}

--- a/internal/probe/gotls/gotls_reorder.go
+++ b/internal/probe/gotls/gotls_reorder.go
@@ -1,0 +1,101 @@
+// Copyright 2024 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gotls
+
+import (
+	"sort"
+)
+
+type goTLSPerfReorder struct {
+	lagNs      uint64
+	maxPending int
+	buf        []*GoTLSDataEvent
+}
+
+func newGoTLSPerfReorder(lagNs uint64) *goTLSPerfReorder {
+	return &goTLSPerfReorder{
+		lagNs:      lagNs,
+		maxPending: 1024,
+	}
+}
+
+func (r *goTLSPerfReorder) less(i, j int) bool {
+	return LessGoTLSDataEventByPerfOrder(r.buf[i], r.buf[j])
+}
+
+// flushAll emits the entire buffer in stable probe order (e.g. on reader shutdown).
+func (r *goTLSPerfReorder) flushAll() []*GoTLSDataEvent {
+	if len(r.buf) == 0 {
+		return nil
+	}
+	sort.SliceStable(r.buf, r.less)
+	out := r.buf
+	r.buf = nil
+	return out
+}
+
+func (r *goTLSPerfReorder) push(ev *GoTLSDataEvent) []*GoTLSDataEvent {
+	r.buf = append(r.buf, ev)
+	if len(r.buf) >= r.maxPending {
+		return r.flushPressure()
+	}
+	return r.flushByLag()
+}
+
+func (r *goTLSPerfReorder) flushPressure() []*GoTLSDataEvent {
+	sort.SliceStable(r.buf, r.less)
+	n := len(r.buf) / 2
+	if n == 0 {
+		n = 1
+	}
+	out := make([]*GoTLSDataEvent, n)
+	copy(out, r.buf[:n])
+	r.buf = append([]*GoTLSDataEvent(nil), r.buf[n:]...)
+	return out
+}
+
+func (r *goTLSPerfReorder) flushByLag() []*GoTLSDataEvent {
+	if len(r.buf) <= 1 {
+		return nil
+	}
+	var maxNs, minNs int64 = -1, -1
+	for _, x := range r.buf {
+		v := int64(x.BpfMonoNs)
+		if maxNs < v {
+			maxNs = v
+		}
+		if minNs < 0 || v < minNs {
+			minNs = v
+		}
+	}
+	if maxNs-minNs < int64(r.lagNs) {
+		return nil
+	}
+	cutoff := maxNs - int64(r.lagNs)
+	var flush []*GoTLSDataEvent
+	var keep []*GoTLSDataEvent
+	for _, x := range r.buf {
+		if int64(x.BpfMonoNs) <= cutoff {
+			flush = append(flush, x)
+		} else {
+			keep = append(keep, x)
+		}
+	}
+	r.buf = keep
+	sort.SliceStable(flush, func(i, j int) bool {
+		return LessGoTLSDataEventByPerfOrder(flush[i], flush[j])
+	})
+	return flush
+}

--- a/internal/probe/gotls/gotls_reorder_test.go
+++ b/internal/probe/gotls/gotls_reorder_test.go
@@ -20,15 +20,15 @@ import (
 
 func TestGoTLSPerfReorder_flushByLag_ordersWithinCutoff(t *testing.T) {
 	r := newGoTLSPerfReorder(10)
-	_ = r.push(&GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 0, Seq: 2, DataLen: 1, Data: []byte{'b'}})
-	out := r.push(&GoTLSDataEvent{BpfMonoNs: 50, EmitCPU: 0, Seq: 1, DataLen: 1, Data: []byte{'a'}})
+	_ = r.push(&GoTLSDataEvent{BpfMonoNs: 100, DataLen: 1, Data: []byte{'b'}})
+	out := r.push(&GoTLSDataEvent{BpfMonoNs: 50, DataLen: 1, Data: []byte{'a'}})
 	if len(out) != 1 {
 		t.Fatalf("want 1 flushed (older mono), got %d", len(out))
 	}
 	if string(out[0].GetData()) != "a" {
 		t.Fatalf("expected payload a, got %q", out[0].GetData())
 	}
-	out = r.push(&GoTLSDataEvent{BpfMonoNs: 120, EmitCPU: 0, Seq: 3, DataLen: 1, Data: []byte{'c'}})
+	out = r.push(&GoTLSDataEvent{BpfMonoNs: 120, DataLen: 1, Data: []byte{'c'}})
 	if len(out) != 1 || string(out[0].GetData()) != "b" {
 		t.Fatalf("expected b flush, got %v", out)
 	}

--- a/internal/probe/gotls/gotls_reorder_test.go
+++ b/internal/probe/gotls/gotls_reorder_test.go
@@ -1,0 +1,39 @@
+// Copyright 2024 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gotls
+
+import (
+	"testing"
+)
+
+func TestGoTLSPerfReorder_flushByLag_ordersWithinCutoff(t *testing.T) {
+	r := newGoTLSPerfReorder(10)
+	_ = r.push(&GoTLSDataEvent{BpfMonoNs: 100, EmitCPU: 0, Seq: 2, DataLen: 1, Data: []byte{'b'}})
+	out := r.push(&GoTLSDataEvent{BpfMonoNs: 50, EmitCPU: 0, Seq: 1, DataLen: 1, Data: []byte{'a'}})
+	if len(out) != 1 {
+		t.Fatalf("want 1 flushed (older mono), got %d", len(out))
+	}
+	if string(out[0].GetData()) != "a" {
+		t.Fatalf("expected payload a, got %q", out[0].GetData())
+	}
+	out = r.push(&GoTLSDataEvent{BpfMonoNs: 120, EmitCPU: 0, Seq: 3, DataLen: 1, Data: []byte{'c'}})
+	if len(out) != 1 || string(out[0].GetData()) != "b" {
+		t.Fatalf("expected b flush, got %v", out)
+	}
+	rest := r.flushAll()
+	if len(rest) != 1 || string(rest[0].GetData()) != "c" {
+		t.Fatalf("remainder: %+v", rest)
+	}
+}

--- a/kern/gotls_kern.c
+++ b/kern/gotls_kern.c
@@ -30,6 +30,8 @@
 
 struct go_tls_event {
     u64 ts_ns;
+    u64 seq;       // per-CPU emit order (PERCPU_ARRAY++); no atomics (tracing forbids bpf_spin_lock & map atomics on some kernels)
+    u32 emit_cpu;  // bpf_get_smp_processor_id() for userspace tie-break across CPUs
     u32 pid;
     u32 tid;
     s32 data_len;
@@ -80,6 +82,15 @@ struct {
     __uint(max_entries, 1);
 } gte_context_gen SEC(".maps");
 
+// Per-CPU seq: each CPU only touches its own slot — no global atomic (verifier rejects
+// BPF_STX atomic on many tracing targets).
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, u32);
+    __type(value, u64);
+} gotls_percpu_seq SEC(".maps");
+
 static __always_inline struct go_tls_event *get_gotls_event() {
     u32 zero = 0;
     struct go_tls_event *event = bpf_map_lookup_elem(&gte_context_gen, &zero);
@@ -87,6 +98,15 @@ static __always_inline struct go_tls_event *get_gotls_event() {
 
     u64 id = bpf_get_current_pid_tgid();
     event->ts_ns = bpf_ktime_get_ns();
+    event->emit_cpu = bpf_get_smp_processor_id();
+    u32 k = 0;
+    u64 *pc = bpf_map_lookup_elem(&gotls_percpu_seq, &k);
+    if (pc) {
+        *pc = *pc + 1;
+        event->seq = *pc;
+    } else {
+        event->seq = 0;
+    }
     event->pid = id >> 32;
     event->tid = (__u32)id;
     event->event_type = GOTLS_EVENT_TYPE_WRITE;

--- a/kern/gotls_kern.c
+++ b/kern/gotls_kern.c
@@ -30,8 +30,6 @@
 
 struct go_tls_event {
     u64 ts_ns;
-    u64 seq;       // per-CPU emit order (PERCPU_ARRAY++); no atomics (tracing forbids bpf_spin_lock & map atomics on some kernels)
-    u32 emit_cpu;  // bpf_get_smp_processor_id() for userspace tie-break across CPUs
     u32 pid;
     u32 tid;
     s32 data_len;
@@ -82,15 +80,6 @@ struct {
     __uint(max_entries, 1);
 } gte_context_gen SEC(".maps");
 
-// Per-CPU seq: each CPU only touches its own slot — no global atomic (verifier rejects
-// BPF_STX atomic on many tracing targets).
-struct {
-    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-    __uint(max_entries, 1);
-    __type(key, u32);
-    __type(value, u64);
-} gotls_percpu_seq SEC(".maps");
-
 static __always_inline struct go_tls_event *get_gotls_event() {
     u32 zero = 0;
     struct go_tls_event *event = bpf_map_lookup_elem(&gte_context_gen, &zero);
@@ -98,15 +87,6 @@ static __always_inline struct go_tls_event *get_gotls_event() {
 
     u64 id = bpf_get_current_pid_tgid();
     event->ts_ns = bpf_ktime_get_ns();
-    event->emit_cpu = bpf_get_smp_processor_id();
-    u32 k = 0;
-    u64 *pc = bpf_map_lookup_elem(&gotls_percpu_seq, &k);
-    if (pc) {
-        *pc = *pc + 1;
-        event->seq = *pc;
-    } else {
-        event->seq = 0;
-    }
     event->pid = id >> 32;
     event->tid = (__u32)id;
     event->event_type = GOTLS_EVENT_TYPE_WRITE;


### PR DESCRIPTION
为了解决 多 CPU perf 读取乱序 导致的 HTTP/2 字节流拼接错误。
<img width="927" height="26" alt="image-20260416111550319" src="https://github.com/user-attachments/assets/add471d2-615a-4364-9006-16a1a6d91182" />
乱序的根本原因在于观测路径而非业务数据流：BPF 程序在每次 `read()` 完成时，通过 `bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, ...)` 将明文副本写入**当前 CPU 对应的 Perf ring buffer**。所谓"不同 CPU"，指的是多次 hook 触发时，BPF 程序可能在不同 CPU 核心上执行，导致样本被写入各自 CPU 对应的 Perf ring buffer 中，形成多生产者（多 CPU 各自 ring）单消费者（用户态合并读取）模型；合并时无法保证全局顺序等于探针触发顺序，在 HTTP/2 二进制帧与多路复用场景下（如文件上传）表现尤为明显。

文档：
[[ecapture] eBPF hook gotls 收包乱序根因分析](https://blog.csdn.net/skylar2/article/details/160212052?spm=1011.2415.3001.5331)
[[eCapture] GoTLS Perf 事件有序下发](https://blog.csdn.net/skylar2/article/details/160155831)
[[ecapture] gotls：三种模式实现说明与上层应用职责](https://blog.csdn.net/skylar2/article/details/160223943?spm=1011.2415.3001.5331)
<!-- devin-review-badge-begin -->


---

<a href="https://app.devin.ai/review/gojue/ecapture/pull/978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


reorder可通过配置开启，lag=10ms 测试对比：
指标 | old（无 reorder） | new（有 reorder）
-- | -- | --
dispatch 条数 | 2774 | 2833
相邻逆序 | 10（0.36%） | 6（0.21%）
全局逆序对占比 | 3.43% | 2.44%
<img width="970" height="427" alt="image-20260414175528657" src="https://github.com/user-attachments/assets/db1cb4a9-9d81-4d04-9f29-86443e98b131" />




单元测试已通过：
<img width="747" height="750" alt="image-20260413152406739" src="https://github.com/user-attachments/assets/8d9b7183-76e1-421e-b096-b92b740ecbb0" />



