### PR TITLE
feat(android16): support BoringSSL TLS capture on Android 16

### DIFF
--- a/kern/boringssl_a_16_kern.c
+++ b/kern/boringssl_a_16_kern.c
@@ -17,9 +17,15 @@
 #define SSL_ST_S3 0x30
 
 // ssl_session_st->ssl_version
+// NOTE: In Android 16, ssl_st no longer has a 'version' field.
+// The version is now read from ssl_session_st->ssl_version instead.
+// This macro also acts as the feature flag for boringssl_const.h to
+// apply Android 16 InplaceVector-based TLS 1.3 secret offset formulas.
 #define SSL_SESSION_ST_SSL_VERSION 0x4
 
 // ssl_session_st->secret
+// In Android 16, 'secret' is InplaceVector<uint8_t, SSL_MAX_MASTER_KEY_LENGTH>.
+// InplaceVector stores storage_[] first, so data starts at the base offset.
 #define SSL_SESSION_ST_SECRET 0xa
 
 // ssl_session_st->cipher
@@ -42,6 +48,11 @@
 
 // bssl::SSL3_STATE->client_random
 #define BSSL__SSL3_STATE_CLIENT_RANDOM 0x30
+
+// bssl::SSL3_STATE->version
+// NOTE: In Android 16, ssl_st.version was removed. The protocol version is
+// now stored here in SSL3_STATE. Used to correctly detect TLS 1.3 connections.
+#define BSSL__SSL3_STATE_VERSION 0xd0
 
 // bssl::SSL3_STATE->exporter_secret
 #define BSSL__SSL3_STATE_EXPORTER_SECRET 0x182

--- a/kern/boringssl_a_16_kern.c
+++ b/kern/boringssl_a_16_kern.c
@@ -4,6 +4,12 @@
 /* OPENSSL_VERSION_TEXT: OpenSSL 1.1.1 (compatible; BoringSSL) */
 /* OPENSSL_VERSION_NUMBER: 269488255 */
 
+// ssl_st->version removed in this BoringSSL version.
+// SSL_SESSION_ST_SSL_VERSION also acts as the Android 16+ feature flag
+// for boringssl_const.h (InplaceVector offsets) and boringssl_masterkey.h.
+// ssl_session_st->ssl_version
+#define SSL_SESSION_ST_SSL_VERSION 0x4
+
 // ssl_st->session
 #define SSL_ST_SESSION 0x58
 
@@ -16,16 +22,11 @@
 // ssl_st->s3
 #define SSL_ST_S3 0x30
 
-// ssl_session_st->ssl_version
-// NOTE: In Android 16, ssl_st no longer has a 'version' field.
-// The version is now read from ssl_session_st->ssl_version instead.
-// This macro also acts as the feature flag for boringssl_const.h to
-// apply Android 16 InplaceVector-based TLS 1.3 secret offset formulas.
-#define SSL_SESSION_ST_SSL_VERSION 0x4
+// ssl_session_st->secret_length removed in this BoringSSL version.
+// Sentinel 0xFF: boringssl_masterkey.h uses BORINGSSL_SSL_MAX_MASTER_KEY_LENGTH.
+#define SSL_SESSION_ST_SECRET_LENGTH 0xFF
 
 // ssl_session_st->secret
-// In Android 16, 'secret' is InplaceVector<uint8_t, SSL_MAX_MASTER_KEY_LENGTH>.
-// InplaceVector stores storage_[] first, so data starts at the base offset.
 #define SSL_SESSION_ST_SECRET 0xa
 
 // ssl_session_st->cipher
@@ -49,16 +50,17 @@
 // bssl::SSL3_STATE->client_random
 #define BSSL__SSL3_STATE_CLIENT_RANDOM 0x30
 
-// bssl::SSL3_STATE->version
-// NOTE: In Android 16, ssl_st.version was removed. The protocol version is
-// now stored here in SSL3_STATE. Used to correctly detect TLS 1.3 connections.
-#define BSSL__SSL3_STATE_VERSION 0xd0
-
 // bssl::SSL3_STATE->exporter_secret
 #define BSSL__SSL3_STATE_EXPORTER_SECRET 0x182
 
 // bssl::SSL3_STATE->established_session
 #define BSSL__SSL3_STATE_ESTABLISHED_SESSION 0x1d0
+
+// SSL3_STATE->version added in Android 16 (replaces ssl_st->version).
+// BSSL__SSL3_STATE_VERSION is the Android 16+ feature flag used by
+// boringssl_masterkey.h to read the TLS version before the 1.2/1.3 branch.
+// bssl::SSL3_STATE->version
+#define BSSL__SSL3_STATE_VERSION 0xd0
 
 // bssl::SSL_HANDSHAKE->new_session
 #define BSSL__SSL_HANDSHAKE_NEW_SESSION 0x5f0
@@ -80,8 +82,6 @@
 
 // bssl::SSL_HANDSHAKE->max_version
 #define BSSL__SSL_HANDSHAKE_MAX_VERSION 0x1e
-
-#define SSL_SESSION_ST_SECRET_LENGTH 0xFF
 
 #include "boringssl_const.h"
 #include "boringssl_masterkey.h"

--- a/kern/boringssl_const.h
+++ b/kern/boringssl_const.h
@@ -5,58 +5,66 @@
 // SSL_MAX_MD_SIZE is size of the largest hash function used in TLS, SHA-384.
 #define SSL_MAX_MD_SIZE 48
 
+// memory layout from boringssl repo  ssl/internal.h
+// struct SSL_HANDSHAKE
+//
+// ── Android ≤ 15  (TLS 1.3 secrets are private raw arrays) ─────────────────
+//   uint16_t max_version;          // public,  2 bytes  @ BSSL__SSL_HANDSHAKE_MAX_VERSION
+//   // private (aligned to 8):
+//   size_t   hash_len_;            // 8 bytes
+//   uint8_t  secret_[48];          // 48 bytes  ← SSL_HANDSHAKE_SECRET_
+//   uint8_t  early_traffic_secret_[48];         // step = 48
+//   ...
+//
+// ── Android 16+  (TLS 1.3 secrets are public InplaceVector<uint8_t,48>) ────
+//   uint16_t max_version;          // public, 2 bytes
+//   InplaceVector<uint8_t,48> secret;           // ← SSL_HANDSHAKE_SECRET_
+//   InplaceVector<uint8_t,48> early_traffic_secret;  // step = 49
+//   ...
+//
+// InplaceVector<uint8_t,N> memory layout (alignof=1, no padding):
+//   [0 .. N-1] storage_[N]  — actual data bytes  (same address as struct base)
+//   [N]        size_         — uint8_t            (equivalent of hash_len_)
+//
+// SSL_SESSION_ST_SSL_VERSION is defined only in android16 kern headers and
+// serves as the version feature-flag here.
+// ────────────────────────────────────────────────────────────────────────────
 
