### PR TITLE
nspr: fix bytecode loading and complete eBPF probe implementation

### DIFF
--- a/internal/probe/nspr/event.go
+++ b/internal/probe/nspr/event.go
@@ -25,35 +25,55 @@ import (
 )
 
 const (
+	// DataType constants matching C enum ssl_data_event_type
+	DataTypeRead  = 0
+	DataTypeWrite = 1
+
 	// MaxDataSize is the maximum size of TLS data payload
-	MaxDataSize = 4096
+	// Must match MAX_DATA_SIZE_OPENSSL in kern/common.h
+	MaxDataSize = 1024 * 16 // 16384
+
+	// TaskCommLen is the maximum length of the process command name
+	// Must match TASK_COMM_LEN in kern/common.h
+	TaskCommLen = 16
 )
 
-// TLSDataEvent represents a TLS data event from NSPR/NSS
+// TLSDataEvent represents a TLS data event from NSPR/NSS eBPF probe.
+// The struct layout must exactly match the C struct ssl_data_event_t in kern/nspr_kern.c:
+//
+//	struct ssl_data_event_t {
+//	    enum ssl_data_event_type type;    // u32 at offset 0 (0=read, 1=write)
+//	    // implicit 4-byte alignment padding
+//	    u64 timestamp_ns;                 // u64 at offset 8
+//	    u32 pid;                          // u32 at offset 16
+//	    u32 tid;                          // u32 at offset 20
+//	    char data[MAX_DATA_SIZE_OPENSSL]; // [16384]byte at offset 24
+//	    s32 data_len;                     // s32 at offset 16408
+//	    char comm[TASK_COMM_LEN];         // [16]byte at offset 16412
+//	};
+//	// Total: 16428 bytes
 type TLSDataEvent struct {
+	// DataType encodes the event type (0=read, 1=write).
+	// Uses int64 to absorb the C struct's u32 type + 4-byte alignment padding.
+	DataType int64 `json:"dataType"`
+
 	// Timestamp is the event timestamp in nanoseconds
-	Timestamp uint64
+	Timestamp uint64 `json:"timestamp"`
 
 	// PID is the process ID
-	PID uint32
+	PID uint32 `json:"pid"`
 
 	// TID is the thread ID
-	TID uint32
-
-	// Comm is the process command name
-	Comm [16]byte
-
-	// FD is the file descriptor
-	FD int32
-
-	// DataLen is the length of actual data
-	DataLen uint32
-
-	// Direction: 0 = read, 1 = write
-	Direction uint32
+	TID uint32 `json:"tid"`
 
 	// Data is the TLS data payload
-	Data [MaxDataSize]byte
+	Data [MaxDataSize]byte `json:"data"`
+
+	// DataLen is the length of actual data
+	DataLen int32 `json:"dataLen"`
+
+	// Comm is the process command name
+	Comm [TaskCommLen]byte `json:"comm"`
 }
 
 // GetTimestamp returns the event timestamp as time.Time
@@ -82,19 +102,9 @@ func (e *TLSDataEvent) GetComm() string {
 	return string(e.Comm[:])
 }
 
-// GetFD returns the file descriptor
-func (e *TLSDataEvent) GetFD() int32 {
-	return e.FD
-}
-
 // GetDataLen returns the length of actual data
 func (e *TLSDataEvent) GetDataLen() uint32 {
-	return e.DataLen
-}
-
-// GetDirection returns the data direction (0 = read, 1 = write)
-func (e *TLSDataEvent) GetDirection() uint32 {
-	return e.Direction
+	return uint32(e.DataLen)
 }
 
 // GetData returns the TLS data payload (up to DataLen bytes)
@@ -102,22 +112,31 @@ func (e *TLSDataEvent) GetData() []byte {
 	if e.DataLen > MaxDataSize {
 		return e.Data[:MaxDataSize]
 	}
+	if e.DataLen < 0 {
+		return nil
+	}
 	return e.Data[:e.DataLen]
 }
 
 // IsRead returns true if this is a read event
 func (e *TLSDataEvent) IsRead() bool {
-	return e.Direction == 0
+	return e.DataType == DataTypeRead
 }
 
 // IsWrite returns true if this is a write event
 func (e *TLSDataEvent) IsWrite() bool {
-	return e.Direction == 1
+	return e.DataType == DataTypeWrite
 }
 
