### PR TITLE
fix: add default value to MasterHookFuncs as v1

### DIFF
--- a/internal/probe/openssl/config.go
+++ b/internal/probe/openssl/config.go
@@ -271,7 +271,7 @@ func (c *Config) getSslBpfFile(soPath, sslVersion string) error {
 		}
 
 		if len(c.MasterHookFuncs) == 0 {
-			c.MasterHookFuncs = []string{MasterKeyHookFuncOpenSSL}
+			c.MasterHookFuncs = masterKeyHookFuncs
 		}
 		// TODO detect sslVersion less then 1.1.0 ,  ref # https://github.com/gojue/ecapture/issues/518
 		tmpSslVer := c.SslVersion

--- a/internal/probe/openssl/libs.go
+++ b/internal/probe/openssl/libs.go
@@ -39,6 +39,7 @@ var (
 	masterKeyHookFuncs = []string{
 		"SSL_get_wbio", // openssl
 		//"SSL_is_init",  // boringssl
+		MasterKeyHookFuncOpenSSL,
 		// 备用HOOK 函数
 		//"SSL_is_init_finished",
 		MasterKeyHookFuncSSLBefore,


### PR DESCRIPTION
https://github.com/gojue/ecapture/blob/e5fd33a6b9b72adf3c4b023f74a9c9c0f550e880/user/module/probe_openssl.go#L124

fix #984 