-// memory layout from boringssl repo  ssl/internal.h line 1720
-// struct of struct SSL_HANDSHAKE
-/*
-  // via boringssl source code  src/ssl/internal.h : line 1585
+#ifdef SSL_SESSION_ST_SSL_VERSION
+// ── Android 16+: three root values differ from older versions ───────────────
 
-  // max_version is the maximum accepted protocol version, taking account both
-  // |SSL_OP_NO_*| and |SSL_CTX_set_max_proto_version| APIs.
-  uint16_t max_version = 0;
+// secret.storage_ starts right after max_version (alignof InplaceVector = 1, no gap)
+#define SSL_HANDSHAKE_SECRET_    (BSSL__SSL_HANDSHAKE_MAX_VERSION + 2)
 
- private:
-  size_t hash_len_ = 0;x
-  uint8_t secret_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t early_traffic_secret_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t client_handshake_secret_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t server_handshake_secret_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t client_traffic_secret_0_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t server_traffic_secret_0_[SSL_MAX_MD_SIZE] = {0};
-  uint8_t expected_client_finished_[SSL_MAX_MD_SIZE] = {0};
-  */
-// In BoringSSL, TLS 1.3 keys are private fields, so direct offsetof
-// calculation is not possible.  Compute the offset by finding the address
-// of the field preceding the private section (max_version at offset 30),
-// then the first private field (size_t hash_len_) sits at offset 32 after
-// alignment. secret_ is at 32 + sizeof(size_t) = 40, and subsequent
-// fields are at SSL_MAX_MD_SIZE increments.
+// hash_len is now secret.size_: the uint8_t sitting right after secret.storage_[48]
+#define SSL_HANDSHAKE_HASH_LEN_  (SSL_HANDSHAKE_SECRET_ + SSL_MAX_MD_SIZE)
 
+// Each InplaceVector<uint8_t,48> occupies 49 bytes (48 data + 1 size_)
+#define SSL_HANDSHAKE_FIELD_STEP (SSL_MAX_MD_SIZE + 1)
 
-//   uint16_t max_version = 0;
-// sizeof(uint16_t) = 2
-#define SSL_HANDSHAKE_HASH_LEN_ roundup(BSSL__SSL_HANDSHAKE_MAX_VERSION+2,8)
+#else
+// ── Android ≤ 15: original layout ───────────────────────────────────────────
 
-// ssl_st->s3->hs
-// bssl::SSL_HANDSHAKE->secret_
-#define SSL_HANDSHAKE_SECRET_ SSL_HANDSHAKE_HASH_LEN_+8
+// hash_len_ is a size_t aligned to 8, sitting right after max_version
+#define SSL_HANDSHAKE_HASH_LEN_  roundup(BSSL__SSL_HANDSHAKE_MAX_VERSION + 2, 8)
 
-// bssl::SSL_HANDSHAKE->early_traffic_secret_
-#define SSL_HANDSHAKE_EARLY_TRAFFIC_SECRET_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*1
+// secret_ follows hash_len_ (size_t = 8 bytes)
+#define SSL_HANDSHAKE_SECRET_    (SSL_HANDSHAKE_HASH_LEN_ + 8)
 
-// bssl::SSL_HANDSHAKE->client_handshake_secret_
-#define SSL_HANDSHAKE_CLIENT_HANDSHAKE_SECRET_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*2
+// Each raw uint8_t[48] field occupies exactly 48 bytes, no extra size field
+#define SSL_HANDSHAKE_FIELD_STEP SSL_MAX_MD_SIZE
 
-// bssl::SSL_HANDSHAKE->server_handshake_secret_
-#define SSL_HANDSHAKE_SERVER_HANDSHAKE_SECRET_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*3
+#endif  // SSL_SESSION_ST_SSL_VERSION
 
-// bssl::SSL_HANDSHAKE->client_traffic_secret_0_
-#define SSL_HANDSHAKE_CLIENT_TRAFFIC_SECRET_0_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*4
+// ── Downstream offsets: identical formula for all versions ──────────────────
+// All fields are laid out consecutively starting from SSL_HANDSHAKE_SECRET_,
+// each spaced SSL_HANDSHAKE_FIELD_STEP bytes apart.
 
-// bssl::SSL_HANDSHAKE->server_traffic_secret_0_
-#define SSL_HANDSHAKE_SERVER_TRAFFIC_SECRET_0_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*5
-
-// bssl::SSL_HANDSHAKE->expected_client_finished_
-#define SSL_HANDSHAKE_EXPECTED_CLIENT_FINISHED_ SSL_HANDSHAKE_SECRET_+SSL_MAX_MD_SIZE*6
+#define SSL_HANDSHAKE_EARLY_TRAFFIC_SECRET_     (SSL_HANDSHAKE_SECRET_ + SSL_HANDSHAKE_FIELD_STEP * 1)
+#define SSL_HANDSHAKE_CLIENT_HANDSHAKE_SECRET_  (SSL_HANDSHAKE_SECRET_ + SSL_HANDSHAKE_FIELD_STEP * 2)
+#define SSL_HANDSHAKE_SERVER_HANDSHAKE_SECRET_  (SSL_HANDSHAKE_SECRET_ + SSL_HANDSHAKE_FIELD_STEP * 3)
+#define SSL_HANDSHAKE_CLIENT_TRAFFIC_SECRET_0_  (SSL_HANDSHAKE_SECRET_ + SSL_HANDSHAKE_FIELD_STEP * 4)
+#define SSL_HANDSHAKE_SERVER_TRAFFIC_SECRET_0_  (SSL_HANDSHAKE_SECRET_ + SSL_HANDSHAKE_FIELD_STEP * 5)
+#define SSL_HANDSHAKE_EXPECTED_CLIENT_FINISHED_ (SSL_HANDSHAKE_SECRET_ + SSL_HANDSHAKE_FIELD_STEP * 6)
 
 ///////////////////////////  END   ///////////////////////////

--- a/kern/boringssl_masterkey.h
+++ b/kern/boringssl_masterkey.h
@@ -204,6 +204,18 @@ int probe_ssl_master_key(struct pt_regs *ctx) {
     }
     s3_address = address;
 
