### PR TITLE
fix(gotls): 单次 hook 按 16KB 分段输出 BPF perf 事件

### DIFF
--- a/kern/gotls_kern.c
+++ b/kern/gotls_kern.c
@@ -249,6 +249,25 @@ static __always_inline void fill_fd_and_addr_from_tls_conn(void *tls_conn_ptr,
     extract_addr_from_netfd_ptr(netfd_ptr, src_ip, src_port, dst_ip, dst_port, ip_version);
 }
 
+// Emit one 16KB segment; seg_idx must be a compile-time constant for verifier bounds.
+#define GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, seg_idx)               \
+    do {                                                                           \
+        const u32 _off = (u32)(seg_idx) * (max_chunk);                             \
+        if (_off < (total)) {                                                      \
+            u32 _remain = (total) - _off;                                          \
+            u32 _chunk = _remain < (max_chunk) ? (_remain & ((max_chunk) - 1))     \
+                                             : (max_chunk);                        \
+            if (_chunk > 0) {                                                      \
+                (event)->data_len = (s32)_chunk;                                   \
+                if (bpf_probe_read_user(&(event)->data, _chunk,                   \
+                                        (void *)((u64)(base) + (u64)_off)) == 0) { \
+                    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,  \
+                                          sizeof(struct go_tls_event));            \
+                }                                                                  \
+            }                                                                      \
+        }                                                                          \
+    } while (0)
+
 static __always_inline int gotls_emit_payload(struct pt_regs *ctx,
                                               struct go_tls_event *event,
                                               const char *base,
@@ -259,33 +278,30 @@ static __always_inline int gotls_emit_payload(struct pt_regs *ctx,
     }
 
     const u32 max_chunk = MAX_DATA_SIZE_OPENSSL;
-    const s32 max_total = (s32)(max_chunk * GOTLS_MAX_SEGMENTS);
-    if (total_len > max_total) {
-        total_len = max_total;
+    const u32 max_total = max_chunk * GOTLS_MAX_SEGMENTS;
+    u32 total = (u32)total_len;
+    if (total > max_total) {
+        total = max_total;
     }
 
-    u32 off = 0;
     event->event_type = event_type;
 
-#pragma clang loop unroll(full)
-    for (int i = 0; i < GOTLS_MAX_SEGMENTS; i++) {
-        if (off >= (u32)total_len) {
-            break;
-        }
-
-        u32 chunk = (u32)total_len - off;
-        if (chunk > max_chunk) {
-            chunk = max_chunk;
-        }
-
-        event->data_len = (s32)chunk;
-        if (bpf_probe_read_user(&event->data, chunk, (void *)(base + off)) < 0) {
-            return 0;
-        }
-        bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
-                              sizeof(struct go_tls_event));
-        off += chunk;
-    }
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 0);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 1);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 2);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 3);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 4);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 5);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 6);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 7);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 8);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 9);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 10);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 11);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 12);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 13);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 14);
+    GOTLS_EMIT_SEG(ctx, event, base, total, max_chunk, 15);
     return 0;
 }
 

--- a/kern/gotls_kern.c
+++ b/kern/gotls_kern.c
@@ -24,6 +24,8 @@
 #define EVP_MAX_MD_SIZE 64
 #define GOTLS_EVENT_TYPE_WRITE 0
 #define GOTLS_EVENT_TYPE_READ 1
+// Max bpf_perf_event_output calls per hook (16 * 16KB = 256KB); must fully unroll for verifier.
+#define GOTLS_MAX_SEGMENTS 16
 
 // // TLS record types in golang tls package
 #define recordTypeApplicationData 23
@@ -247,6 +249,46 @@ static __always_inline void fill_fd_and_addr_from_tls_conn(void *tls_conn_ptr,
     extract_addr_from_netfd_ptr(netfd_ptr, src_ip, src_port, dst_ip, dst_port, ip_version);
 }
 
