### PR TITLE
fix: OpenSSL version-to-bytecode mapping bugs + Docker build reproducibility

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -2,12 +2,22 @@ FROM ubuntu:22.04 as ecapture_builder
 
 # Install Compilers
 RUN apt-get update &&\
-  apt-get install --yes git build-essential pkgconf libelf-dev llvm-14 clang-14 linux-tools-common linux-headers-$(uname -r) make gcc flex bison file wget linux-source &&\
-  # the for-shell built-in instruction does not count as a command 
+  apt-get install --yes git build-essential pkgconf libelf-dev llvm-14 clang-14 linux-tools-common make gcc flex bison file wget linux-source &&\
+  # the for-shell built-in instruction does not count as a command
   # and the shell used to execute the script is sh by default and not bash.
   rm -f /usr/bin/clang && ln -s /usr/bin/clang-14 /usr/bin/clang &&\
   rm -f /usr/bin/llc && ln -s /usr/bin/llc-14 /usr/bin/llc &&\
-  rm -f /usr/bin/llvm-strip && ln -s /usr/bin/llvm-strip-14 /usr/bin/llvm-strip
+  rm -f /usr/bin/llvm-strip && ln -s /usr/bin/llvm-strip-14 /usr/bin/llvm-strip &&\
+  # Prepare stable kernel headers from linux-source for reproducible noncore eBPF bytecode.
+  # Avoids depending on linux-headers-$(uname -r) which varies with the CI runner's kernel.
+  cd /usr/src &&\
+  source_file=$$(find . -maxdepth 1 -name "*linux-source*.tar.bz2") &&\
+  source_dir=$$(echo "$$source_file" | sed 's/\.tar\.bz2//g') &&\
+  tar -xf "$$source_file" &&\
+  cd "$$source_dir" &&\
+  test -f .config || make oldconfig &&\
+  make prepare V=0 &&\
+  ln -sf "$$source_dir" /usr/src/linux-headers-ecapture
 
 # Install golang
 ARG TARGETARCH
@@ -29,7 +39,7 @@ ARG VERSION
 
 RUN cd /build/ecapture &&\
   make clean &&\
-  make all SNAPSHOT_VERSION=${VERSION}_docker
+  KERN_HEADERS=/usr/src/linux-headers-ecapture make all SNAPSHOT_VERSION=${VERSION}_docker
 
 # ecapture release image
 FROM alpine:latest as ecapture

--- a/internal/probe/openssl/libs.go
+++ b/internal/probe/openssl/libs.go
@@ -78,7 +78,7 @@ const (
 	SupportedOpenSSL33Version1    = 1 // openssl 3.3.0 ~ 3.3.1
 	SupportedOpenSSL33Version2    = 2 // openssl 3.3.2
 	SupportedOpenSSL33Version3    = 3 // openssl 3.3.3
-	MaxSupportedOpenSSL33Version  = 4 // openssl 3.3.4
+	MaxSupportedOpenSSL33Version  = 7 // openssl 3.3.7
 	SupportedOpenSSL34Version0    = 0 // openssl 3.4.0
 	MaxSupportedOpenSSL34Version  = 6 // openssl 3.4.1 ~ 3.4.6
 	SupportedOpenSSL35Version0    = 7 // openssl 3.5.0 ~ 3.5.7
@@ -256,7 +256,7 @@ func init() {
 
 	// openssl 3.2.4 ~ 3.2.6
 	for ch := 4; ch <= SupportedOpenSSL32Version4; ch++ {
-		sslVersionBpfMap[fmt.Sprintf("openssl 3.2.%d", SupportedOpenSSL32Version4)] = "openssl_3_2_4_kern.o"
+		sslVersionBpfMap[fmt.Sprintf("openssl 3.2.%d", ch)] = "openssl_3_2_4_kern.o"
 	}
 
 	// openssl 3.3.0 - 3.3.1
@@ -268,7 +268,7 @@ func init() {
 	sslVersionBpfMap[fmt.Sprintf("openssl 3.3.%d", 2)] = "openssl_3_3_2_kern.o"
 
 	// openssl 3.3.3 ~ 3.3.7
-	for ch := 2; ch <= SupportedOpenSSL33Version3; ch++ {
+	for ch := SupportedOpenSSL33Version3; ch <= MaxSupportedOpenSSL33Version; ch++ {
 		sslVersionBpfMap[fmt.Sprintf("openssl 3.3.%d", ch)] = "openssl_3_3_3_kern.o"
 	}
 


### PR DESCRIPTION
## Summary

Fixes two issues discovered during v2.5.0 release analysis.

### 1. OpenSSL version-to-bytecode mapping bugs (`libs.go`)

**Bug A — OpenSSL 3.2.4/3.2.5 missing from map**: The loop `Sprintf` used the constant `SupportedOpenSSL32Version4` (=6) instead of the loop variable `ch`, causing only `openssl 3.2.6` to be mapped (written 3 times). Versions 3.2.4 and 3.2.5 had no mapping.

**Bug B — OpenSSL 3.3.2 overwritten + 3.3.4~3.3.7 missing**: 
- The 3.3.3~3.3.7 loop started at `ch=2`, overwriting the 3.3.2 mapping (`openssl_3_3_2_kern.o` → `openssl_3_3_3_kern.o`)
- `MaxSupportedOpenSSL33Version` was not updated from 4 to 7, losing mappings for 3.3.4 through 3.3.7

### 2. Docker image ~4 MB smaller than v2.4.2 (`Dockerfile`)

**Root cause**: The Docker build used `linux-headers-$(uname -r)` from apt for noncore eBPF bytecode compilation. Since Docker shares the CI runner's kernel, a kernel update between the v2.4.2 and v2.5.0 builds caused different noncore bytecode to be compiled (`~/.noptrdata` section dropped from 14.5 MB to 9.9 MB).

| Build | v2.4.2 | v2.5.0 |
|-------|--------|--------|
| Release amd64 | 36,111,472 | 36,112,016 |
| Docker amd64 | 36,110,448 | **31,480,944** ❌ |

**Fix**: Extract `linux-source` package, run `make oldconfig && make prepare`, and pass `KERN_HEADERS` to the Makefile. This uses stable, reproducible kernel headers regardless of the CI runner's kernel version.

## Files changed

| File | Change |
|------|--------|
| `internal/probe/openssl/libs.go` | Fix 3.2.x loop variable + fix 3.3.x loop range and MaxSupportedOpenSSL33Version |
| `builder/Dockerfile` | Prepare stable kernel headers from linux-source + pass KERN_HEADERS to make |

🤖 Generated with [Claude Code](https://claude.com/claude-code)