-// DecodeFromBytes implements domain.Event interface
+// DecodeFromBytes implements domain.Event interface.
+// Reads fields in exact order matching the C struct layout.
 func (e *TLSDataEvent) DecodeFromBytes(data []byte) error {
-	buf := bytes.NewReader(data)
+	buf := bytes.NewBuffer(data)
+
+	// Read DataType (int64 absorbs C's u32 type + 4-byte padding)
+	if err := binary.Read(buf, binary.LittleEndian, &e.DataType); err != nil {
+		return errors.NewEventDecodeError("nspr.DataType", err)
+	}
 
 	// Read Timestamp
 	if err := binary.Read(buf, binary.LittleEndian, &e.Timestamp); err != nil {
@@ -134,14 +153,9 @@ func (e *TLSDataEvent) DecodeFromBytes(data []byte) error {
 		return errors.NewEventDecodeError("nspr.TID", err)
 	}
 
-	// Read Comm
-	if err := binary.Read(buf, binary.LittleEndian, &e.Comm); err != nil {
-		return errors.NewEventDecodeError("nspr.Comm", err)
-	}
-
-	// Read FD
-	if err := binary.Read(buf, binary.LittleEndian, &e.FD); err != nil {
-		return errors.NewEventDecodeError("nspr.FD", err)
+	// Read Data
+	if err := binary.Read(buf, binary.LittleEndian, &e.Data); err != nil {
+		return errors.NewEventDecodeError("nspr.Data", err)
 	}
 
 	// Read DataLen
@@ -149,14 +163,9 @@ func (e *TLSDataEvent) DecodeFromBytes(data []byte) error {
 		return errors.NewEventDecodeError("nspr.DataLen", err)
 	}
 
-	// Read Direction
-	if err := binary.Read(buf, binary.LittleEndian, &e.Direction); err != nil {
-		return errors.NewEventDecodeError("nspr.Direction", err)
-	}
-
-	// Read Data
-	if err := binary.Read(buf, binary.LittleEndian, &e.Data); err != nil {
-		return errors.NewEventDecodeError("nspr.Data", err)
+	// Read Comm
+	if err := binary.Read(buf, binary.LittleEndian, &e.Comm); err != nil {
+		return errors.NewEventDecodeError("nspr.Comm", err)
 	}
 
 	return nil
@@ -169,8 +178,8 @@ func (e *TLSDataEvent) String() string {
 		direction = "write"
 	}
 
-	return fmt.Sprintf("TLSDataEvent{Timestamp: %v, PID: %d, TID: %d, Comm: %s, FD: %d, Direction: %s, DataLen: %d}",
-		e.GetTimestamp(), e.PID, e.TID, e.GetComm(), e.FD, direction, e.DataLen)
+	return fmt.Sprintf("TLSDataEvent{Timestamp: %v, PID: %d, TID: %d, Comm: %s, Direction: %s, DataLen: %d}",
+		e.GetTimestamp(), e.PID, e.TID, e.GetComm(), direction, e.DataLen)
 }
 
 // StringHex implements domain.Event interface - returns a hexadecimal representation
@@ -180,8 +189,8 @@ func (e *TLSDataEvent) StringHex() string {
 		direction = "write"
 	}
 
-	return fmt.Sprintf("TLSDataEvent{Timestamp: %v, PID: %d, TID: %d, Comm: %s, FD: %d, Direction: %s, DataLen: %d, Data(hex): %x}",
-		e.GetTimestamp(), e.PID, e.TID, e.GetComm(), e.FD, direction, e.DataLen, e.GetData())
+	return fmt.Sprintf("TLSDataEvent{Timestamp: %v, PID: %d, TID: %d, Comm: %s, Direction: %s, DataLen: %d, Data(hex): %x}",
+		e.GetTimestamp(), e.PID, e.TID, e.GetComm(), direction, e.DataLen, e.GetData())
 }
 
 // Clone implements domain.Event interface
@@ -216,6 +225,11 @@ func (e *TLSDataEvent) Decode(data []byte) error {
 func (e *TLSDataEvent) Encode() ([]byte, error) {
 	buf := new(bytes.Buffer)
 
+	// Write DataType
+	if err := binary.Write(buf, binary.LittleEndian, e.DataType); err != nil {
+		return nil, fmt.Errorf("failed to write data type: %w", err)
+	}
+
 	// Write Timestamp
 	if err := binary.Write(buf, binary.LittleEndian, e.Timestamp); err != nil {
 		return nil, fmt.Errorf("failed to write timestamp: %w", err)
@@ -231,14 +245,9 @@ func (e *TLSDataEvent) Encode() ([]byte, error) {
 		return nil, fmt.Errorf("failed to write TID: %w", err)
 	}
 
-	// Write Comm
-	if err := binary.Write(buf, binary.LittleEndian, e.Comm); err != nil {
-		return nil, fmt.Errorf("failed to write comm: %w", err)
-	}
-
-	// Write FD
-	if err := binary.Write(buf, binary.LittleEndian, e.FD); err != nil {
-		return nil, fmt.Errorf("failed to write FD: %w", err)
+	// Write Data
+	if err := binary.Write(buf, binary.LittleEndian, e.Data); err != nil {
+		return nil, fmt.Errorf("failed to write data: %w", err)
 	}
 
 	// Write DataLen
@@ -246,14 +255,9 @@ func (e *TLSDataEvent) Encode() ([]byte, error) {
 		return nil, fmt.Errorf("failed to write data length: %w", err)
 	}
 
-	// Write Direction
-	if err := binary.Write(buf, binary.LittleEndian, e.Direction); err != nil {
-		return nil, fmt.Errorf("failed to write direction: %w", err)
-	}
-
-	// Write Data
-	if err := binary.Write(buf, binary.LittleEndian, e.Data); err != nil {
-		return nil, fmt.Errorf("failed to write data: %w", err)
+	// Write Comm
+	if err := binary.Write(buf, binary.LittleEndian, e.Comm); err != nil {
+		return nil, fmt.Errorf("failed to write comm: %w", err)
 	}
 
 	return buf.Bytes(), nil

--- a/internal/probe/nspr/nspr_probe.go
+++ b/internal/probe/nspr/nspr_probe.go
@@ -15,25 +15,33 @@
 package nspr
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"math"
 
 	"github.com/cilium/ebpf"
-
-	"github.com/gojue/ecapture/internal/factory"
+	manager "github.com/gojue/ebpfmanager"
+	"golang.org/x/sys/unix"
 
 	"github.com/gojue/ecapture/assets"
 	"github.com/gojue/ecapture/internal/domain"
 	"github.com/gojue/ecapture/internal/errors"
+	"github.com/gojue/ecapture/internal/factory"
 	"github.com/gojue/ecapture/internal/probe/base"
+	"github.com/gojue/ecapture/pkg/util/kernel"
 )
 
 // Probe represents the NSPR/NSS probe
 type Probe struct {
 	*base.BaseProbe
 	config           *Config
+	bpfManager       *manager.Manager
 	eventFuncMaps    map[*ebpf.Map]domain.EventDecoder
 	mapNameToDecoder map[string]domain.EventDecoder // Maps configured in setupManager
 	eventMaps        []*ebpf.Map
+	output           io.Writer
 }
 
 // NewProbe creates a new NSPR probe
@@ -65,18 +73,6 @@ func (p *Probe) Initialize(ctx context.Context, cfg domain.Configuration) error 
 
 	p.config = nsprConfig
 
-	// Load eBPF bytecode
-	bpfFileName := "bytecode/nspr_kern.o"
-	_, err := assets.Asset(bpfFileName)
-	if err != nil {
-		return errors.NewEBPFLoadError(bpfFileName, err)
-	}
-
-	// eBPF manager setup, event maps, and hooks will be implemented
-	// Manager includes:
-	// - Probes: PR_Send, PR_Recv hooks
-	// - Event maps for TLS data capture
-
 	p.Logger().Info().
 		Str("nss_path", nsprConfig.NSSPath).
 		Str("nspr_path", nsprConfig.NSPRPath).
@@ -95,33 +91,62 @@ func (p *Probe) Start(ctx context.Context) error {
 		return errors.NewProbeStartError("nspr", nil)
 	}
 
-	// Retrieve eBPF maps and associate with decoders (configured in setupManager)
+	// Load eBPF bytecode with correct filename (core vs noncore)
+	bpfFileName := p.BaseProbe.GetBPFName("bytecode/nspr_kern.o")
+	p.Logger().Info().Str("file", bpfFileName).Msg("Loading eBPF bytecode")
+
+	byteBuf, err := assets.Asset(bpfFileName)
+	if err != nil {
+		return errors.NewEBPFLoadError(bpfFileName, err)
+	}
+
+	// Setup eBPF manager with probes and maps
+	if err := p.setupManager(); err != nil {
+		return err
+	}
+
+	// Initialize eBPF manager
+	if err := p.bpfManager.InitWithOptions(bytes.NewReader(byteBuf), p.getManagerOptions()); err != nil {
+		return errors.NewEBPFLoadError("nspr manager init", err)
+	}
+
+	// Start eBPF manager
+	if err := p.bpfManager.Start(); err != nil {
+		return errors.NewEBPFAttachError("nspr manager start", err)
+	}
+
+	// Retrieve eBPF maps and associate with decoders
 	if err := p.retrieveEventMaps(); err != nil {
 		return err
 	}
 
-	// Start eBPF event processing when implemented
-	// - Start reading from perf buffers
-	// - Process TLS data events and forward to appropriate handler
-	// - Process master secret events (keylog mode)
-	// - Process packet events (pcap mode)
+	// Start event readers for all configured maps
+	for em, decoder := range p.eventFuncMaps {
+		if err := p.StartPerfEventReader(em, decoder); err != nil {
+			return err
+		}
+	}
 
-	p.Logger().Info().Msg("NSPR probe started")
+	p.Logger().Info().Msg("NSPR probe started successfully")
 	return nil
 }
 
 // retrieveEventMaps retrieves eBPF maps from the manager and creates eventFuncMaps.
 // The decoder mapping by name (mapNameToDecoder) is already configured in setupManager().
-// This will be populated when eBPF implementation is complete.
 func (p *Probe) retrieveEventMaps() error {
-	// TODO: When eBPF is implemented, retrieve actual maps
-	// for mapName, decoder := range p.mapNameToDecoder {
-	//     em, found, err := p.bpfManager.GetMap(mapName)
-	//     if found {
-	//         p.eventMaps = append(p.eventMaps, em)
-	//         p.eventFuncMaps[em] = decoder
-	//     }
-	// }
+	for mapName, decoder := range p.mapNameToDecoder {
+		em, found, err := p.bpfManager.GetMap(mapName)
+		if err != nil {
+			return errors.Wrap(errors.ErrCodeEBPFMapAccess, fmt.Sprintf("failed to get %s map", mapName), err)
+		}
+		if !found {
+			p.Logger().Warn().Str("map", mapName).Msg("Map not found but was configured")
+			continue
+		}
+
+		p.eventMaps = append(p.eventMaps, em)
+		p.eventFuncMaps[em] = decoder
+	}
 
 	p.Logger().Info().
 		Int("num_maps", len(p.eventMaps)).
@@ -133,11 +158,7 @@ func (p *Probe) retrieveEventMaps() error {
 
 // Stop stops the probe
 func (p *Probe) Stop(ctx context.Context) error {
-	// Stop eBPF event processing when implemented
-	// - Stop reading from perf buffers
-	// - Detach eBPF programs
-	// - Clean up event maps
-
+	// Stop event readers are handled by BaseProbe
 	return p.BaseProbe.Stop(ctx)
 }
 
@@ -148,13 +169,124 @@ func (p *Probe) Events() []*ebpf.Map {
 
 // Close closes the probe and releases resources
 func (p *Probe) Close() error {
-	// Unload eBPF program and clean up resources when implemented
+	if p.bpfManager != nil {
+		if err := p.bpfManager.Stop(manager.CleanAll); err != nil {
+			p.Logger().Warn().Err(err).Msg("Failed to stop eBPF manager")
+		}
+	}
 	return p.BaseProbe.Close()
+}
+
+// SetOutput sets the output writer for the probe (for testing purposes).
+func (p *Probe) SetOutput(w io.Writer) {
+	p.output = w
 }
 
 func (p *Probe) DecodeFun(em *ebpf.Map) (domain.EventDecoder, bool) {
 	fun, found := p.eventFuncMaps[em]
 	return fun, found
+}
+
+// setupManager configures the eBPF manager with uprobes/uretprobes for PR_Write/PR_Read.
+func (p *Probe) setupManager() error {
+	nsprPath := p.config.NSPRPath
+	if nsprPath == "" {
+		return errors.NewConfigurationError("nspr_path is required for NSPR probe", nil)
+	}
+
+	p.Logger().Info().
+		Str("nspr_path", nsprPath).
+		Str("nss_path", p.config.NSSPath).
+		Msg("Setting up eBPF probes for NSPR")
+
+	// Configure probes: uprobe/uretprobe pairs for PR_Write and PR_Read
+	probes := []*manager.Probe{
+		{
+			Section:          "uprobe/PR_Write",
+			EbpfFuncName:     "probe_entry_SSL_write",
+			AttachToFuncName: "PR_Write",
+			BinaryPath:       nsprPath,
+		},
+		{
+			Section:          "uretprobe/PR_Write",
+			EbpfFuncName:     "probe_ret_SSL_write",
+			AttachToFuncName: "PR_Write",
+			BinaryPath:       nsprPath,
+		},
+		{
+			Section:          "uprobe/PR_Read",
+			EbpfFuncName:     "probe_entry_SSL_read",
+			AttachToFuncName: "PR_Read",
+			BinaryPath:       nsprPath,
+		},
+		{
+			Section:          "uretprobe/PR_Read",
+			EbpfFuncName:     "probe_ret_SSL_read",
+			AttachToFuncName: "PR_Read",
+			BinaryPath:       nsprPath,
+		},
+	}
+
+	// Configure maps matching those defined in kern/nspr_kern.c
+	maps := []*manager.Map{
+		{Name: "nspr_events"},
+		{Name: "active_ssl_read_args_map"},
+		{Name: "active_ssl_write_args_map"},
+		{Name: "data_buffer_heap"},
+	}
+
+	// Configure decoder for nspr_events map
+	p.mapNameToDecoder["nspr_events"] = &nsprEventDecoder{probe: p}
+
+	p.bpfManager = &manager.Manager{
+		Probes: probes,
+		Maps:   maps,
+	}
+
+	return nil
+}
+
+// getManagerOptions returns eBPF manager options with constant editors for filtering.
+func (p *Probe) getManagerOptions() manager.Options {
+	opts := manager.Options{
+		DefaultKProbeMaxActive: 512,
+		VerifierOptions: ebpf.CollectionOptions{
+			Programs: ebpf.ProgramOptions{
+				LogSizeStart: 2097152,
+			},
+		},
+		RLimit: &unix.Rlimit{
+			Cur: math.MaxUint64,
+			Max: math.MaxUint64,
+		},
+	}
+
+	// Add constant editors if kernel supports global variables
+	if p.config.EnableGlobalVar() {
+		kv, _ := kernel.HostVersion()
+		kernelLess52 := uint64(0)
+		if kv < kernel.VersionCode(5, 2, 0) {
+			kernelLess52 = 1
+		}
+
+		opts.ConstantEditors = []manager.ConstantEditor{
+			{Name: "target_pid", Value: p.config.GetPid()},
+			{Name: "target_uid", Value: p.config.GetUid()},
+			{Name: "less52", Value: kernelLess52},
+			{Name: "target_cgroup_id", Value: uint64(0)},
+		}
+	} else {
+		if p.config.GetPid() != 0 {
+			p.Logger().Warn().Uint64("pid", p.config.GetPid()).
+				Msg("PID filter is not supported on kernel < 5.2, --pid filter will be ignored")
+		}
+		if p.config.GetUid() != 0 {
+			p.Logger().Warn().Uint64("uid", p.config.GetUid()).
+				Msg("UID filter is not supported on kernel < 5.2, --uid filter will be ignored")
+		}
+	}
+
+	return opts
 }
 
 // nsprEventDecoder implements domain.EventDecoder for NSPR TLS data events
@@ -164,11 +296,12 @@ type nsprEventDecoder struct {
 
 func (d *nsprEventDecoder) Decode(_ *ebpf.Map, data []byte) (domain.Event, error) {
 	event := &TLSDataEvent{}
-	if err := event.Decode(data); err != nil {
-		return nil, errors.NewEventDecodeError("nspr.TLSDataEvent", err)
+	if err := event.DecodeFromBytes(data); err != nil {
+		return nil, err
 	}
-
-	// Event will be handled by dispatcher
+	if err := event.Validate(); err != nil {
+		return nil, err
+	}
 	return event, nil
 }
 

--- a/internal/probe/nspr/nspr_probe_test.go
+++ b/internal/probe/nspr/nspr_probe_test.go
@@ -88,16 +88,18 @@ func TestProbe_Name(t *testing.T) {
 func TestTLSDataEventDecode(t *testing.T) {
 	event := &TLSDataEvent{}
 	var err error
-	// Create minimal valid data
+
+	// Create binary data matching the C struct layout:
+	// DataType (int64), Timestamp (uint64), PID (uint32), TID (uint32),
+	// Data ([MaxDataSize]byte), DataLen (int32), Comm ([TaskCommLen]byte)
 	buf := new(bytes.Buffer)
-	err = binary.Write(buf, binary.LittleEndian, uint64(12345))       // Timestamp
-	err = binary.Write(buf, binary.LittleEndian, uint32(1234))        // PID
-	err = binary.Write(buf, binary.LittleEndian, uint32(5678))        // TID
-	err = binary.Write(buf, binary.LittleEndian, [16]byte{'t'})       // Comm
-	err = binary.Write(buf, binary.LittleEndian, int32(10))           // FD
-	err = binary.Write(buf, binary.LittleEndian, uint32(100))         // DataLen
-	err = binary.Write(buf, binary.LittleEndian, uint32(1))           // Direction
-	err = binary.Write(buf, binary.LittleEndian, [MaxDataSize]byte{}) // Data
+	err = binary.Write(buf, binary.LittleEndian, int64(DataTypeWrite))   // DataType (absorbs u32 + padding)
+	err = binary.Write(buf, binary.LittleEndian, uint64(12345))          // Timestamp
+	err = binary.Write(buf, binary.LittleEndian, uint32(1234))           // PID
+	err = binary.Write(buf, binary.LittleEndian, uint32(5678))           // TID
+	err = binary.Write(buf, binary.LittleEndian, [MaxDataSize]byte{})    // Data
+	err = binary.Write(buf, binary.LittleEndian, int32(100))             // DataLen
+	err = binary.Write(buf, binary.LittleEndian, [TaskCommLen]byte{'t'}) // Comm
 	if err != nil {
 		t.Fatalf("binary.Write failed: %v", err)
 		return
@@ -127,13 +129,12 @@ func TestTLSDataEventDecode(t *testing.T) {
 
 func TestTLSDataEventString(t *testing.T) {
 	event := &TLSDataEvent{
+		DataType:  DataTypeRead,
 		Timestamp: 12345,
 		PID:       1234,
 		TID:       5678,
-		Comm:      [16]byte{'f', 'i', 'r', 'e', 'f', 'o', 'x', 0},
-		FD:        10,
+		Comm:      [TaskCommLen]byte{'f', 'i', 'r', 'e', 'f', 'o', 'x', 0},
 		DataLen:   100,
-		Direction: 0,
 	}
 
 	str := event.String()


### PR DESCRIPTION
Fix #1016: The NSPR probe failed to load eBPF bytecode with `open bytecode/nspr_kern.o: file does not exist`.

## Root Causes

1. **Wrong bytecode filename**: `nspr_probe.go` hardcoded `"bytecode/nspr_kern.o"` but embedded assets use `_core.o` / `_noncore.o` suffixes. Now uses `GetBPFName()` like all other probes.

2. **Missing eBPF manager setup**: The NSPR probe was an incomplete skeleton — it checked bytecode existence but never set up the eBPF manager or started probes. Now implemented fully (uprobe/uretprobe for PR_Write/PR_Read).

3. **C/Go struct mismatch**: The Go `TLSDataEvent` had completely different field order and extra fields (FD, Direction) that did not exist in the C `ssl_data_event_t`. Now matches exactly.

## Changes

| File | Changes |
|------|---------|
| `internal/probe/nspr/event.go` | Rewrote `TLSDataEvent` to match C struct layout. `MaxDataSize` changed 4096→16384. |
| `internal/probe/nspr/nspr_probe.go` | Implemented full eBPF lifecycle: `setupManager()` with 4 uprobes, `Start()` loads bytecode via `GetBPFName()`, `Close()` stops manager. |
| `internal/probe/nspr/nspr_probe_test.go` | Updated tests for new struct layout. |

## Verification

- ✅ `make all` builds successfully (ARM aarch64 on Linux)
- ✅ All 12 NSPR unit tests pass
- ✅ Full `make test-race` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)