+static __always_inline int gotls_emit_payload(struct pt_regs *ctx,
+                                              struct go_tls_event *event,
+                                              const char *base,
+                                              s32 total_len,
+                                              u8 event_type) {
+    if (!base || total_len <= 0) {
+        return 0;
+    }
+
+    const u32 max_chunk = MAX_DATA_SIZE_OPENSSL;
+    const s32 max_total = (s32)(max_chunk * GOTLS_MAX_SEGMENTS);
+    if (total_len > max_total) {
+        total_len = max_total;
+    }
+
+    u32 off = 0;
+    event->event_type = event_type;
+
+#pragma clang loop unroll(full)
+    for (int i = 0; i < GOTLS_MAX_SEGMENTS; i++) {
+        if (off >= (u32)total_len) {
+            break;
+        }
+
+        u32 chunk = (u32)total_len - off;
+        if (chunk > max_chunk) {
+            chunk = max_chunk;
+        }
+
+        event->data_len = (s32)chunk;
+        if (bpf_probe_read_user(&event->data, chunk, (void *)(base + off)) < 0) {
+            return 0;
+        }
+        bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event,
+                              sizeof(struct go_tls_event));
+        off += chunk;
+    }
+    return 0;
+}
+
 static __always_inline int gotls_write(struct pt_regs *ctx, bool is_register_abi) {
     if (!passes_filter(ctx)) {
         return 0;
@@ -277,23 +319,14 @@ static __always_inline int gotls_write(struct pt_regs *ctx, bool is_register_abi
     if (!event) {
         return 0;
     }
-
     fill_fd_and_addr_from_tls_conn(tls_conn_ptr, &event->fd,
                                     event->src_ip, &event->src_port,
                                     event->dst_ip, &event->dst_port,
                                     &event->ip_version, "WRITE");
 
-    event->data_len =
-        (len < MAX_DATA_SIZE_OPENSSL ? (len & (MAX_DATA_SIZE_OPENSSL - 1))
-                                     : MAX_DATA_SIZE_OPENSSL);
-    int ret = bpf_probe_read_user(&event->data, event->data_len, (void *)str);
-    if (ret < 0) {
-        return 0;
-    }
     debug_bpf_printk("gotls_write: pid=%u fd=%u ip_version=%u\n",
                      event->pid, event->fd, event->ip_version);
-    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event, sizeof(struct go_tls_event));
-    return 0;
+    return gotls_emit_payload(ctx, event, str, len, GOTLS_EVENT_TYPE_WRITE);
 }
 
 // capture golang tls plaintext, supported golang stack-based ABI (go version
@@ -344,25 +377,14 @@ static __always_inline int gotls_read(struct pt_regs *ctx, bool is_register_abi)
     if (!event) {
         return 0;
     }
-
     fill_fd_and_addr_from_tls_conn(tls_conn_ptr, &event->fd,
                                     event->src_ip, &event->src_port,
                                     event->dst_ip, &event->dst_port,
                                     &event->ip_version, "READ");
 
-    event->data_len =
-        (ret_len < MAX_DATA_SIZE_OPENSSL ? (ret_len & (MAX_DATA_SIZE_OPENSSL - 1))
-                                     : MAX_DATA_SIZE_OPENSSL);
-    event->event_type = GOTLS_EVENT_TYPE_READ;
-    int ret = bpf_probe_read_user(&event->data, event->data_len, (void *)str);
-    if (ret < 0) {
-        return 0;
-    }
     debug_bpf_printk("gotls_read: pid=%u fd=%u ip_version=%u\n",
                      event->pid, event->fd, event->ip_version);
-
-    bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, event, sizeof(struct go_tls_event));
-    return 0;
+    return gotls_emit_payload(ctx, event, str, ret_len, GOTLS_EVENT_TYPE_READ);
 }
 
 // capture golang tls plaintext, supported golang stack-based ABI (go version


### PR DESCRIPTION
## 摘要

- 当 `writeRecordLocked` / `Read` 单次明文超过 `MAX_DATA_SIZE_OPENSSL`（16KB）时，循环 `bpf_perf_event_output`，避免只发首段、尾部被丢弃。
- 单次 hook 最多 16 段（256KB）；用 `GOTLS_EMIT_SEG` 宏手动展开 16 次，替代 `#pragma clang loop unroll(full)`（Android CI 上 unroll 失败导致 verifier 报 `R2 min value is negative`）。
- `chunk` 边界用 `u32 total` + `remain & (max_chunk-1)`；读地址用 `(u64)base + off`。

## 背景

GoTLS uprobe 在单次 TLS 读写超过 16KB 时，原先只拷贝并输出第一个 16KB，用户态只能收到截断明文。

## 测试计划

- [x] 目标内核 `gotls_kern_core.o` 编译通过（172.31.28.30）
- [x] gimli 打包部署 + Caddy GoTLS hook 成功
- [x] HTTP/2 上传 small.pdf / xlsx / docx，Caddy 返回正确文件大小
- [x] ClickHouse `access.file.size` 入库正确（pdf 1495477、xlsx 1407761、docx 930189）
- [ ] CI Android E2E / Linux E2E 待跑