### PR TITLE
feat: implement probabilistic upgrade check and fix release URL

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -320,6 +320,10 @@ func runProbe(probeType factory.ProbeType, probeConfig domain.Configuration) err
 
 	// upgrade check
 	go func() {
+		// 1/10 概率触发
+		if time.Now().UnixNano()%10 != 0 {
+			return
+		}
 		tags, upgradeUrl, e := upgradeCheck(ctx)
 		if e != nil {
 			logger.Debug().Msgf("upgrade check failed: %s", e.Error())

--- a/cli/cmd/upgrade.go
+++ b/cli/cmd/upgrade.go
@@ -12,9 +12,9 @@ import (
 	"github.com/gojue/ecapture/pkg/upgrade"
 )
 
-const urlReleases = "https://api.github.com/repos/gojue"
+const urlReleases = "https://api.github.com"
 const urlReleasesCN = "https://image.cnxct.com"
-const apiReleases string = "/ecapture/releases/latest"
+const apiReleases string = "/repos/gojue/ecapture/releases/latest"
 
 var (
 	ErrOsArchNotFound       = errors.New("new tag found, but no os/arch match")


### PR DESCRIPTION
This pull request introduces a probabilistic trigger for the upgrade check and corrects the GitHub API endpoint used for release checks. The main focus is on reducing unnecessary upgrade check executions and ensuring the correct API path is used.

Upgrade check improvements:

* The upgrade check in `root.go` now only runs approximately 10% of the time, reducing the frequency of upgrade requests by adding a probabilistic trigger.

API endpoint correction:

* The `urlReleases` and `apiReleases` constants in `upgrade.go` have been updated to use the correct GitHub API base and path for fetching the latest release information.