+#ifdef BSSL__SSL3_STATE_VERSION
+    // Android 16: ssl_st.version was removed; the negotiated protocol version
+    // now lives in SSL3_STATE.version. Read it here — before the TLS 1.2/1.3
+    // branch decision — so that TLS 1.3 connections are correctly identified.
+    u64 *s3_version_ptr = (u64 *)(s3_address + BSSL__SSL3_STATE_VERSION);
+    ret = bpf_probe_read_user(&ssl_version, sizeof(ssl_version), (void *)s3_version_ptr);
+    if (ret == 0) {
+        mastersecret->version = ssl_version & 0xFFFF;
+        debug_bpf_printk("s3->version: %d\n", mastersecret->version);
+    }
+#endif
+
     struct ssl3_state_st ssl3_stat;
     ret = bpf_probe_read_user(&ssl3_stat, sizeof(ssl3_stat), (void *)address);
     if (ret) {

--- a/utils/README-zh_Hans.md
+++ b/utils/README-zh_Hans.md
@@ -1,0 +1,229 @@
+# utils — 结构体偏移地址生成脚本
+
+本目录包含用于生成 eBPF 兼容 C 头文件的工具集
+（`kern/boringssl_a_XX_kern.c`、`kern/boringssl_na_kern.c`、`kern/gnutls_*.c`、
+`kern/openssl_*.c` 等）。每个头文件定义了 TLS 关键字段在目标库内部结构体中的字节偏移地址常量（`#define`），eBPF 探针在运行时通过这些常量从进程内存中读取明文密钥。
+
+---
+
+## 目录结构
+
+```
+utils/
+├── boringssl-offset.c              # C++17 偏移探测工具（Android BoringSSL 专用）
+├── boringssl_android_offset.sh     # 驱动脚本：Android 13–16 BoringSSL
+├── boringssl_non_android_offset.sh # 驱动脚本：非 Android（上游）BoringSSL
+├── gnutls_offset.c / gnutls_offset.sh
+├── openssl_*_offset.c / openssl_offset_*.sh
+└── README-zh_Hans.md               # 本文件
+```
+
+---
+
+## 快速开始
+
+所有脚本**必须在项目根目录**（包含 `go.mod` 的目录）下执行：
+
+```bash
+# Android BoringSSL（android13 – android16）
+bash utils/boringssl_android_offset.sh
+
+# 非 Android（上游）BoringSSL
+bash utils/boringssl_non_android_offset.sh
+
+# GnuTLS
+bash utils/gnutls_offset.sh
+
+# OpenSSL（选择对应版本的脚本）
+bash utils/openssl_offset_3.5.sh
+```
+
+生成的文件写入 `kern/` 目录。若目标文件已存在，脚本会跳过该版本。删除文件可强制重新生成。
+
+> **平台要求**：脚本需要编译原生 C++ 代码，必须在 Linux / Android 构建主机上运行
+> （x86\_64 内核 ≥ 4.18，aarch64 ≥ 5.5），**不支持 macOS**。
+> 请通过 SSH 登录远程 Linux 服务器执行：
+> ```bash
+> ssh cfc4n@172.16.71.128
+> cd /home/cfc4n/project/ecapture
+> bash utils/boringssl_android_offset.sh
+> ```
+
+---
+
+## `boringssl_android_offset.sh` 工作原理
+
+### 流程概览
+
+```
+boringssl_android_offset.sh
+        │
+        ├─ git clone / checkout  android13-release … android16-release
+        │
+        ├─ 编译  boringssl-offset.c  （C++17，链接 boringssl 头文件）
+        │
+        ├─ 运行 ./offset  →  输出 #define 常量 + feature-flag 宏
+        │
+        └─ 包装输出  →  kern/boringssl_a_XX_kern.c
+```
+
+### 添加新 Android 版本
+
+在 `boringssl_android_offset.sh` 的 `sslVerMap` 中加一行：
+
+```bash
+sslVerMap["5"]="17"   # android17-release
+```
+
+重新运行脚本即可，大多数情况下无需其他改动——详见下方[设计思路](#boringssl-offsetc--偏移探测工具)。
+
+---
+
+## `boringssl-offset.c` — 偏移探测工具
+
+### 用途
+
+该工具**针对目标库自身的头文件编译**，因此 `offsetof(struct_name, field)` 返回的是该特定库版本与 CPU 架构下的精确字节偏移。
+
+输出示例：
+
+```c
+// ssl_st->session
+#define SSL_ST_SESSION 0x58
+
+// ssl_session_st->ssl_version
+#define SSL_SESSION_ST_SSL_VERSION 0x4
+```
+
+这些 `#define` 值原样写入生成的 kern 头文件，在 eBPF 编译阶段被 `kern/boringssl_masterkey.h` 使用。
+
+### 设计思路 — 基于 C++17 类型特征的自动版本探测
+
+旧版工具使用固定的字段列表，依赖 shell 脚本中的 `sed` 后处理来应对不同 Android 版本间被删除或重命名的字段。这种方式很脆弱：每当新 Android 版本改动了某个结构体，就需要在脚本里增加一条专用的 `sed` 规则。
+
+当前工具改用 **C++17 类型特征（`std::void_t` + SFINAE）** 在编译期探测字段是否可访问，再通过**偏模板特化（partial template specialisation）** 选择正确的输出路径：
+
+```
+                  字段是否存在？
+                  ┌─── 存在 ──→  输出 offsetof(T, field) 的值
+ 类型特征探测 ────┤
+                  └─── 不存在 ──→  输出替代宏 / 哨兵值
+```
+
+#### 关键设计原则
+
+1. **不使用 `if constexpr`**。在非模板函数中，`if constexpr` 的两个分支仍然都会被编译器进行语法检查，因此即使在未执行的分支中，`offsetof(T, 已删除字段)` 也会触发硬错误。
+
+2. **使用偏模板特化**。`emit_foo<T, true>::emit()` 的函数体中包含 `offsetof(T, field)` 这一**依赖表达式**（依赖于模板参数 `T`），编译器只有在该特化被实际实例化时才会检查它——即只有在选择 `Present=true` 分支时才会编译。
+
+3. **feature-flag 宏是探测的副产品**。当某个字段不存在时，工具会输出一个**替代宏**，该宏的存在本身就是一个版本特性标志，供下游消费者判断：
+
+   | 不存在的字段 | 输出的宏 | 消费方 |
+   |---|---|---|
+   | `ssl_st::version` | `SSL_SESSION_ST_SSL_VERSION` | `boringssl_const.h`、`boringssl_masterkey.h` |
+   | `ssl_session_st::secret_length` | `SSL_SESSION_ST_SECRET_LENGTH 0xFF`（哨兵） | `boringssl_masterkey.h` |
+   | `SSL3_STATE::version`（存在时） | `BSSL__SSL3_STATE_VERSION` | `boringssl_masterkey.h` |
+
+### 已跟踪的字段变化
+
+| Android 版本 | 变化 | 工具行为 |
+|---|---|---|
+| ≤ 15 | `ssl_st::version` 存在 | 输出 `SSL_ST_VERSION` |
+| 16+ | `ssl_st::version` **被删除** | 输出 `SSL_SESSION_ST_SSL_VERSION`（feature flag） |
+| ≤ 15 | `ssl_session_st::secret_length` 存在 | 输出 `SSL_SESSION_ST_SECRET_LENGTH <偏移值>` |
+| 16+ | `ssl_session_st::secret_length` **被删除** | 输出 `SSL_SESSION_ST_SECRET_LENGTH 0xFF`（哨兵） |
+| ≤ 15 | `SSL3_STATE::version` 不存在 | 不输出任何内容 |
+| 16+ | `SSL3_STATE::version` **新增** | 输出 `BSSL__SSL3_STATE_VERSION`（feature flag） |
+
+### 支持未来新版本 Android 的步骤
+
+若新版 Android 删除或改动了某个结构体字段：
+
+1. **在 `boringssl-offset.c` 中添加类型特征探测**：
+   ```cpp
+   template <typename T, typename = void>
+   struct foo_has_new_field : std::false_type {};
+   template <typename T>
+   struct foo_has_new_field<T, std::void_t<decltype(std::declval<T>().new_field)>>
+       : std::true_type {};
+   ```
+
+2. **添加一对 emitter**（主模板 + `<T,true>` 偏特化）：
+   ```cpp
+   template <typename T, bool Present>
+   struct emit_new_field {
+       static void emit() { /* 字段不存在：输出替代宏 */ }
+   };
+   template <typename T>
+   struct emit_new_field<T, true> {
+       static void emit() { format("foo", "new_field", offsetof(T, new_field)); }
+   };
+   ```
+
+3. **在 `main()` 中调用 emitter**：
+   ```cpp
+   emit_new_field<foo_t, foo_has_new_field<foo_t>::value>::emit();
+   ```
+
+4. **在 `boringssl_const.h` 或 `boringssl_masterkey.h` 中处理 feature flag**：
+   ```c
+   #ifdef NEW_FEATURE_FLAG
+   // 新版本特有逻辑
+   #endif
+   ```
+
+5. **在 `boringssl_android_offset.sh` 中注册新版本**：
+   ```bash
+   sslVerMap["5"]="17"   # android17-release
+   ```
+
+全程无需 `sed` 规则，工具本身不包含任何硬编码的版本号判断。
+
+---
+
+## `boringssl_const.h` 与 `boringssl_masterkey.h` — 自适应头文件
+
+这两个头文件已将**所有版本特定逻辑实现为纯 C 预处理器条件编译**，只要偏移工具输出了正确的 feature flag，就无需手动修改。
+
+### `boringssl_const.h` — TLS 1.3 密钥偏移地址
+
+通过 `#ifdef SSL_SESSION_ST_SSL_VERSION`（Android 16+ feature flag）在两套偏移计算公式间切换，用于 `SSL_HANDSHAKE` 结构体中 TLS 1.3 密钥字段：
+
+| | Android ≤ 15 | Android 16+ |
+|---|---|---|
+| 密钥存储类型 | `private uint8_t secret_[48]`（私有 raw 数组） | `public InplaceVector<uint8_t,48>`（公有） |
+| 字段步长 | 48 字节 | 49 字节（`SSL_HANDSHAKE_FIELD_STEP`） |
+| `SSL_HANDSHAKE_SECRET_` 基址 | `roundup(MAX_VERSION+2, 8) + 8` | `MAX_VERSION + 2` |
+| `SSL_HANDSHAKE_HASH_LEN_` | 独立的 `size_t hash_len_` 字段 | `secret.size_`，位于 `SECRET_ + 48` |
+
+6 个下游字段偏移（`EARLY_TRAFFIC_SECRET_` 等）统一用 `SECRET_ + FIELD_STEP * N` 一条公式计算，无重复代码。
+
+### `boringssl_masterkey.h` — TLS 版本探测
+
+使用两个 feature flag 确保在所有 Android 版本上正确工作：
+
+- `#ifndef SSL_SESSION_ST_SSL_VERSION` — Android ≤ 15：从 `ssl_st.version` 读取 TLS 版本。
+- `#ifdef BSSL__SSL3_STATE_VERSION` — Android 16+：在 TLS 1.2 / 1.3 分支判断**之前**，从 `SSL3_STATE.version`（偏移 `0xd0`）读取版本，确保 TLS 1.3 连接被正确识别、密钥被正确捕获。
+- `#ifdef SSL_SESSION_ST_SSL_VERSION` — 在 TLS 1.2 分支内部，从 `ssl_session_st.ssl_version` 补读版本，用于准确上报。
+
+#### Android 16 的背景
+
+Android 16 对 BoringSSL 做了较大重构，主要影响：
+
+| 变化 | 影响 |
+|---|---|
+| `ssl_st.version` 字段删除 | 无法直接从 SSL 对象读取协议版本 |
+| `ssl_session_st.secret_length` 字段删除 | master secret 长度需用最大值（48）替代 |
+| `ssl_session_st.secret` 类型从 `uint8_t[]` 改为 `InplaceVector<uint8_t,48>` | 偏移值不变（`storage_` 在首位），但 TLS 1.3 所有握手密钥字段同样改为 InplaceVector |
+| `SSL_HANDSHAKE` TLS 1.3 密钥从 `private uint8_t[]` 改为 `public InplaceVector` | 字段步长从 48 变为 49，整体基址前移 8 字节 |
+| `SSL3_STATE.version` 新增 | 替代被删除的 `ssl_st.version`，用于读取协议版本 |
+
+---
+
+## 注意事项
+
+- **网络访问**：启动时会尝试 `git fetch --tags`；若网络不可用，脚本会使用本地已缓存的分支继续执行。
+- **CPU 架构**：偏移地址与 CPU 架构强相关。工具必须在**与目标设备相同的 CPU 架构**上编译并运行（例如，为 Android ARM64 设备生成偏移时须在 aarch64 主机上运行），跨架构生成会得到错误的偏移值。
+- **不要手动编辑生成文件**：脚本不再在工具输出之后追加任何硬编码的 `#define`，所有常量均由工具统一输出。手动修改生成文件会导致与源码漂移，应重新运行脚本生成。
+- **`boringssl-offset.c` 需要 C++17**：`std::void_t` 依赖 C++17 标准，编译时必须传入 `-std=c++17`，脚本已自动添加该参数。
+

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,249 @@
+# utils — Struct Offset Generation Scripts
+
+This directory contains tooling to generate eBPF-compatible C header files
+(`kern/boringssl_a_XX_kern.c`, `kern/boringssl_na_kern.c`, `kern/gnutls_*.c`,
+`kern/openssl_*.c`, …).  Each header defines `#define` constants for the byte
+offsets of TLS-critical fields within the target library's internal structs,
+which the eBPF probes in `kern/` use to read plaintext keys from process memory.
+
+---
+
+## Directory layout
+
+```
+utils/
+├── boringssl-offset.c            # C++17 offset-probe tool (Android BoringSSL)
+├── boringssl_android_offset.sh   # Driver: Android 13-16 BoringSSL
+├── boringssl_non_android_offset.sh # Driver: non-Android (upstream) BoringSSL
+├── gnutls_offset.c / gnutls_offset.sh
+├── openssl_*_offset.c / openssl_offset_*.sh
+└── README.md                     # this file
+```
+
+---
+
+## Quick start
+
+All scripts **must be run from the project root directory** (the one that
+contains `go.mod`):
+
+```bash
+# Android BoringSSL (android13 – android16)
+bash utils/boringssl_android_offset.sh
+
+# Non-Android (upstream) BoringSSL
+bash utils/boringssl_non_android_offset.sh
+
+# GnuTLS
+bash utils/gnutls_offset.sh
+
+# OpenSSL (pick the right version script)
+bash utils/openssl_offset_3.5.sh
+```
+
+Generated files are written to `kern/`.  If a target file already exists the
+script skips that version.  Delete the file to force regeneration.
+
+> **Platform requirement**: scripts compile native C++ and must run on a
+> Linux / Android build host (x86\_64 kernel ≥ 4.18, aarch64 ≥ 5.5).
+> They will not work on macOS.  Use the remote Linux server via SSH:
+> ```bash
+> ssh cfc4n@172.16.71.128
+> cd /home/cfc4n/project/ecapture
+> bash utils/boringssl_android_offset.sh
+> ```
+
+---
+
+## How `boringssl_android_offset.sh` works
+
+### Overview
+
+```
+boringssl_android_offset.sh
+        │
+        ├─ git clone / checkout  android13-release … android16-release
+        │
+        ├─ compile  boringssl-offset.c  (C++17, against boringssl headers)
+        │
+        ├─ run ./offset  →  emits #define constants + feature-flag macros
+        │
+        └─ wrap output  →  kern/boringssl_a_XX_kern.c
+```
+
+### Adding a new Android version
+
+Edit the `sslVerMap` in `boringssl_android_offset.sh` and add one line:
+
+```bash
+sslVerMap["5"]="17"   # android17-release
+```
+
+Then re-run the script.  No other changes are needed in most cases—see the
+[Design philosophy](#design-philosophy) section below.
+
+---
+
+## `boringssl-offset.c` — the offset-probe tool
+
+### Purpose
+
+The tool is compiled **against the target library's own headers**, so
+`offsetof(struct_name, field)` returns the exact byte offset for that
+specific library version and architecture.
+
+It produces output like:
+
+```c
+// ssl_st->session
+#define SSL_ST_SESSION 0x58
+
+// ssl_session_st->ssl_version
+#define SSL_SESSION_ST_SSL_VERSION 0x4
+```
+
+These `#define` values are pasted verbatim into the generated kern header and
+consumed by `kern/boringssl_masterkey.h` at eBPF compile time.
+
+### Design philosophy — automatic version detection via C++17 type traits
+
+Older versions of the tool used a fixed field list and relied on `sed`
+post-processing in the shell script to cope with fields that were removed or
+renamed between Android releases.  This approach was fragile: every new
+Android version that changed a struct required a new version-specific `sed`
+rule.
+
+The current tool uses **C++17 type traits (`std::void_t` + SFINAE)** to probe
+whether a field is publicly accessible at compile time, then selects the
+correct output via **partial template specialisation**:
+
+```
+                  field present?
+                  ┌─── yes ──→  emit offsetof(T, field)
+ type-trait probe ┤
+                  └─── no  ──→  emit alternative macro / sentinel
+```
+
+Key design rules:
+
+1. **`if constexpr` is NOT used** for this purpose.  In a non-template
+   function, both branches of `if constexpr` are still parsed and checked by
+   the compiler, so `offsetof(T, removed_field)` would be a hard error even
+   in the untaken branch.
+
+2. **Partial specialisation IS used**.  The body of
+   `emit_foo<T, true>::emit()` contains `offsetof(T, field)` as a
+   *dependent expression* (it depends on `T`).  The compiler only instantiates
+   and checks it when `T` is actually substituted—i.e. only when the
+   `Present=true` branch is selected.
+
+3. **Feature-flag macros are a by-product of detection**.  When a field is
+   absent, the tool emits an *alternative* macro whose presence in the
+   generated header signals downstream consumers:
+
+   | Absent field | Emitted macro | Consumed by |
+   |---|---|---|
+   | `ssl_st::version` | `SSL_SESSION_ST_SSL_VERSION` | `boringssl_const.h`, `boringssl_masterkey.h` |
+   | `ssl_session_st::secret_length` | `SSL_SESSION_ST_SECRET_LENGTH 0xFF` (sentinel) | `boringssl_masterkey.h` |
+   | *(none)* | `BSSL__SSL3_STATE_VERSION` (when present) | `boringssl_masterkey.h` |
+
+### Currently tracked field changes
+
+| Android version | Change | Tool behaviour |
+|---|---|---|
+| ≤ 15 | `ssl_st::version` present | emits `SSL_ST_VERSION` |
+| 16+ | `ssl_st::version` **removed** | emits `SSL_SESSION_ST_SSL_VERSION` (feature flag) |
+| ≤ 15 | `ssl_session_st::secret_length` present | emits `SSL_SESSION_ST_SECRET_LENGTH <offset>` |
+| 16+ | `ssl_session_st::secret_length` **removed** | emits `SSL_SESSION_ST_SECRET_LENGTH 0xFF` (sentinel) |
+| ≤ 15 | `SSL3_STATE::version` absent | nothing emitted |
+| 16+ | `SSL3_STATE::version` **added** | emits `BSSL__SSL3_STATE_VERSION` (feature flag) |
+
+### Supporting future Android versions
+
+If a new Android release changes or removes a struct field:
+
+1. **Add a new type-trait probe** in `boringssl-offset.c`:
+   ```cpp
+   template <typename T, typename = void>
+   struct foo_has_new_field : std::false_type {};
+   template <typename T>
+   struct foo_has_new_field<T, std::void_t<decltype(std::declval<T>().new_field)>>
+       : std::true_type {};
+   ```
+
+2. **Add a new emitter pair** (primary template + `<T,true>` partial spec):
+   ```cpp
+   template <typename T, bool Present>
+   struct emit_new_field { static void emit() { /* absent: emit alternative */ } };
+   template <typename T>
+   struct emit_new_field<T, true> { static void emit() { format("foo", "new_field", offsetof(T, new_field)); } };
+   ```
+
+3. **Call the emitter** from `main()`:
+   ```cpp
+   emit_new_field<foo_t, foo_has_new_field<foo_t>::value>::emit();
+   ```
+
+4. **Handle the feature flag** in `boringssl_const.h` or
+   `boringssl_masterkey.h` using `#ifdef NEW_FEATURE_FLAG`.
+
+5. **Register the new Android version** in `boringssl_android_offset.sh`:
+   ```bash
+   sslVerMap["5"]="17"   # android17-release
+   ```
+
+No `sed` rules, no hardcoded version numbers in the tool itself.
+
+---
+
+## `boringssl_const.h` and `boringssl_masterkey.h` — the adaptive headers
+
+These two headers already contain **all version-specific logic as pure C
+preprocessor conditionals**.  They require no manual edits when a new Android
+version is supported, provided the offset tool emits the correct feature flags.
+
+### `boringssl_const.h` — TLS 1.3 secret offsets
+
+Uses `#ifdef SSL_SESSION_ST_SSL_VERSION` (the Android 16+ feature flag) to
+select between two offset formulas for the `SSL_HANDSHAKE` TLS 1.3 secret
+fields:
+
+| | Android ≤ 15 | Android 16+ |
+|---|---|---|
+| Secret storage type | `private uint8_t secret_[48]` | `public InplaceVector<uint8_t,48>` |
+| Field step size | 48 bytes | 49 bytes (`SSL_HANDSHAKE_FIELD_STEP`) |
+| `SSL_HANDSHAKE_SECRET_` base | `roundup(MAX_VERSION+2, 8) + 8` | `MAX_VERSION + 2` |
+| `SSL_HANDSHAKE_HASH_LEN_` | separate `size_t hash_len_` field | `secret.size_` at `SECRET_ + 48` |
+
+All 6 downstream field offsets (`EARLY_TRAFFIC_SECRET_`, etc.) are computed
+with a single shared formula `SECRET_ + FIELD_STEP * N`, requiring no
+duplication.
+
+### `boringssl_masterkey.h` — TLS version detection
+
+Uses two feature flags to work correctly on all Android versions:
+
+- `#ifndef SSL_SESSION_ST_SSL_VERSION` — Android ≤ 15: reads TLS version from
+  `ssl_st.version`.
+- `#ifdef BSSL__SSL3_STATE_VERSION` — Android 16+: reads TLS version from
+  `SSL3_STATE.version` (offset `0xd0`), **before** the TLS 1.2 / 1.3 branch
+  decision, so TLS 1.3 connections are correctly identified.
+- `#ifdef SSL_SESSION_ST_SSL_VERSION` — inside the TLS 1.2 block, re-reads
+  version from `ssl_session_st.ssl_version` for accurate reporting.
+
+---
+
+## Notes and caveats
+
+- **Network access**: `git fetch --tags` is attempted at startup; if the
+  network is unavailable the script continues with locally cached branches.
+- **Architecture**: offsets are architecture-specific.  The tool must be
+  compiled and run on the **same CPU architecture** as the target device
+  (e.g. aarch64 for Android ARM64 devices).  Cross-architecture offset
+  generation will produce wrong values.
+- **Duplicate definitions**: the shell script no longer appends any hardcoded
+  `#define` after the tool output.  All defines come exclusively from the
+  tool.  Editing the tool output by hand will cause drift; regenerate instead.
+- **`boringssl-offset.c` requires C++17**: the `-std=c++17` flag is mandatory
+  for `std::void_t`.  The script passes it automatically.
+

--- a/utils/boringssl-offset.c
+++ b/utils/boringssl-offset.c
@@ -12,67 +12,182 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//  g++ -I include/ -I src/ ./src/offset.c -o off
+// Compile: g++ -std=c++17 -Wno-invalid-offsetof -I include/ -I . -I ./src/ offset.c -o offset
+//
+// This tool auto-detects BoringSSL struct layout changes across Android
+// versions using C++ type traits + explicit template specialisation, so no
+// external sed post-processing is needed when a new Android release removes or
+// renames a field.
+//
+// Why template specialisation (not if constexpr)?
+//   if constexpr in a non-template function still compiles *both* branches
+//   syntactically, so offsetof on a removed field would be a hard error even
+//   in the untaken branch.  Explicit template specialisation guarantees that
+//   only the selected specialisation is instantiated and compiled.
+//
+// How the feature flags work:
+//   The "false" specialisation (field absent) emits an *alternative* macro
+//   (e.g. SSL_SESSION_ST_SSL_VERSION, BSSL__SSL3_STATE_VERSION, or the 0xFF
+//   sentinel) that also doubles as a feature flag read by boringssl_const.h
+//   and boringssl_masterkey.h to switch to the correct code path.
+
 #include <ctype.h>
 #include <openssl/base.h>
 #include <openssl/crypto.h>
 #include <ssl/internal.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <type_traits>
 
-#define SSL_STRUCT_OFFSETS                   \
-    X(ssl_st, version)                       \
-    X(ssl_st, session)                       \
-    X(ssl_st, rbio)                          \
-    X(ssl_st, wbio)                          \
-    X(ssl_st, s3)                            \
-    X(ssl_session_st, secret_length)         \
-    X(ssl_session_st, secret)                \
-    X(ssl_session_st, cipher)                \
-    X(bio_st, num)                           \
-    X(bio_st, method)                        \
-    X(bio_method_st, type)                   \
-    X(ssl_cipher_st, id)                     \
-    X(bssl::SSL3_STATE, hs)                  \
-    X(bssl::SSL3_STATE, client_random)       \
-    X(bssl::SSL3_STATE, exporter_secret)     \
-    X(bssl::SSL3_STATE, established_session) \
-    X(bssl::SSL_HANDSHAKE, new_session)      \
-    X(bssl::SSL_HANDSHAKE, early_session)    \
-    X(bssl::SSL_HANDSHAKE, hints)            \
-    X(bssl::SSL_HANDSHAKE, client_version)   \
-    X(bssl::SSL_HANDSHAKE, state)            \
-    X(bssl::SSL_HANDSHAKE, tls13_state)      \
-    X(bssl::SSL_HANDSHAKE, max_version)
+// ─── Type-trait probes ───────────────────────────────────────────────────────
+// Each probe checks whether a named public field exists on type T.
+// A removed or private field causes substitution failure → false_type.
 
-void toUpper(char *s) {
-    int i = 0;
-    while (s[i] != '\0') {
-        if (s[i] == '.' || s[i] == ':') {
-            putchar('_');
-        } else {
-            putchar(toupper(s[i]));
-        }
-        i++;
+// ssl_st::version  (present in Android ≤ 15, removed in Android 16)
+template <typename T, typename = void>
+struct ssl_st_has_version : std::false_type {};
+template <typename T>
+struct ssl_st_has_version<T, std::void_t<decltype(std::declval<T>().version)>> : std::true_type {};
+
+// ssl_session_st::secret_length  (present in Android ≤ 15, removed in Android 16)
+template <typename T, typename = void>
+struct ssl_session_has_secret_length : std::false_type {};
+template <typename T>
+struct ssl_session_has_secret_length<T, std::void_t<decltype(std::declval<T>().secret_length)>>
+    : std::true_type {};
+
+// bssl::SSL3_STATE::version  (absent in Android ≤ 15, added in Android 16)
+template <typename T, typename = void>
+struct ssl3_state_has_version : std::false_type {};
+template <typename T>
+struct ssl3_state_has_version<T, std::void_t<decltype(std::declval<T>().version)>>
+    : std::true_type {};
+
+// ─── Output helpers ──────────────────────────────────────────────────────────
+
+void toUpper(const char *s) {
+    for (int i = 0; s[i] != '\0'; i++) {
+        if (s[i] == '.' || s[i] == ':') putchar('_');
+        else putchar(toupper((unsigned char)s[i]));
     }
 }
 
-void format(char *struct_name, char *field_name, size_t offset) {
-    printf("// %s->%s\n", struct_name, field_name);
-    printf("#define ");
+void format(const char *struct_name, const char *field_name, size_t offset) {
+    printf("// %s->%s\n#define ", struct_name, field_name);
     toUpper(struct_name);
-    printf("_");
+    putchar('_');
     toUpper(field_name);
     printf(" 0x%lx\n\n", offset);
 }
+
+// ─── Per-field emitters (partial template specialisation) ────────────────────
+// Pattern: emit_xxx<T, Present>
+//   Primary template (Present=false): field absent → emit alternative/sentinel.
+//   Partial specialisation <T, true>:  field present → emit real offsetof(T,…).
+//
+// Why partial specialisation, not full specialisation?
+//   Full specialisation bodies are compiled immediately.  Partial specialisation
+//   bodies contain a *dependent* expression (offsetof(T, field)) that is only
+//   checked when the specialisation is instantiated with a concrete T.
+//   This ensures offsetof is never evaluated for a field that doesn't exist.
+
+// --- ssl_st::version ---------------------------------------------------------
+// Absent  → emit SSL_SESSION_ST_SSL_VERSION (Android 16+ feature flag).
+// Present → emit SSL_ST_VERSION.
+template <typename T, bool Present>
+struct emit_ssl_st_version {
+    static void emit() {
+        printf("// ssl_st->version removed in this BoringSSL version.\n");
+        printf("// SSL_SESSION_ST_SSL_VERSION also acts as the Android 16+ feature flag\n");
+        printf("// for boringssl_const.h (InplaceVector offsets) and boringssl_masterkey.h.\n");
+        format("ssl_session_st", "ssl_version", offsetof(ssl_session_st, ssl_version));
+    }
+};
+template <typename T>
+struct emit_ssl_st_version<T, true> {
+    // offsetof(T, version) is a dependent expression: only compiled when T is known.
+    static void emit() { format("ssl_st", "version", offsetof(T, version)); }
+};
+
+// --- ssl_session_st::secret_length -------------------------------------------
+// Absent  → emit sentinel 0xFF (signals boringssl_masterkey.h to use the max).
+// Present → emit the real offset.
+template <typename T, bool Present>
+struct emit_secret_length {
+    static void emit() {
+        printf("// ssl_session_st->secret_length removed in this BoringSSL version.\n");
+        printf("// Sentinel 0xFF: boringssl_masterkey.h uses BORINGSSL_SSL_MAX_MASTER_KEY_LENGTH.\n");
+        printf("#define SSL_SESSION_ST_SECRET_LENGTH 0xFF\n\n");
+    }
+};
+template <typename T>
+struct emit_secret_length<T, true> {
+    static void emit() {
+        format("ssl_session_st", "secret_length", offsetof(T, secret_length));
+    }
+};
+
+// --- bssl::SSL3_STATE::version -----------------------------------------------
+// Absent  → nothing to emit (field didn't exist before Android 16).
+// Present → emit BSSL__SSL3_STATE_VERSION (Android 16+ feature flag).
+//           boringssl_masterkey.h reads it before the TLS 1.2/1.3 branch so
+//           that TLS 1.3 connections are correctly identified.
+template <typename T, bool Present>
+struct emit_ssl3_state_version {
+    static void emit() { /* field not present in this version, nothing to emit */ }
+};
+template <typename T>
+struct emit_ssl3_state_version<T, true> {
+    static void emit() {
+        printf("// SSL3_STATE->version added in Android 16 (replaces ssl_st->version).\n");
+        printf("// BSSL__SSL3_STATE_VERSION is the Android 16+ feature flag used by\n");
+        printf("// boringssl_masterkey.h to read the TLS version before the 1.2/1.3 branch.\n");
+        format("bssl::SSL3_STATE", "version", offsetof(T, version));
+    }
+};
+
+// ─── Main ────────────────────────────────────────────────────────────────────
 
 int main() {
     printf("/* OPENSSL_VERSION_TEXT: %s */\n", OPENSSL_VERSION_TEXT);
     printf("/* OPENSSL_VERSION_NUMBER: %d */\n\n", OPENSSL_VERSION_NUMBER);
 
-#define X(struct_name, field_name) format(#struct_name, #field_name, offsetof(struct struct_name, field_name));
-    SSL_STRUCT_OFFSETS
-#undef X
+    // ── ssl_st ────────────────────────────────────────────────────────────────
+    emit_ssl_st_version<ssl_st, ssl_st_has_version<ssl_st>::value>::emit();
+    format("ssl_st", "session", offsetof(ssl_st, session));
+    format("ssl_st", "rbio",    offsetof(ssl_st, rbio));
+    format("ssl_st", "wbio",    offsetof(ssl_st, wbio));
+    format("ssl_st", "s3",      offsetof(ssl_st, s3));
+
+    // ── ssl_session_st ────────────────────────────────────────────────────────
+    emit_secret_length<ssl_session_st, ssl_session_has_secret_length<ssl_session_st>::value>::emit();
+    format("ssl_session_st", "secret", offsetof(ssl_session_st, secret));
+    format("ssl_session_st", "cipher", offsetof(ssl_session_st, cipher));
+
+    // ── bio / cipher ──────────────────────────────────────────────────────────
+    format("bio_st",        "num",    offsetof(bio_st, num));
+    format("bio_st",        "method", offsetof(bio_st, method));
+    format("bio_method_st", "type",   offsetof(bio_method_st, type));
+    format("ssl_cipher_st", "id",     offsetof(ssl_cipher_st, id));
+
+    // ── bssl::SSL3_STATE ──────────────────────────────────────────────────────
+    format("bssl::SSL3_STATE", "hs",                  offsetof(bssl::SSL3_STATE, hs));
+    format("bssl::SSL3_STATE", "client_random",       offsetof(bssl::SSL3_STATE, client_random));
+    format("bssl::SSL3_STATE", "exporter_secret",     offsetof(bssl::SSL3_STATE, exporter_secret));
+    format("bssl::SSL3_STATE", "established_session", offsetof(bssl::SSL3_STATE, established_session));
+    emit_ssl3_state_version<bssl::SSL3_STATE, ssl3_state_has_version<bssl::SSL3_STATE>::value>::emit();
+
+    // ── bssl::SSL_HANDSHAKE ───────────────────────────────────────────────────
+    // TLS 1.3 secret offsets (secret_, early_traffic_secret_, …) are NOT emitted
+    // here; boringssl_const.h computes them from BSSL__SSL_HANDSHAKE_MAX_VERSION
+    // with the correct per-version step (48 for raw arrays, 49 for InplaceVectors).
+    format("bssl::SSL_HANDSHAKE", "new_session",    offsetof(bssl::SSL_HANDSHAKE, new_session));
+    format("bssl::SSL_HANDSHAKE", "early_session",  offsetof(bssl::SSL_HANDSHAKE, early_session));
+    format("bssl::SSL_HANDSHAKE", "hints",          offsetof(bssl::SSL_HANDSHAKE, hints));
+    format("bssl::SSL_HANDSHAKE", "client_version", offsetof(bssl::SSL_HANDSHAKE, client_version));
+    format("bssl::SSL_HANDSHAKE", "state",          offsetof(bssl::SSL_HANDSHAKE, state));
+    format("bssl::SSL_HANDSHAKE", "tls13_state",    offsetof(bssl::SSL_HANDSHAKE, tls13_state));
+    format("bssl::SSL_HANDSHAKE", "max_version",    offsetof(bssl::SSL_HANDSHAKE, max_version));
 
     return 0;
 }

--- a/utils/boringssl_android_offset.sh
+++ b/utils/boringssl_android_offset.sh
@@ -20,7 +20,7 @@ if [[ ! -d "${BORINGSSL_DIR}/.git" ]]; then
 fi
 
 function run() {
-  git fetch --tags
+  git fetch --tags || echo "Warning: git fetch --tags failed (network issue?), continuing with existing tags"
   cp -f ${PROJECT_ROOT_DIR}/utils/boringssl-offset.c ${BORINGSSL_DIR}/offset.c
   declare -A sslVerMap=()
   # get all commit about ssl/internel.h  who commit date > Apr 25 23:00:0 2021  (android 12 release)
@@ -49,7 +49,7 @@ function run() {
     echo "Android Version: ${val}, Generating ${header_file}"
 
     # Check if the $val variable is greater than 15
-    if ( val > 15 ); then
+    if (( ${val} > 15 )); then
         echo "Android version val greater than 15, remove some offsets"
         sed -i '/X(ssl_st, version)/d' offset.c
         sed -i 's/X(ssl_session_st, secret_length)/X(ssl_session_st, ssl_version)/g' offset.c

--- a/utils/boringssl_android_offset.sh
+++ b/utils/boringssl_android_offset.sh
@@ -23,10 +23,6 @@ function run() {
   git fetch --tags || echo "Warning: git fetch --tags failed (network issue?), continuing with existing tags"
   cp -f ${PROJECT_ROOT_DIR}/utils/boringssl-offset.c ${BORINGSSL_DIR}/offset.c
   declare -A sslVerMap=()
-  # get all commit about ssl/internel.h  who commit date > Apr 25 23:00:0 2021  (android 12 release)
-  # see https://android.googlesource.com/platform/external/boringssl/+/refs/heads/android12-release .
-  # range commit id from 160e1757ccacbde7488b145070eca94f2c370de2
-  # this repo is different from https://boringssl.googlesource.com/boringssl
   sslVerMap["1"]="13" # android13-release
   sslVerMap["2"]="14" # android14-release
   sslVerMap["3"]="15" # android15-release
@@ -48,22 +44,24 @@ function run() {
     git checkout ${tag}
     echo "Android Version: ${val}, Generating ${header_file}"
 
-    # Check if the $val variable is greater than 15
-    if (( ${val} > 15 )); then
-        echo "Android version val greater than 15, remove some offsets"
-        sed -i '/X(ssl_st, version)/d' offset.c
-        sed -i 's/X(ssl_session_st, secret_length)/X(ssl_session_st, ssl_version)/g' offset.c
-    fi
-    g++ -Wno-write-strings -Wno-invalid-offsetof -I include/ -I . -I ./src/ offset.c -o offset
+    # The offset tool (boringssl-offset.c) uses C++17 type traits to auto-detect
+    # which fields exist in this BoringSSL version and emits the appropriate
+    # macros and feature flags directly.  No version-specific sed post-processing
+    # is required here.
+    g++ -std=c++17 -Wno-write-strings -Wno-invalid-offsetof \
+        -I include/ -I . -I ./src/ offset.c -o offset
 
-    echo -e "#ifndef ECAPTURE_${header_define}" >${header_file}
-    echo -e "#define ECAPTURE_${header_define}\n" >>${header_file}
-    ./offset >>${header_file}
-    echo -e "#define SSL_SESSION_ST_SECRET_LENGTH 0xFF\n" >>${header_file}
-    echo -e "#include \"boringssl_const.h\"" >>${header_file}
-    echo -e "#include \"boringssl_masterkey.h\"" >>${header_file}
-    echo -e "#include \"openssl.h\"" >>${header_file}
-    echo -e "\n#endif" >>${header_file}
+    {
+      echo "#ifndef ECAPTURE_${header_define}"
+      echo "#define ECAPTURE_${header_define}"
+      echo ""
+      ./offset
+      echo "#include \"boringssl_const.h\""
+      echo "#include \"boringssl_masterkey.h\""
+      echo "#include \"openssl.h\""
+      echo ""
+      echo "#endif"
+    } > "${header_file}"
 
   done
 


### PR DESCRIPTION
- Fix bash numeric comparison bug in boringssl_android_offset.sh
- Add boringssl_a_16_kern.c with Android 16 struct offsets
- Refactor boringssl_const.h: use SSL_HANDSHAKE_FIELD_STEP to unify TLS 1.3 secret offsets for both InplaceVector (a16) and raw array (≤a15)
- Fix TLS 1.3 capture: read version from SSL3_STATE.version (0xd0) since ssl_st.version was removed in Android 16
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gojue/ecapture/pull/998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->